### PR TITLE
Add a `/hardening/ansible` test, with gui too

### DIFF
--- a/conf/remediation_excludes.py
+++ b/conf/remediation_excludes.py
@@ -1,0 +1,34 @@
+# this file contains rules that should NOT be remediated under certain
+# conditions, as their remediation would lead to a broken OS, unable to
+# report test results
+#
+# do not use it to exclude expected failures, use the waiving logic instead
+
+# skip Ansible remediation for these rules
+ansible_skip_tags = [
+    # TODO:
+    #'ensure_gpgcheck_globally_activated',
+    #'ensure_gpgcheck_local_packages',
+    #'ensure_gpgcheck_never_disabled',
+    #'ensure_gpgcheck_repo_metadata',
+    #'ensure_redhat_gpgkey_installed',
+    #'no_direct_root_logins',
+    #'set_firewalld_default_zone',
+    #'firewalld_sshd_disabled',
+    #'service_sshd_disabled',
+    #'iptables_sshd_disabled',
+    #'sshd_disable_root_login',
+    #'sshd_disable_empty_passwords',
+    #'disable_host_auth',
+    #'harden_sshd_crypto_policy',
+    #'configure_etc_hosts_deny',
+    #'sudo_add_noexec',
+    #'accounts_password_set_max_life_existing',
+]
+
+# same os "machine hardening" exclusions, the remediation of which would break
+# this test suite
+same_os = [
+    # required by TMT
+    'package_rsync_removed',
+]

--- a/conf/waivers
+++ b/conf/waivers
@@ -17,7 +17,7 @@
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
 # and a later enable_authselect remediation breaks it
 # - see https://github.com/OpenSCAP/openscap/issues/1880
-/hardening/.+/accounts_password_pam_retry
+/hardening/(anaconda|oscap)/.+/accounts_password_pam_retry
     rhel >= 8
 
 # https://github.com/ComplianceAsCode/content/pull/10499
@@ -97,5 +97,74 @@
 # seems to be happening much more reliably with GUI
 /hardening/anaconda/with-gui/cis_workstation_l[12]
     Match(status == 'error', sometimes=True)
+
+# TODO: completely unknown, investigate and sort
+#
+# all RHELs
+/hardening/ansible/.+/aide_verify_acls
+/hardening/ansible/.+/aide_verify_ext_attributes
+/hardening/ansible/.+/mount_option_boot_noexec
+/hardening/ansible/.+/mount_option_boot_nosuid
+/hardening/ansible/.+/mount_option_home_noexec
+/hardening/ansible/.+/accounts_password_set_min_life_existing
+/hardening/ansible/.+/audit_rules_usergroup_modification
+    True
+# RHEL-9 only
+/hardening/ansible/.+/aide_scan_notification
+/hardening/ansible/.+/dnf-automatic_apply_updates
+/hardening/ansible/.+/dnf-automatic_security_updates_only
+/hardening/ansible/.+/accounts_polyinstantiated_tmp
+/hardening/ansible/.+/accounts_polyinstantiated_var_tmp
+/hardening/ansible/.+/disable_ctrlaltdel_(burstaction|reboot)
+/hardening/ansible/.+/configure_opensc_card_drivers
+/hardening/ansible/.+/force_opensc_card_drivers
+/hardening/ansible/with-gui/.+/network_nmcli_permissions
+    rhel == 9
+# RHEL-8 or 9
+/hardening/ansible/.+/no_tmux_in_shells
+/hardening/ansible/.+/configure_usbguard_auditbackend
+/hardening/ansible/.+/audit_rules_unsuccessful_file_modification
+    rhel == 8 or rhel == 9
+# RHEL-7
+/hardening/ansible/.+/sshd_use_strong_ciphers
+/hardening/ansible/.+/sshd_use_strong_macs
+/hardening/ansible/.+/audit_rules_for_ospp
+/hardening/ansible/.+/aide_use_fips_hashes
+/hardening/ansible/.+/smartcard_auth
+    rhel == 7
+
+# it's weird how specific home_nosuid is - seems to pass for many other
+# profiles, or even for the same profile on different RHELs
+/hardening/ansible(/with-gui)?/anssi_bp28_high/mount_option_home_nosuid
+/hardening/ansible/stig/mount_option_home_nosuid
+    rhel == 9 or rhel == 8
+/hardening/ansible/with-gui/stig_gui/mount_option_home_nosuid
+    rhel == 9
+/hardening/ansible/cui/mount_option_home_nosuid
+/hardening/ansible/ospp/mount_option_home_nosuid
+    rhel == 8
+/hardening/ansible/with-gui/anssi_nt28_high/mount_option_home_nosuid
+    rhel == 7
+
+# only on ism_o, seems to pass everywhere else
+/hardening/ansible(/with-gui)?/ism_o/enable_fips_mode
+    rhel == 9
+
+# only pci-dss, passes everywhere else
+/hardening/ansible(/with-gui)?/pci-dss/audit_rules_login_events
+    rhel == 8 or rhel == 9
+
+# WARNING: UNPROTECTED PRIVATE KEY FILE!
+/hardening/ansible/with-gui/cis_workstation_l[12]
+    status == 'error'
+
+# ansible-playbook completed, but returned non-0, TODO: investigate
+/hardening/ansible/stig
+/hardening/ansible/with-gui/stig_gui
+    status == 'error' and rhel == 8
+
+
+
+
 
 # vim: syntax=python

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -1,0 +1,112 @@
+summary: Runs ansible remediation and scan inside VMs
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 1h
+recommend+:
+    # ansible-core is not available on RHEL-7
+    # ansible is not on RHEL-8+
+    - ansible-core
+    - ansible
+    # needed for the ini_file ansible plugin
+    - rhc-worker-playbook
+extra-hardware: |
+    keyvalue = HVM=1
+    hostrequire = memory>=4800
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro >= rhel-8
+        enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: CUI doesn't have a kickstart on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: doesn't exist on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: >
+            RHEL-7 kickstart has a non-standard name and we decided that
+            it is too close to EOL to introduce a hacky logic specifically
+            for this case
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    adjust:
+        enabled: false
+        because: not supported without GUI, use stig instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -9,7 +9,7 @@ recommend+:
     # ansible is not on RHEL-8+
     - ansible-core
     - ansible
-    # needed for the ini_file ansible plugin
+    # needed for the ini_file ansible plugin, and more
     - rhc-worker-playbook
 extra-hardware: |
     keyvalue = HVM=1

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -27,15 +27,23 @@ if not g.can_be_snapshotted():
     g.install(kickstart=ks)
     g.prepare_for_snapshot()
 
-# TODO: no clue why this is needed, but it was in the old tests
-for collection in ['community.general', 'ansible.posix']:
-    util.subprocess_run(
-        ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
-        check=True)
-
 # the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks
 # on trying to accept its ssh key - tell it to ignore this
 os.environ['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
+
+# rhc-worker-playbook modules, exported per official instructions on
+# https://access.redhat.com/articles/remediation
+os.environ['ANSIBLE_COLLECTIONS_PATH'] = \
+    '/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/'
+
+# this is an alternate way to get modules provided by rhc-worker-playbook,
+# a RPM which is not available on CentOS / Fedora - uncomment and use this
+# if we ever run on non-RHEL
+# https://issues.redhat.com/browse/OPENSCAP-2296
+#for collection in ['community.general', 'ansible.posix']:
+#    util.subprocess_run(
+#        ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
+#        check=True)
 
 with g.snapshotted():
     # remediate using a locally-run 'ansible-playbook', which connects

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python3
+
+import os
+import re
+import subprocess
+
+from lib import util, results, virt, oscap, versions
+from conf import remediation_excludes
+
+
+virt.setup_host()
+
+profile = os.environ['PROFILE']
+profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
+
+use_gui = os.environ.get('USE_SERVER_WITH_GUI')
+
+if use_gui:
+    g = virt.Guest('gui_with_oscap')
+else:
+    g = virt.Guest('minimal_with_oscap')
+
+if not g.can_be_snapshotted():
+    ks = virt.Kickstart()
+    if use_gui:
+        ks.add_package_group('Server with GUI')
+    g.install(kickstart=ks)
+    g.prepare_for_snapshot()
+
+# TODO: no clue why this is needed, but it was in the old tests
+for collection in ['community.general', 'ansible.posix']:
+    util.subprocess_run(
+        ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
+        check=True)
+
+# the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks
+# on trying to accept its ssh key - tell it to ignore this
+os.environ['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
+
+with g.snapshotted():
+    # remediate using a locally-run 'ansible-playbook', which connects
+    # to the guest using ssh
+    playbook = util.get_playbook(profile)
+    skip_tags = ','.join(remediation_excludes.ansible_skip_tags)
+    skip_tags_arg = ['--skip-tags', skip_tags] if skip_tags else []
+    ansible_cmd = [
+        'ansible-playbook', '-v', '-i', f'{g.ipaddr},',
+        '--private-key', g.ssh_keyfile_path,
+        *skip_tags_arg,
+        playbook,
+    ]
+
+    _, lines = util.subprocess_stream(ansible_cmd, check=True)
+    for line in lines:
+        # avoid printing/logging facts, which make up 99% of the output
+        if re.match('[a-z]+: \[[0-9\.]+\] => {"ansible_facts": ', line):
+            line = re.sub(
+                '"ansible_facts": .*',
+                '"ansible_facts": <contest redacted to save log space>',
+                line,
+                count=1)
+        util.log(line)
+
+    g.soft_reboot()
+
+    # old RHEL-7 oscap mixes errors into --progress rule names without a newline
+    verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
+    redir = '2>&1' if versions.oscap >= 1.3 else ''
+
+    # scan the remediated system
+    g.copy_to(util.get_datastream(), 'contest-ds.xml')
+    proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile_full} --progress '
+                               f'--report report.html contest-ds.xml {redir}')
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0,2]:
+        raise RuntimeError("post-reboot oscap failed unexpectedly")
+
+    g.copy_from('report.html')
+
+results.report_and_exit(logs=['report.html'])

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -49,18 +49,7 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-
-    _, lines = util.subprocess_stream(ansible_cmd, check=True)
-    for line in lines:
-        # avoid printing/logging facts, which make up 99% of the output
-        if re.match('[a-z]+: \[[0-9\.]+\] => {"ansible_facts": ', line):
-            line = re.sub(
-                '"ansible_facts": .*',
-                '"ansible_facts": <contest redacted to save log space>',
-                line,
-                count=1)
-        util.log(line)
-
+    util.subprocess_run(ansible_cmd, check=True)
     g.soft_reboot()
 
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -1,0 +1,123 @@
+environment+:
+    USE_SERVER_WITH_GUI: 1
+duration: 2h
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro >= rhel-8
+        enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    adjust:
+        enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    adjust:
+        - when: distro == rhel-7
+          enabled: false
+          because: CUI doesn't have a kickstart on RHEL-7
+        - when: distro <= rhel-8
+          enabled: false
+          because: >
+              not supported on RHEL-8 according to RHEL documentation,
+              the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: doesn't exist on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: >
+            RHEL-7 kickstart has a non-standard name and we decided that
+            it is too close to EOL to introduce a hacky logic specifically
+            for this case
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    adjust:
+        enabled: false
+        because: >
+            not supported with GUI, use stig_gui instead;
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig_gui

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -77,7 +77,6 @@ import sys
 import re
 import socket
 import time
-import builtins
 import subprocess
 import textwrap
 import contextlib
@@ -575,7 +574,7 @@ class Guest:
             try:
                 util.log(f"shutting down {self.name}")
                 self.shutdown()
-            except builtins.TimeoutError:
+            except TimeoutError:
                 util.log(f"shutdown timed out, destroying {self.name}")
                 self.destroy()
 
@@ -721,7 +720,7 @@ def wait_for_domstate(name, state, timeout=300, sleep=0.5):
     while datetime.now() < end_time:
         if guest_domstate(name) == state:
             return
-    raise builtins.TimeoutError(f"wait for {name} to be in {state} timed out")
+    raise TimeoutError(f"wait for {name} to be in {state} timed out")
 
 
 #
@@ -759,7 +758,7 @@ def wait_for_ifaddr(name, timeout=600, sleep=0.5):
             return domifaddr(name)
         except ConnectionError:
             time.sleep(sleep)
-    raise builtins.TimeoutError(f"wait for {name} IP addr timed out (not requested DHCP?)")
+    raise TimeoutError(f"wait for {name} IP addr timed out (not requested DHCP?)")
 
 
 def wait_for_ssh(ip, port=22, timeout=600, sleep=0.5, to_shutdown=False):
@@ -788,7 +787,7 @@ def wait_for_ssh(ip, port=22, timeout=600, sleep=0.5, to_shutdown=False):
             if to_shutdown:
                 return
             time.sleep(sleep)
-    raise builtins.TimeoutError(f"ssh wait for {ip}:{port} timed out")
+    raise TimeoutError(f"ssh wait for {ip}:{port} timed out")
 
 
 #


### PR DESCRIPTION
Even though this is Draft, the test does work as-is and the waivers should be mostly accurate.

I didn't apparently need to use any skip-tags, the runs finished in a reasonable amount of time and there were no failures that I could easily identify as part of the testing environment.  
There were a few spurious "could not resolve" DNS issues with our internal download servers, but those seem intermittent and didn't always manifest.

If you know of something that should definitely be in skip-tags, let me know, otherwise I'll remove the TODO along with the commented-out tags. The functionality will remain, just with empty list for now.

The `same_os` skip-tags are useless for now (they're for a future "machine hardening" style test), but since I went through the old tests, I put them here anyway.

Otherwise the Ansible test really just does `ansible-playbook` + check via `oscap` (like for Anaconda).

Your comments on the waivers are welcome, but, as usual, I'm not aiming to investigate every single fail here in this PR. It's mostly about implementing a new test + recording what currently fails.

Any extra non-Ansible changes are confined to their commits.

Thanks!