### PR TITLE
Use shipped/upstream content (xml, kickstarts) directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ on Red Hat Enterprise Linux.
   - set to `1` to verbosely report only genuine oscap rule failures
   - other results are unaffected (for now)
 
+- `CONTEST_DATASTREAMS`
+  - alternate location for `/usr/share/xml/scap/ssg/content`
+- `CONTEST_PLAYBOOKS`
+  - alternate location for `/usr/share/scap-security-guide/ansible`
+- `CONTEST_KICKSTARTS`
+  - alternate location for `/usr/share/scap-security-guide/kickstart`
+
 ## Workarounds
 
 (TODO: Find a better place for this?)

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ finishes.
 These have some unfortunate metadata, such as
 
 - hardcoded network interface names
-- unnecessarily big partition sizes
+- unnecessarily large `/var/log/audit` size
 - oscap Anaconda addon configuration using `scap-security-guide`
 
-At least the first two are hopefully temporary, until TODO:PR-here is resolved.
+which are removed by `translate_ssg_kickstart()` [in virt.py](lib/virt.py).
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ on Red Hat Enterprise Linux.
 
 (TODO: Find a better place for this?)
 
+### Virtual machines and logging in
+
 The VM-using `/hardening` tests do two hacks to allow login after hardening:
 
 - `-oPermitRootLogin=yes` in `OPTIONS` of `/etc/sysconfig/sshd`
@@ -76,6 +78,16 @@ for `oscap`, as we can simply do `oscap xccdf eval ... ; chage ...` in the same
 shell, but Ansible remediation cannot do this.  
 So we need a simple side-channel that can run `chage` **after** ansible-playbook
 finishes.
+
+### Using upstream/shipped content kickstarts
+
+These have some unfortunate metadata, such as
+
+- hardcoded network interface names
+- unnecessarily big partition sizes
+- oscap Anaconda addon configuration using `scap-security-guide`
+
+At least the first two are hopefully temporary, until TODO:PR-here is resolved.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,40 @@ on Red Hat Enterprise Linux.
 - `CONTEST_KICKSTARTS`
   - alternate location for `/usr/share/scap-security-guide/kickstart`
 
+## Testing content from source
+
+Normally, you would run this test suite via `tmt` as ie.
+
+```
+tmt \
+    -c distro=rhel-9.2 \
+    run -vvva \
+        plans -n /plans/default \
+        provision -h ... \
+        discover -h fmf -t '/hardening/anaconda/stig$' \
+        report -h html
+```
+
+and this simply uses content shipped in whatever distro you specify to
+`provision`, or whatever distro is already installed if you use
+`provision -h connect ...`.
+
+To build content from source, just run the `/plans/upstream` plan instead,
+and **optionally** give it parameters to test your specific code - ie. prior
+or during a pull request submission:
+
+```
+tmt \
+    -c distro=rhel-9.2 \
+    run -vvva \
+        -e CONTENT_URL=https://github.com/someuser/your-content.git \
+        -e CONTENT_BRANCH=small_fixes \
+            plans -n /plans/upstream \
+            provision -h ... \
+            discover -h fmf -t '/hardening/anaconda/stig$' \
+            report -h html
+```
+
 ## Workarounds
 
 (TODO: Find a better place for this?)

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -59,6 +59,9 @@ extra-hardware: |
 /cui:
     environment+:
         PROFILE: cui
+    adjust:
+        when: distro < rhel-8
+        enabled: false
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cui
     extra-nitrate: TC#0615169
     id: dcc000cc-f65a-47fd-bce2-d3ed4a1d5f4f
@@ -97,6 +100,9 @@ extra-hardware: |
 /pci-dss:
     environment+:
         PROFILE: pci-dss
+    adjust:
+        when: distro < rhel-8
+        enabled: false
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/pci-dss
     extra-nitrate: TC#0615175
     id: f0f0151a-888c-4efa-aef8-90d0a94499c1

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -8,16 +8,6 @@ extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=4800
 
-/anssi_bp28_enhanced:
-    environment+:
-        PROFILE: anssi_bp28_enhanced
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_enhanced
-    extra-nitrate: TC#0615156
-    id: 6e955ca9-ca5d-4440-a8e7-69112f1c7d1e
-
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
@@ -28,36 +18,6 @@ extra-hardware: |
     extra-nitrate: TC#0615157
     id: fa9bafe4-ec23-4f9e-8f20-277b32c3bcb3
 
-/anssi_bp28_intermediary:
-    environment+:
-        PROFILE: anssi_bp28_intermediary
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_intermediary
-    extra-nitrate: TC#0615158
-    id: 51655663-3160-4519-8407-ea8dc6214663
-
-/anssi_bp28_minimal:
-    environment+:
-        PROFILE: anssi_bp28_minimal
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_minimal
-    extra-nitrate: TC#0615159
-    id: b5c4fe1d-19ea-4830-8716-9dea0e63557c
-
-/anssi_nt28_enhanced:
-    environment+:
-        PROFILE: anssi_nt28_enhanced
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_enhanced
-    extra-nitrate: TC#0615160
-    id: 18774c52-bbb7-43be-9293-58dc864761d5
-
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
@@ -67,37 +27,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_high
     extra-nitrate: TC#0615161
     id: c30492f5-a24e-4b88-a566-b75cc3485855
-
-/anssi_nt28_intermediary:
-    environment+:
-        PROFILE: anssi_nt28_intermediary
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_intermediary
-    extra-nitrate: TC#0615162
-    id: cd4508df-d376-4780-80cd-3e15e7b276e9
-
-/anssi_nt28_minimal:
-    environment+:
-        PROFILE: anssi_nt28_minimal
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_minimal
-    extra-nitrate: TC#0615163
-    id: 7b325e6a-ccd6-4351-8290-7e74bb21ab28
-
-/C2S:
-    environment+:
-        PROFILE: C2S
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/C2S
-    extra-nitrate: TC#0615155
-    id: c7c35b94-ce61-43d5-a784-c60730e152a1
-    enabled: false
 
 /cis:
     environment+:
@@ -126,17 +55,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cis_workstation_l2
     extra-nitrate: TC#0615167
     id: 2b1bb08e-baca-40a7-8ba5-7a8710d9fe2e
-
-/cjis:
-    environment+:
-        PROFILE: cjis
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cjis
-    extra-nitrate: TC#0615168
-    id: 35526efe-728a-47a1-b448-5f4c6e73bca3
-    enabled: false
 
 /cui:
     environment+:
@@ -169,17 +87,6 @@ extra-hardware: |
     extra-nitrate: TC#0615172
     id: 0d9c11fb-da88-4a94-8a35-3247287b4fc5
 
-/ncp:
-    environment+:
-        PROFILE: ncp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ncp
-    extra-nitrate: TC#0615173
-    id: 2cec7079-dab0-4c3c-b6df-c077fdcd6bb4
-    enabled: false
-
 /ospp:
     environment+:
         PROFILE: ospp
@@ -193,50 +100,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/pci-dss
     extra-nitrate: TC#0615175
     id: f0f0151a-888c-4efa-aef8-90d0a94499c1
-
-/rhelh-stig:
-    environment+:
-        PROFILE: rhelh-stig
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/rhelh-stig
-    extra-nitrate: TC#0615176
-    id: 53d79015-f08e-4bb5-9792-3948897285d3
-    enabled: false
-
-/rhelh-vpp:
-    environment+:
-        PROFILE: rhelh-vpp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/rhelh-vpp
-    extra-nitrate: TC#0615177
-    id: e9ead67f-d5b5-4423-98b1-0c5c073ef242
-    enabled: false
-
-/rht-ccp:
-    environment+:
-        PROFILE: rht-ccp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/rht-ccp
-    extra-nitrate: TC#0615178
-    id: 2d58bbcb-835e-408a-8a8f-3e4c97fd579e
-    enabled: false
-
-/standard:
-    environment+:
-        PROFILE: standard
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/standard
-    extra-nitrate: TC#0615179
-    id: 4359e4ac-7359-47fc-a61f-4abbf390aacb
-    enabled: false
 
 /stig:
     environment+:

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -12,38 +12,42 @@ import versions
 
 virt.setup_host()
 
-profile = os.environ['PROFILE']
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
-
 g = virt.Guest()
 
-ks = virt.Kickstart()
+profile = os.environ['PROFILE']
 
-# remediate using Anaconda's oscap addon
-oscap_conf = {
-    'content-type': 'scap-security-guide',
-    'profile': profile,
-}
-ks.add_oscap(oscap_conf)
+# use kickstart from content, not ours
+ks = virt.translate_ssg_kickstart(profile)
+
+profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 ks.add_post('chage -d 99999 root')
 
 if profile.endswith('_gui'):
     ks.add_package_group('Server with GUI')
 
-g.install(kickstart=ks)
+oscap_conf = {
+    'content-type': 'datastream',
+    'content-url': f'http://{virt.NETWORK_HOST}:8088/contest-ds.xml',
+    'profile': profile,
+}
+ks.add_oscap(oscap_conf)
+
+# host a HTTP server with a datastream and let the guest download it
+virt.firewalld_allow_port(8088)
+srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 8088)
+srv.add_file(util.get_datastream(), 'contest-ds.xml')
+with srv:
+    g.install(kickstart=ks)
 
 with g.booted():
-    # copy our datastream to the guest
-    g.copy_to(util.get_datastream(), 'contest-ds.xml')
-
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
     redir = '2>&1' if versions.oscap >= 1.3 else ''
 
     # scan the remediated system
     proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile} --progress '
-                               f'--report report.html contest-ds.xml {redir}')
+                               f'--report report.html /root/openscap_data/contest-ds.xml {redir}')
     failed = oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -3,6 +3,7 @@
 import os
 import sys
 
+import util
 import results
 import virt
 import oscap
@@ -33,13 +34,16 @@ if profile.endswith('_gui'):
 g.install(kickstart=ks)
 
 with g.booted():
+    # copy our datastream to the guest
+    g.copy_to(util.get_datastream(), 'contest-ds.xml')
+
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
     redir = '2>&1' if versions.oscap >= 1.3 else ''
 
     # scan the remediated system
     proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile} --progress '
-                               f'--report report.html {oscap.DATASTREAM} {redir}')
+                               f'--report report.html contest-ds.xml {redir}')
     failed = oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -34,7 +34,6 @@ oscap_conf = {
 ks.add_oscap(oscap_conf)
 
 # host a HTTP server with a datastream and let the guest download it
-virt.firewalld_allow_port(8088)
 srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 8088)
 srv.add_file(util.get_datastream(), 'contest-ds.xml')
 with srv:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -8,16 +8,6 @@ extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=4800
 
-/anssi_bp28_enhanced:
-    environment+:
-        PROFILE: anssi_bp28_enhanced
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_enhanced
-    extra-nitrate: TC#0615183
-    id: d7da0b03-a520-4077-9721-b4a516370e40
-
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
@@ -28,36 +18,6 @@ extra-hardware: |
     extra-nitrate: TC#0615184
     id: f505892f-12ab-49de-bfa0-59e3fe9fe5c4
 
-/anssi_bp28_intermediary:
-    environment+:
-        PROFILE: anssi_bp28_intermediary
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_intermediary
-    extra-nitrate: TC#0615185
-    id: a93199cf-dea3-4715-a87b-ffde76d9dd97
-
-/anssi_bp28_minimal:
-    environment+:
-        PROFILE: anssi_bp28_minimal
-    adjust:
-        when: distro < rhel-8
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_minimal
-    extra-nitrate: TC#0615186
-    id: cb6173f7-49d5-4f06-97be-ac804f5ed458
-
-/anssi_nt28_enhanced:
-    environment+:
-        PROFILE: anssi_nt28_enhanced
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_enhanced
-    extra-nitrate: TC#0615187
-    id: 331b5394-05d7-449f-8392-5888d00dadf1
-
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
@@ -67,37 +27,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_high
     extra-nitrate: TC#0615188
     id: 72343ccf-47c6-4d0f-83e2-1026951c370c
-
-/anssi_nt28_intermediary:
-    environment+:
-        PROFILE: anssi_nt28_intermediary
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_intermediary
-    extra-nitrate: TC#0615189
-    id: 53d8ba13-2fff-475e-a043-dda495c22a4c
-
-/anssi_nt28_minimal:
-    environment+:
-        PROFILE: anssi_nt28_minimal
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_minimal
-    extra-nitrate: TC#0615190
-    id: efc66467-2d06-4a9e-8e7f-4522ed45f01b
-
-/C2S:
-    environment+:
-        PROFILE: C2S
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/C2S
-    extra-nitrate: TC#0615182
-    id: dd5cf152-086f-475b-ac3b-4e0b7e1d4c6c
-    enabled: false
 
 /cis:
     environment+:
@@ -126,17 +55,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l2
     extra-nitrate: TC#0615194
     id: a984cb43-71a8-4aea-b965-5c29a6c4018a
-
-/cjis:
-    environment+:
-        PROFILE: cjis
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cjis
-    extra-nitrate: TC#0615195
-    id: e17cea3b-c97a-48a9-a6fa-e2c079f1c8da
-    enabled: false
 
 /cui:
     environment+:
@@ -169,17 +87,6 @@ extra-hardware: |
     extra-nitrate: TC#0615199
     id: 71ec5f37-5061-490a-a845-7eea86ad0c16
 
-/ncp:
-    environment+:
-        PROFILE: ncp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ncp
-    extra-nitrate: TC#0615200
-    id: 8c093236-2529-481e-9c67-5763ed660544
-    enabled: false
-
 /ospp:
     environment+:
         PROFILE: ospp
@@ -193,50 +100,6 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/pci-dss
     extra-nitrate: TC#0615202
     id: 339cb66e-0b63-4266-802a-3972b6cf36ff
-
-/rhelh-stig:
-    environment+:
-        PROFILE: rhelh-stig
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/rhelh-stig
-    extra-nitrate: TC#0615203
-    id: b4cb06e4-463e-4fc9-8d08-f72fd872010a
-    enabled: false
-
-/rhelh-vpp:
-    environment+:
-        PROFILE: rhelh-vpp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/rhelh-vpp
-    extra-nitrate: TC#0615204
-    id: 80c8033b-a568-455f-b236-6112b9cf8f59
-    enabled: false
-
-/rht-ccp:
-    environment+:
-        PROFILE: rht-ccp
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/rht-ccp
-    extra-nitrate: TC#0615205
-    id: 91e1ff19-6720-4c58-80c6-57400106616c
-    enabled: false
-
-/standard:
-    environment+:
-        PROFILE: standard
-    adjust:
-        when: distro > rhel-7
-        enabled: false
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/standard
-    extra-nitrate: TC#0615206
-    id: 9659aafa-7482-47bb-9c7a-cd9c9f3b2196
-    enabled: false
 
 /stig:
     environment+:

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -6,17 +6,14 @@ from pathlib import Path
 
 import results
 import util
-from versions import rhel
 
 _log = logging.getLogger(__name__).debug
 _no_remediation_cache = None
 
-DATASTREAM = f'/usr/share/xml/scap/ssg/content/ssg-rhel{rhel.major}-ds.xml'
-
 
 def _rules_without_remediation():
     # TODO: parse this info from datastream XML
-    cmd = ['oscap', 'xccdf', 'generate', '--profile', '(all)', 'fix', DATASTREAM]
+    cmd = ['oscap', 'xccdf', 'generate', '--profile', '(all)', 'fix', util.get_datastream()]
     proc, lines = util.proc_stream(cmd, check=True)
     for line in lines:
         match = re.search('FIX FOR THIS RULE \'xccdf_org.ssgproject.content_rule_(.+)\' IS MISSING!', line)  # noqa

--- a/lib/util.py
+++ b/lib/util.py
@@ -107,6 +107,8 @@ class BackgroundHTTPServer(HTTPServer):
     def __init__(self, host, port):
         self.log = logging.getLogger(f'{__name__}.{self.__class__.__name__}').debug
         self.file_mapping = {}
+        self.listen_port = port
+        self.firewalld_zones = []
         super().__init__((host, port), _BackgroundHTTPServerHandler)
 
     def add_file(self, fspath, urlpath=None):
@@ -116,6 +118,19 @@ class BackgroundHTTPServer(HTTPServer):
 
     def __enter__(self):
         self.log(f"starting with: {self.file_mapping}")
+        # allow the target port on the firewall
+        if shutil.which('firewall-cmd'):
+            res = subprocess.run(
+                ['firewall-cmd', '--state'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if res.returncode == 0:
+                res = subprocess.run(
+                    ['firewall-cmd', '--get-zones'], stdout=subprocess.PIPE,
+                    universal_newlines=True, check=True)
+                self.firewalld_zones = res.stdout.strip().split(' ')
+                for zone in self.firewalld_zones:
+                    subprocess.run(
+                        ['firewall-cmd', f'--zone={zone}', f'--add-port={self.listen_port}/tcp'],
+                        stdout=subprocess.DEVNULL, check=True)
         proc = multiprocessing.Process(target=self.serve_forever)
         self.process = proc
         proc.start()
@@ -124,3 +139,8 @@ class BackgroundHTTPServer(HTTPServer):
         self.log("ending")
         self.process.terminate()
         self.process.join()
+        # remove allow rules from the firewall
+        for zone in self.firewalld_zones:
+            subprocess.run(
+                ['firewall-cmd', f'--zone={zone}', f'--remove-port={self.listen_port}/tcp'],
+                stdout=subprocess.DEVNULL, check=True)

--- a/lib/util.py
+++ b/lib/util.py
@@ -4,10 +4,39 @@ import inspect
 import subprocess
 from pathlib import Path
 
+import versions
+
+
 # directory with all these modules, and potentially more files
 # - useful until TMT can parametrize 'environment:' with variable expressions,
 #   so we could add the libdir to PATH and PYTHONPATH
 libdir = Path(inspect.getfile(inspect.currentframe())).parent
+
+# content locations
+DATASTREAMS = Path(os.getenv('CONTEST_DATASTREAMS', '/usr/share/xml/scap/ssg/content'))
+PLAYBOOKS = Path(os.getenv('CONTEST_PLAYBOOKS', '/usr/share/scap-security-guide/ansible'))
+KICKSTARTS = Path(os.getenv('CONTEST_KICKSTARTS', '/usr/share/scap-security-guide/kickstart'))
+
+
+def get_datastream():
+    if versions.rhel:
+        return DATASTREAMS / f'ssg-rhel{versions.rhel.major}-ds.xml'
+    else:
+        raise RuntimeError("cannot find datastream for non-RHEL")
+
+
+def get_playbook(profile):
+    if versions.rhel:
+        return PLAYBOOKS / f'rhel{versions.rhel.major}-playbook-{profile}.yml'
+    else:
+        raise RuntimeError("cannot find playbook for non-RHEL")
+
+
+def get_kickstart(profile):
+    if versions.rhel:
+        return KICKSTARTS / f'ssg-rhel{versions.rhel.major}-{profile}-ks.cfg'
+    else:
+        raise RuntimeError("cannot find kickstart for non-RHEL")
 
 
 def make_printable(obj):

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -819,8 +819,9 @@ def host_dnf_repos():
         c.read(repofile)
         for section in c.sections():
             if all(x in c[section] for x in ['name', 'baseurl', 'enabled']):
-                if c[section]['enabled'] == '1':
-                    yield (section, c[section]['baseurl'])
+                baseurl = c[section]['baseurl']
+                if c[section]['enabled'] == '1' and not baseurl.startswith('file://'):
+                    yield (section, baseurl)
 
 
 def ssh_keygen(path):

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -145,11 +145,14 @@ KICKSTART_PACKAGES = [
 # as byte-strings
 INSTALL_FAILURES = [
     br"org\.fedoraproject\.Anaconda\.Addons\.OSCAP\.*: The installation should be aborted",
+    br"The installation should be aborted.",
     br"\.common\.OSCAPaddonError:",
     br"The installation was stopped due to an error",
     br"There was an error running the kickstart script",
     br"Aborting the installation",
     br"Something went wrong during the final hardening",
+    # RHEL-7 ignores inst.noninteractive
+    br"Please respond ",
 ]
 
 PIPE = subprocess.PIPE

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -155,7 +155,6 @@ dnf -y makecache || yum -y makecache
 
 KICKSTART_PACKAGES = [
     'openscap-scanner',
-    'scap-security-guide',
     # because of semanage permissive -a virt_qemu_ga_t
     'policycoreutils-python' if versions.rhel < 8 else 'policycoreutils-python-utils',
 ]

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -863,15 +863,6 @@ def translate_ssg_kickstart(profile):
     return Kickstart(template=ks_text)
 
 
-def firewalld_allow_port(port):
-    """Allow guests to access the host on a specific TCP port."""
-    # just try everything we reasonably can and ignore any errors,
-    # RHEL-7 needs the rule in 'public', RHEL-9 in 'libvirt',
-    # RHEL-8 in Beaker doesn't seem to have firewalld running
-    for zone in ['public', 'libvirt']:
-        subprocess.run(['firewall-cmd', f'--zone={zone}',  f'--add-port={port}/tcp'])
-
-
 #
 # libvirt domain (guest) XML operations
 #

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -836,7 +836,10 @@ def translate_ssg_kickstart(profile):
     into class Kickstart instance.
     """
     ks_text = ''
-    with open(util.get_kickstart(profile)) as f:
+    ks_file = util.get_kickstart(profile)
+    _log(f"using orig file: {ks_file}")
+
+    with open(ks_file) as f:
         for line in f:
             line = line.rstrip('\n')
 

--- a/plans/default.fmf
+++ b/plans/default.fmf
@@ -3,16 +3,3 @@ discover:
     how: fmf
 execute:
     how: tmt
-adjust:
-    prepare:
-      - how: shell
-        name: install-epel-on-rhel7
-        because: python3 is not on RHEL 7 by default
-        script: |
-            if ! rpm -q epel-release; then
-                curl -o epel-release.rpm --retry 10 https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-                rpm -ivh epel-release.rpm
-                rm -f epel-release.rpm
-                #sed -i 's/^enabled=.*/enabled=1/' /etc/yum.repos.d/epel*
-            fi
-    when: distro < rhel-8

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,3 +1,16 @@
 # do not inherit test-specific metadata from toplevel
 /:
     inherit: false
+
+adjust:
+    - prepare:
+        - how: shell
+          name: install-epel-on-rhel7
+          because: python3 is not on RHEL 7 by default
+          script: |
+              if ! rpm -q epel-release; then
+                  curl -o epel-release.rpm --retry 10 https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+                  rpm -ivh epel-release.rpm
+                  rm -f epel-release.rpm
+              fi
+      when: distro < rhel-8

--- a/plans/upstream.fmf
+++ b/plans/upstream.fmf
@@ -1,0 +1,38 @@
+summary: Build upstream content and test against it
+discover:
+    how: fmf
+execute:
+    how: tmt
+
+adjust+:
+    - prepare+:
+          - how: install
+            package:
+                - git-core
+          - how: shell
+            name: Build content
+            script: |
+                url=${CONTENT_URL:-https://github.com/ComplianceAsCode/content.git}
+                branch=${CONTENT_BRANCH:-master}
+                major=$(. /etc/os-release && echo "${VERSION_ID%%.*}")
+                tmpdir=/var/tmp/content-from-source
+                echo -e "\nURL: $url\nBRANCH: $branch\nMAJOR: $major\n"
+
+                case "$major" in
+                    7) yum install -y cmake make openscap-utils openscap-scanner PyYAML python-jinja2 ;;
+                    *) dnf install -y cmake make openscap-utils openscap-scanner python3 python3-pyyaml python3-jinja2 python3-setuptools ;;
+                esac
+
+                rm -rf "$tmpdir"
+                git clone -b "$branch" --depth=1 "$url" "$tmpdir"
+                cd "$tmpdir"
+                ./build_product "rhel${major}"
+                ln -s "products/rhel${major}/kickstart"
+      finish+:
+          how: shell
+          script: rm -rf /var/tmp/content-from-source
+      environment+:
+          CONTEST_DATASTREAMS: /var/tmp/content-from-source/build
+          CONTEST_PLAYBOOKS: /var/tmp/content-from-source/build/ansible
+          CONTEST_KICKSTARTS: /var/tmp/content-from-source/kickstart
+      when: true


### PR DESCRIPTION
(Instead of using whatever is in the compose.)

This makes
* `oscap` use a copied datastream XML directly
* `anaconda` to use a HTTP-server-supplied datastream XML
* (future) ansible test to use a playbook directly

Essentially this enables us to source all the content pieces from wherever we want, rather than relying on them being available in the compose.

It also makes the `/hardening/anaconda` test already use content-provided kickstarts, rather than our own ones.

I'm not super proud of the `firewalld` workaround logic, but I think it's GEFN until we figure out all the environments we want to run in. Minimal install (ie. `easy-virt-install` kickstart) uses firewalld enabled by default, Beaker disables it for its installs, the zone used by libvirt differs between releases, etc.

Probably go through this commit-by-commit.

There's a few TODOs left in the code comments that I plan to resolve soon (1-2 days) after I get a reply from some package groups (compositions) experts and submit a CaC/content PR for potentially changing `%packages` sections of kickstarts, after which we may not need to clear them out.

Additional changes (testing all profiles via `Server with GUI`) will follow later, and are currently out of scope for this PR.