### PR TITLE
Custom logging, silencing PASS, change to PYTHONPATH, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ on Red Hat Enterprise Linux.
 
 ## Parameters
 
-(TODO: Probably document this on a better place.)
+- `CONTEST_VERBOSE`
+  - Set to `1` to make Beaker/TMT report all results, incl. `pass`, `warn` and
+    `info`. These are suppressed by default to avoid huge result sets.  
+    This applies to sub-results (`/something` after a test name), results for
+    tests themselves (as seen by TMT) are always reported.
 
 ## Testing latest upstream content
 

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -1,8 +1,8 @@
 summary: Remediates VM via anaconda %addon, scans via oscap
-test: python3 -m runtest ./test.py
+test: python3 -m lib.runtest ./test.py
 result: custom
 environment+:
-    PYTHONPATH: ../../lib
+    PYTHONPATH: ../..
 duration: 1h
 extra-hardware: |
     keyvalue = HVM=1

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -2,11 +2,7 @@
 
 import os
 
-import util
-import results
-import virt
-import oscap
-import versions
+from lib import util, results, virt, oscap, versions
 
 
 virt.setup_host()

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -1,8 +1,8 @@
 summary: Runs oscap remediation and scan inside VMs
-test: python3 -m runtest ./test.py
+test: python3 -m lib.runtest ./test.py
 result: custom
 environment+:
-    PYTHONPATH: ../../lib
+    PYTHONPATH: ../..
 duration: 1h
 extra-hardware: |
     keyvalue = HVM=1

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -2,11 +2,7 @@
 
 import os
 
-import util
-import results
-import virt
-import oscap
-import versions
+from lib import util, results, virt, oscap, versions
 
 
 virt.setup_host()

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -3,8 +3,7 @@ import re
 import logging
 from pathlib import Path
 
-import results
-import util
+from . import util, results
 
 _log = logging.getLogger(__name__).debug
 _no_remediation_cache = None

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -1,11 +1,9 @@
 import sys
 import re
-import logging
 from pathlib import Path
 
 from . import util, results
 
-_log = logging.getLogger(__name__).debug
 _no_remediation_cache = None
 
 
@@ -96,4 +94,4 @@ def report_from_verbose(lines):
     if total == 0:
         raise RuntimeError("oscap returned no results")
 
-    _log(f"all done: {total} total results")
+    util.log(f"all done: {total} total results")

--- a/lib/results.py
+++ b/lib/results.py
@@ -19,8 +19,7 @@ import shutil
 import requests
 from pathlib import Path
 
-import util
-import waive
+from . import util, waive
 
 _log = logging.getLogger(__name__).debug
 

--- a/lib/results.py
+++ b/lib/results.py
@@ -14,14 +14,11 @@ Beaker uses the HTTP API, connecting to a local labcontroller.
 import os
 import sys
 import re
-import logging
 import shutil
 import requests
 from pathlib import Path
 
 from . import util, waive
-
-_log = logging.getLogger(__name__).debug
 
 _valid_statuses = ['pass', 'fail', 'warn', 'error', 'info']
 
@@ -140,7 +137,7 @@ def report_beaker(status, name=None, note=None, logs=None):
     }
     r = requests.post(url, data=payload)
     if r.status_code != 201:
-        _log(f"reporting to {url} failed with {r.status_code}")
+        util.log(f"reporting to {url} failed with {r.status_code}")
         return
 
     if logs:
@@ -149,7 +146,7 @@ def report_beaker(status, name=None, note=None, logs=None):
             with open(log, 'rb') as f:
                 r = requests.put(logpath, data=f)
                 if r.status_code != 204:
-                    _log(f"uploading log {logpath} failed with {r.status_code}")
+                    util.log(f"uploading log {logpath} failed with {r.status_code}")
 
 
 def report_plain(status, name=None, note=None, logs=None):
@@ -157,7 +154,7 @@ def report_plain(status, name=None, note=None, logs=None):
         name = '/'
     note = f' ({note})' if note else ''
     logs = f' / {logs}' if logs else ''
-    _log(f'{status.upper()} {name}{note}{logs}')
+    util.log(f'{status.upper()} {name}{note}{logs}')
 
 
 def report(status, name=None, note=None, logs=None, *, add_output=True):

--- a/lib/results.py
+++ b/lib/results.py
@@ -60,6 +60,11 @@ def _sanitize_yaml_id(string):
 def report_tmt(status, name=None, note=None, logs=None, *, add_output=True):
     report_plain(status, name, note, logs)
 
+    # report these only in verbose mode
+    if status in ['pass', 'info'] and name:
+        if os.environ.get('CONTEST_VERBOSE') != '1':
+            return
+
     if not name:
         name = '/'  # https://github.com/teemtee/tmt/issues/1855
     else:
@@ -101,17 +106,12 @@ def report_tmt(status, name=None, note=None, logs=None, *, add_output=True):
 
 
 def report_beaker(status, name=None, note=None, logs=None):
-    # limit results reported directly to Beaker, because there is no way
-    # for us to post-process them, to remove "unimportant" results, like there
-    # is with TMT, so just pick some reasonable default of "fails only"
-    # - plus, this saves several minutes of slow Beaker reporting
-    #
-    # never skip name=None results (reports for the test itself) as these
-    # contain report.html attached
-    if status in ['pass', 'warn', 'info'] and name:
-        return
-
     report_plain(status, name, note, logs)
+
+    # report these only in verbose mode
+    if status in ['pass', 'warn', 'info'] and name:
+        if os.environ.get('CONTEST_VERBOSE') != '1':
+            return
 
     labctl = os.environ['LAB_CONTROLLER']
     taskid = os.environ['TASKID']

--- a/lib/runtest.py
+++ b/lib/runtest.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import re
-import logging
 import runpy
 import signal
 from pathlib import Path
@@ -55,10 +54,6 @@ def _setup_timeout_handling():
     signal.signal(signal.SIGALRM, _alarm_timed_out)
     signal.alarm(duration)
 
-
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s %(name)s:%(funcName)s:%(lineno)d: %(message)s',
-                    datefmt='%Y-%m-%d %H:%M:%S')
 
 if util.running_in_tmt():
     _setup_timeout_handling()

--- a/lib/runtest.py
+++ b/lib/runtest.py
@@ -6,8 +6,7 @@ import runpy
 import signal
 from pathlib import Path
 
-import util
-import results
+from . import util, results
 
 
 # handle test duration on our own, don't rely on TMT -

--- a/lib/util.py
+++ b/lib/util.py
@@ -8,12 +8,14 @@ import multiprocessing
 from pathlib import Path
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 
-import versions
+from . import versions
 
 
 # directory with all these modules, and potentially more files
 # - useful until TMT can parametrize 'environment:' with variable expressions,
 #   so we could add the libdir to PATH and PYTHONPATH
+# TODO: after RHEL-7, replace with importlib.resources to access files
+#       in the python package hierarchy, python 3.7+
 libdir = Path(inspect.getfile(inspect.currentframe())).parent
 
 

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -92,8 +92,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import util
-import versions
+from . import util, versions
 
 _log = logging.getLogger(__name__).debug
 

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -196,14 +196,14 @@ def setup_host():
     if ret.returncode != 0:
         _log("installing libvirt + qemu")
         cmd = [dnf, '-y', '--nogpgcheck', '--setopt=install_weak_deps=False', 'install']
-        subprocess.run(cmd + host_pkgs, check=True)
+        util.subprocess_run(cmd + host_pkgs, check=True)
         # free up some disk space
-        subprocess.run([dnf, 'clean', 'packages'], check=True)
+        util.subprocess_run([dnf, 'clean', 'packages'], check=True)
 
     ret = subprocess.run(['systemctl', 'is-active', '--quiet', 'libvirtd'])
     if ret.returncode != 0:
         _log("starting libvirtd")
-        subprocess.run(['systemctl', 'start', 'libvirtd'], check=True)
+        util.subprocess_run(['systemctl', 'start', 'libvirtd'], check=True)
 
     net_xml = textwrap.dedent(f'''\
         <network>
@@ -540,7 +540,7 @@ class Guest:
             '-b', self.orig_disk_path, '-F', self.orig_disk_format,
             self.snapshot_path
         ]
-        subprocess.run(cmd, check=True)
+        util.subprocess_run(cmd, check=True)
 
         virsh('restore', self.state_file_path, check=True)
 
@@ -583,7 +583,7 @@ class Guest:
                 self.log(f"shutdown timed out, destroying {self.name}")
                 self.destroy()
 
-    def _do_ssh(self, *cmd, func=subprocess.run, capture=False, **run_args):
+    def _do_ssh(self, *cmd, func=util.subprocess_run, capture=False, **run_args):
         if capture:
             run_args['stdout'] = PIPE
             run_args['stderr'] = PIPE
@@ -592,7 +592,6 @@ class Guest:
             '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
             f'{GUEST_SSH_USER}@{self.ipaddr}', '--', *cmd
         ]
-        self.log(f"running ssh root@{self.ipaddr} {' '.join(cmd)}")
         return func(ssh_cmdline, **run_args)
 
     def ssh(self, *cmd, **kwargs):
@@ -608,7 +607,7 @@ class Guest:
             '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
             *args
         ]
-        return subprocess.run(scp_cmdline, check=True)
+        return util.subprocess_run(scp_cmdline, check=True)
 
     def copy_from(self, remote_file, local_file=None):
         if not local_file:
@@ -831,7 +830,7 @@ def ssh_keygen(path):
     """
     Generate private/public keys prefixed by 'path'.
     """
-    subprocess.run(['ssh-keygen', '-N', '', '-f', path], stdout=DEVNULL, check=True)
+    util.subprocess_run(['ssh-keygen', '-N', '', '-f', path], stdout=DEVNULL, check=True)
 
 
 def translate_ssg_kickstart(profile):

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -8,8 +8,7 @@ import re
 import textwrap
 from pathlib import Path
 
-import util
-import versions
+from . import util, versions
 
 _sections_cache = None
 


### PR DESCRIPTION
These are a bunch of miscellaneous changes I made while adding a new Ansible test, and I'm sending them ahead of the Ansible PR as they aren't strictly related.

### Changing `PYTHONPATH` to repo root

This basically means we have to `import lib` or `import lib.util` or `from lib import util`, instead of just doing `import util`. This alone is probably a good change, as we're not polluting the global module search namespace with `lib/*.py`, but it was done mainly to allow importing from `conf`.

For Ansible (and other tests), I wanted to have `--skip-tags` and similar configuration in `conf` as python modules, which can not only use pythonic ways to define data (lists, dictionaries, etc.), but they can even do ie. `from ..lib import versions` and selectively add/remove list items depending on RHEL / content / etc. version.

With this change, the tests can simply do `from conf import whatever` (and I already do that for `--skip-tags`).

As a TODO in code also mentions, this will allow `lib/waive.py` to access `conf/waives` natively, without a path hack, once we migrate away from Python 3.6.

### The logging stuff

While writing the Ansible test, I noticed I'm not getting any log messages for `subprocess.run` stuff. This wasn't an issue before since we issued most commands via ssh, which does custom logging,
```python
        ssh_cmdline = [
            'ssh', '-q', '-i', self.ssh_keyfile_path, '-o', 'BatchMode=yes',
            '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null',
            f'{GUEST_SSH_USER}@{self.ipaddr}', '--', *cmd
        ]
        self.log(f"running ssh root@{self.ipaddr} {' '.join(cmd)}")
```
but since `ansible-playbook` runs via `subprocess.run`, I didn't see it. Neither did I see `ansible-galaxy` commands.

So I implemented an `util.subprocess_run` wrapper, but it only highlighted a bigger problem we've had in the suite forever, that log messages are emited from the functions that call `_log()` or `self.log()`, without any context.
```
2023-05-18 17:57:51 virt.Guest:_do_ssh:596: running ssh root@192.168.121.115 oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig_gui --progress --remediate contest-ds.xml
```
I can't tell where this originated.  
The new function made things even worse because everything was `subprocess_run`, losing the parent context:
```
2023-05-18 17:56:44 lib.util:subprocess_run:154: (['qemu-img', 'create', '-f', 'qcow2', '-b', '/var/lib/libvirt/images/contest.img', '-F', 'raw', '/var/lib/libvirt/images/contest-snap.qcow2'],)

2023-05-18 17:58:30 lib.util:subprocess_run:154: (['ssh', '-q', '-i', '/var/lib/libvirt/images/contest.sshkey', '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'root@192.168.121.115', '--', 'oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_stig_gui --progress --remediate contest-ds.xml'],)
```
Then I discovered that the standard `logging` is kind of a black sheep in Python, using non-pythonic naming and syntax, and that making up custom logging is kind of common.

So I did that.

The new `util.log()` function can be called from anywhere, it doesn't need `getLogger()` in a class `__init__`, it doesn't need any setup in `runtest.py`, it Just Works. And allows us to adjust the context so that it always shows something meaningful. In most cases.

```
2023-05-18 17:29:23 test.py:8: lib.virt.setup_host:202: running: systemctl start libvirtd
2023-05-18 17:29:24 test.py:25: lib.virt.Guest._restore_snapshotted:537: running: qemu-img create -f qcow2 -b /var/lib/libvirt/images/contest.img -F raw /var/lib/libvirt/images/contest-snap.qcow2
Formatting '/var/lib/libvirt/images/contest-snap.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=21474836480 backing_file=/var/lib/libvirt/images/contest.img backing_fmt=raw lazy_refcounts=off refcount_bits=16
2023-05-18 17:29:25 test.py:25: lib.virt.wait_for_ifaddr:753: waiting for IP addr of contest for up to 600sec
2023-05-18 17:29:25 test.py:25: lib.virt.wait_for_ssh:775: waiting for ssh on 192.168.121.115:22 to start for up to 600sec
2023-05-18 17:29:25 test.py:25: lib.virt.Guest.snapshotted:555: guest contest ready
2023-05-18 17:29:25 test.py:27: lib.virt.Guest.copy_to:615: copying /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml to guest, to contest-ds.xml
```
As an added bonus, this allows us to always correlate a log message down to a specific test line number, making debugging easier.

See code doctext for more.

### `CONTEST_VERBOSE`

I had to give in. Beaker was not the only one with large result set issues. So this silences `pass`/`info` (and `warn` for Beaker).  
From the commit msg:

```
With just a few tests, we can already reach ~12000 results,
which is impossible for Beaker to handle, but also causes
issues for TMT and its slow / memory-hungry YAML processing,
not to mention the >100MB size of resulting logs, as oscap
(and other) verbose logs are always stored, even for PASS.

I left report_plain to always report all results as they are
just text lines, and that should be good enough for investigating
whether a specific result PASSed or didn't exist at all.
```

We also eventually need to make Contest compatible with Testing Farm, and this change at least allows it to run as-is, without breaking/freezing Oculus (TF reporting interface).