### PR TITLE
run all oscap/anaconda tests on "Server with GUI" too

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -12,8 +12,9 @@ extra-hardware: |
     environment+:
         PROFILE: anssi_bp28_high
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_high
     extra-nitrate: TC#0615157
     id: fa9bafe4-ec23-4f9e-8f20-277b32c3bcb3
@@ -22,8 +23,9 @@ extra-hardware: |
     environment+:
         PROFILE: anssi_nt28_high
     adjust:
-        when: distro > rhel-7
+        when: distro >= rhel-8
         enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_high
     extra-nitrate: TC#0615161
     id: c30492f5-a24e-4b88-a566-b75cc3485855
@@ -60,8 +62,9 @@ extra-hardware: |
     environment+:
         PROFILE: cui
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: CUI doesn't have a kickstart on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cui
     extra-nitrate: TC#0615169
     id: dcc000cc-f65a-47fd-bce2-d3ed4a1d5f4f
@@ -84,8 +87,9 @@ extra-hardware: |
     environment+:
         PROFILE: ism_o
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ism_o
     extra-nitrate: TC#0615172
     id: 0d9c11fb-da88-4a94-8a35-3247287b4fc5
@@ -101,8 +105,12 @@ extra-hardware: |
     environment+:
         PROFILE: pci-dss
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: >
+            RHEL-7 kickstart has a non-standard name and we decided that
+            it is too close to EOL to introduce a hacky logic specifically
+            for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/pci-dss
     extra-nitrate: TC#0615175
     id: f0f0151a-888c-4efa-aef8-90d0a94499c1
@@ -113,3 +121,11 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig
     extra-nitrate: TC#0615180
     id: 156ae132-5eac-4063-8189-7bd2fdd32e21
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    adjust:
+        enabled: false
+        because: not supported without GUI, use stig instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -113,10 +113,3 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig
     extra-nitrate: TC#0615180
     id: 156ae132-5eac-4063-8189-7bd2fdd32e21
-
-/stig_gui:
-    environment+:
-        PROFILE: stig_gui
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
-    extra-nitrate: TC#0615181
-    id: 21b4d2f5-36fb-469f-8de9-d2c7a0eb0f92

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -22,7 +22,7 @@ profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 ks.add_post('chage -d 99999 root')
 
-if profile.endswith('_gui'):
+if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.add_package_group('Server with GUI')
 
 oscap_conf = {

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -1,0 +1,83 @@
+environment+:
+    USE_SERVER_WITH_GUI: 1
+duration: 2h
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro > rhel-7
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/pci-dss
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig_gui

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -6,26 +6,38 @@ duration: 2h
     environment+:
         PROFILE: anssi_bp28_high
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_bp28_high
 
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
     adjust:
-        when: distro > rhel-7
+        when: distro >= rhel-8
         enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_nt28_high
 
 /cis:
     environment+:
         PROFILE: cis
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_server_l1
 
 /cis_workstation_l1:
@@ -42,8 +54,14 @@ duration: 2h
     environment+:
         PROFILE: cui
     adjust:
-        when: distro < rhel-8
-        enabled: false
+        - when: distro == rhel-7
+          enabled: false
+          because: CUI doesn't have a kickstart on RHEL-7
+        - when: distro <= rhel-8
+          enabled: false
+          because: >
+              not supported on RHEL-8 according to RHEL documentation,
+              the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cui
 
 /e8:
@@ -60,22 +78,44 @@ duration: 2h
     environment+:
         PROFILE: ism_o
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ism_o
 
 /ospp:
     environment+:
         PROFILE: ospp
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ospp
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: >
+            RHEL-7 kickstart has a non-standard name and we decided that
+            it is too close to EOL to introduce a hacky logic specifically
+            for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    adjust:
+        enabled: false
+        because: >
+            not supported with GUI, use stig_gui instead;
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig
 
 /stig_gui:
     environment+:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -12,8 +12,9 @@ extra-hardware: |
     environment+:
         PROFILE: anssi_bp28_high
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_high
     extra-nitrate: TC#0615184
     id: f505892f-12ab-49de-bfa0-59e3fe9fe5c4
@@ -22,8 +23,9 @@ extra-hardware: |
     environment+:
         PROFILE: anssi_nt28_high
     adjust:
-        when: distro > rhel-7
+        when: distro >= rhel-8
         enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_high
     extra-nitrate: TC#0615188
     id: 72343ccf-47c6-4d0f-83e2-1026951c370c
@@ -81,8 +83,9 @@ extra-hardware: |
     environment+:
         PROFILE: ism_o
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ism_o
     extra-nitrate: TC#0615199
     id: 71ec5f37-5061-490a-a845-7eea86ad0c16
@@ -107,3 +110,11 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig
     extra-nitrate: TC#0615207
     id: 90d8c69c-4dea-404f-9158-2b2923e929c3
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    adjust:
+        enabled: false
+        because: not supported without GUI, use stig instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -107,10 +107,3 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig
     extra-nitrate: TC#0615207
     id: 90d8c69c-4dea-404f-9158-2b2923e929c3
-
-/stig_gui:
-    environment+:
-        PROFILE: stig_gui
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
-    extra-nitrate: TC#0615208
-    id: c50a0633-b112-43dd-bb70-8d99da62294f

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -14,14 +14,16 @@ virt.setup_host()
 profile = os.environ['PROFILE']
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
-if profile.endswith('_gui'):
+use_gui = os.environ.get('USE_SERVER_WITH_GUI')
+
+if use_gui:
     g = virt.Guest('gui_with_oscap')
 else:
     g = virt.Guest('minimal_with_oscap')
 
 if not g.can_be_snapshotted():
     ks = virt.Kickstart()
-    if profile.endswith('_gui'):
+    if use_gui:
         ks.add_package_group('Server with GUI')
     g.install(kickstart=ks)
     g.prepare_for_snapshot()

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -6,26 +6,38 @@ duration: 2h
     environment+:
         PROFILE: anssi_bp28_high
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_bp28_high
 
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
     adjust:
-        when: distro > rhel-7
+        when: distro >= rhel-8
         enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_nt28_high
 
 /cis:
     environment+:
         PROFILE: cis
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_server_l1
 
 /cis_workstation_l1:
@@ -41,6 +53,12 @@ duration: 2h
 /cui:
     environment+:
         PROFILE: cui
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cui
 
 /e8:
@@ -57,19 +75,37 @@ duration: 2h
     environment+:
         PROFILE: ism_o
     adjust:
-        when: distro < rhel-8
+        when: distro == rhel-7
         enabled: false
+        because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ism_o
 
 /ospp:
     environment+:
         PROFILE: ospp
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ospp
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    adjust:
+        enabled: false
+        because: >
+            not supported with GUI, use stig_gui instead;
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig
 
 /stig_gui:
     environment+:

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -1,0 +1,77 @@
+environment+:
+    USE_SERVER_WITH_GUI: 1
+duration: 2h
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro > rhel-7
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro < rhel-8
+        enabled: false
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/pci-dss
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig_gui


### PR DESCRIPTION
The `2h` duration is there because the extra packages do add +20-30min of time, sometimes more.