### PR TITLE
Add `/hardening/host-os/{oscap,ansible}` tests

### DIFF
--- a/conf/remediation_excludes.py
+++ b/conf/remediation_excludes.py
@@ -26,9 +26,9 @@ ansible_skip_tags = [
     #'accounts_password_set_max_life_existing',
 ]
 
-# same os "machine hardening" exclusions, the remediation of which would break
+# host os "machine hardening" exclusions, the remediation of which would break
 # this test suite
-same_os = [
+host_os = [
     # required by TMT
     'package_rsync_removed',
 ]

--- a/conf/waivers
+++ b/conf/waivers
@@ -9,9 +9,14 @@
 /hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_exec_tmux
 /hardening/oscap(/with-gui)?/[^/]+/no_tmux_in_shells
 /hardening/oscap(/with-gui)?/[^/]+/configure_usbguard_auditbackend
+/hardening/host-os/oscap/[^/]+/configure_bashrc_exec_tmux
+/hardening/host-os/oscap/[^/]+/no_tmux_in_shells
+/hardening/host-os/oscap/[^/]+/configure_usbguard_auditbackend
     rhel >= 8
 /hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
 /hardening/oscap(/with-gui)?/stig(_gui)?/postfix_prevent_unrestricted_relay
+/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
+/hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
     rhel == 8
 
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
@@ -19,6 +24,8 @@
 # - see https://github.com/OpenSCAP/openscap/issues/1880
 /hardening/(anaconda|oscap)/.+/accounts_password_pam_retry
     rhel >= 8
+/hardening/host-os/oscap/[^/]+/accounts_password_pam_retry
+    Match(rhel >= 8, sometimes=True)
 
 # https://github.com/ComplianceAsCode/content/pull/10499
 # these are missing the required partitions, making the oscap Anaconda addon
@@ -48,8 +55,12 @@
     rhel == 8
 
 # https://github.com/ComplianceAsCode/content/issues/10424
+# happens on host-os hardening too, probably because Beaker doesn't have
+# firewall enabled or even installed
 /hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
     ssg >= '0.1.68'
+/hardening/host-os/oscap/[^/]+/service_nftables_disabled
+    Match(ssg >= '0.1.68', sometimes=True)
 
 # caused by us not caring whether the VM has it installed,
 # - remediation should fix it, but doesn't -- possibly caused by
@@ -97,6 +108,16 @@
 # seems to be happening much more reliably with GUI
 /hardening/anaconda/with-gui/cis_workstation_l[12]
     Match(status == 'error', sometimes=True)
+
+# probably because Beaker has crond enabled
+# - TODO: shouldn't oscap be able to disable a service via remediation?
+/hardening/host-os/oscap/[^/]+/service_crond_enabled
+    Match(True, sometimes=True)
+# same for dnf-automatic and rsyslog (??), is this fully random?
+/hardening/host-os/oscap/[^/]+/package_dnf-automatic_installed
+/hardening/host-os/oscap/[^/]+/timer_dnf-automatic_enabled
+/hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
+    Match(rhel >= 8, sometimes=True)
 
 # TODO: completely unknown, investigate and sort
 #

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -1,0 +1,110 @@
+summary: Runs ansible remediation directly on the target system
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../../..
+duration: 1h
+recommend+:
+    # ansible-core is not available on RHEL-7
+    # ansible is not on RHEL-8+
+    - ansible-core
+    - ansible
+    # needed for the ini_file ansible plugin, and more
+    - rhc-worker-playbook
+enabled: false
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro >= rhel-8
+        enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: CUI doesn't have a kickstart on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: doesn't exist on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: >
+            RHEL-7 kickstart has a non-standard name and we decided that
+            it is too close to EOL to introduce a hacky logic specifically
+            for this case
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    adjust:
+        enabled: false
+        because: not supported without GUI, use stig instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig_gui

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+
+from lib import util, results, oscap, versions
+from conf import remediation_excludes
+
+
+profile = os.environ['PROFILE']
+profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
+
+# the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks
+# on trying to accept its ssh key - tell it to ignore this
+os.environ['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
+
+# rhc-worker-playbook modules, exported per official instructions on
+# https://access.redhat.com/articles/remediation
+os.environ['ANSIBLE_COLLECTIONS_PATH'] = \
+    '/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/'
+
+# this is an alternate way to get modules provided by rhc-worker-playbook,
+# a RPM which is not available on CentOS / Fedora - uncomment and use this
+# if we ever run on non-RHEL
+# https://issues.redhat.com/browse/OPENSCAP-2296
+#for collection in ['community.general', 'ansible.posix']:
+#    util.subprocess_run(
+#        ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
+#        check=True)
+
+if util.get_reboot_count() == 0:
+
+    util.log("first boot, remediating using ansible-playbook")
+    playbook = util.get_playbook(profile)
+    skip_tags = ','.join(remediation_excludes.ansible_skip_tags)
+    skip_tags_arg = ['--skip-tags', skip_tags] if skip_tags else []
+    cmd = [
+        'ansible-playbook', '-v', '-c', 'local', '-i', 'localhost,',
+        *skip_tags_arg,
+        playbook,
+    ]
+    util.subprocess_run(cmd, check=True)
+
+    # restore basic login functionality
+    util.subprocess_run(['chage', '-d', '99999', 'root'], check=True)
+    with open('/etc/sysconfig/sshd', 'a') as f:
+        f.write('\nOPTIONS=-oPermitRootLogin=yes\n')
+
+    util.reboot()
+
+else:
+
+    util.log("second boot, scanning")
+
+    # old RHEL-7 oscap mixes errors into --progress rule names without a newline
+    verbose = ['--verbose', 'INFO'] if versions.oscap >= 1.3 else []
+    redir = {'stderr': subprocess.STDOUT} if versions.oscap >= 1.3 else {}
+
+    # scan the remediated system
+    cmd = [
+        'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
+        '--progress', '--report', 'report.html',
+        util.get_datastream(),
+    ]
+    proc, lines = util.subprocess_stream(cmd, **redir)
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0,2]:
+        raise RuntimeError("post-reboot oscap failed unexpectedly")
+
+    results.report_and_exit(logs=['report.html'])

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -29,8 +29,8 @@ os.environ['ANSIBLE_COLLECTIONS_PATH'] = \
 #        check=True)
 
 if util.get_reboot_count() == 0:
-
     util.log("first boot, remediating using ansible-playbook")
+
     playbook = util.get_playbook(profile)
     skip_tags = ','.join(remediation_excludes.ansible_skip_tags)
     skip_tags_arg = ['--skip-tags', skip_tags] if skip_tags else []
@@ -49,7 +49,6 @@ if util.get_reboot_count() == 0:
     util.reboot()
 
 else:
-
     util.log("second boot, scanning")
 
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -12,7 +12,7 @@ duration: 1h
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_high
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/anssi_bp28_high
 
 /anssi_nt28_high:
     environment+:
@@ -21,42 +21,42 @@ duration: 1h
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_high
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/anssi_nt28_high
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_server_l1
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l1
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l2
 
 /cui:
     environment+:
         PROFILE: cui
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cui
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cui
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/e8
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/hipaa
 
 /ism_o:
     environment+:
@@ -65,22 +65,22 @@ duration: 1h
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ism_o
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ism_o
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ospp
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/pci-dss
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/pci-dss
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig
 
 /stig_gui:
     environment+:
@@ -88,4 +88,4 @@ duration: 1h
     adjust:
         enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig_gui

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -1,0 +1,91 @@
+summary: Runs oscap remediation directly on the target system
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../../..
+duration: 1h
+
+/anssi_bp28_high:
+    environment+:
+        PROFILE: anssi_bp28_high
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: RHEL-7 has anssi_nt28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_high
+
+/anssi_nt28_high:
+    environment+:
+        PROFILE: anssi_nt28_high
+    adjust:
+        when: distro >= rhel-8
+        enabled: false
+        because: RHEL-8 and newer have anssi_bp28_high instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_high
+
+/cis:
+    environment+:
+        PROFILE: cis
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis
+
+/cis_server_l1:
+    environment+:
+        PROFILE: cis_server_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_server_l1
+
+/cis_workstation_l1:
+    environment+:
+        PROFILE: cis_workstation_l1
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l1
+
+/cis_workstation_l2:
+    environment+:
+        PROFILE: cis_workstation_l2
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l2
+
+/cui:
+    environment+:
+        PROFILE: cui
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cui
+
+/e8:
+    environment+:
+        PROFILE: e8
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/e8
+
+/hipaa:
+    environment+:
+        PROFILE: hipaa
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/hipaa
+
+/ism_o:
+    environment+:
+        PROFILE: ism_o
+    adjust:
+        when: distro == rhel-7
+        enabled: false
+        because: doesn't exist on RHEL-7
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ism_o
+
+/ospp:
+    environment+:
+        PROFILE: ospp
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ospp
+
+/pci-dss:
+    environment+:
+        PROFILE: pci-dss
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/pci-dss
+
+/stig:
+    environment+:
+        PROFILE: stig
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig
+
+/stig_gui:
+    environment+:
+        PROFILE: stig_gui
+    adjust:
+        enabled: false
+        because: not supported without GUI, use stig instead
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -21,9 +21,12 @@ if util.get_reboot_count() == 0:
 
     util.log("first boot, doing remediation")
     oscap.unselect_rules(ds, new_ds, remediation_excludes.host_os)
-    proc = util.subprocess_run(
-        ['oscap', 'xccdf', 'eval', '--profile', profile,
-         '--progress', '--remediate', new_ds])
+    cmd = [
+        'oscap', 'xccdf', 'eval', '--profile', profile,
+        '--progress', '--remediate',
+        new_ds,
+    ]
+    proc = util.subprocess_run(cmd)
     if proc.returncode not in [0,2]:
         raise RuntimeError("remediation oscap failed unexpectedly")
 
@@ -43,9 +46,12 @@ else:
     redir = {'stderr': subprocess.STDOUT} if versions.oscap >= 1.3 else {}
 
     # scan the remediated system
-    proc, lines = util.subprocess_stream(
-        ['oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
-         '--progress', '--report', 'report.html', new_ds], **redir)
+    cmd = [
+        'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
+        '--progress', '--report', 'report.html',
+        new_ds,
+    ]
+    proc, lines = util.subprocess_stream(cmd, **redir)
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+
+from pathlib import Path
+
+from lib import util, results, oscap, versions
+from conf import remediation_excludes
+
+
+profile = os.environ['PROFILE']
+profile = f'xccdf_org.ssgproject.content_profile_{profile}'
+
+ds = util.get_datastream()
+
+unique_name = util.get_test_name().lstrip('/').replace('/', '-')
+new_ds = Path(f'/var/tmp/contest-{unique_name}')
+
+if util.get_reboot_count() == 0:
+
+    util.log("first boot, doing remediation")
+    oscap.unselect_rules(ds, new_ds, remediation_excludes.host_os)
+    proc = util.subprocess_run(
+        ['oscap', 'xccdf', 'eval', '--profile', profile,
+         '--progress', '--remediate', new_ds])
+    if proc.returncode not in [0,2]:
+        raise RuntimeError("remediation oscap failed unexpectedly")
+
+    # restore basic login functionality
+    util.subprocess_run(['chage', '-d', '99999', 'root'], check=True)
+    with open('/etc/sysconfig/sshd', 'a') as f:
+        f.write('\nOPTIONS=-oPermitRootLogin=yes\n')
+
+    util.reboot()
+
+else:
+
+    util.log("second boot, scanning")
+
+    # old RHEL-7 oscap mixes errors into --progress rule names without a newline
+    verbose = ['--verbose', 'INFO'] if versions.oscap >= 1.3 else []
+    redir = {'stderr': subprocess.STDOUT} if versions.oscap >= 1.3 else {}
+
+    # scan the remediated system
+    proc, lines = util.subprocess_stream(
+        ['oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
+         '--progress', '--report', 'report.html', new_ds], **redir)
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0,2]:
+        raise RuntimeError("post-reboot oscap failed unexpectedly")
+
+    results.report_and_exit(logs=['report.html'])

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -18,8 +18,8 @@ unique_name = util.get_test_name().lstrip('/').replace('/', '-')
 new_ds = Path(f'/var/tmp/contest-{unique_name}')
 
 if util.get_reboot_count() == 0:
-
     util.log("first boot, doing remediation")
+
     oscap.unselect_rules(ds, new_ds, remediation_excludes.host_os)
     cmd = [
         'oscap', 'xccdf', 'eval', '--profile', profile,
@@ -38,7 +38,6 @@ if util.get_reboot_count() == 0:
     util.reboot()
 
 else:
-
     util.log("second boot, scanning")
 
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline

--- a/lib/util/environment.py
+++ b/lib/util/environment.py
@@ -1,16 +1,52 @@
 import os
+import time
+
+from .subprocess import subprocess_run
 
 
 def running_in_beaker():
-    """
-    Return True if running in Beaker under the FMF wrapper.
-    """
+    """Return True if running in Beaker under the FMF wrapper."""
     taskpath = os.environ.get('RSTRNT_TASKPATH')
     return bool(taskpath and taskpath.endswith('/distribution/wrapper/fmf'))
 
 
 def running_in_tmt():
-    """
-    Return True if running under TMT.
-    """
+    """Return True if running under TMT."""
     return bool(os.environ.get('TMT_TEST_DATA'))
+
+
+def reboot():
+    """Reboot the system using whatever means appropriate."""
+    # flush buffers to disk, just in case reboot doesn't do it
+    os.sync()
+    if running_in_tmt():
+        subprocess_run('tmt-reboot')
+    elif running_in_beaker():
+        subprocess_run('rstrnt-reboot')
+    else:
+        subprocess_run('reboot')
+    while True:
+        time.sleep(1000000)
+
+
+def get_reboot_count():
+    """Return the number of OS reboots the test underwent."""
+    if running_in_tmt():
+        return int(os.environ.get('TMT_REBOOT_COUNT'))
+    elif running_in_beaker():
+        return int(os.environ.get('RSTRNT_REBOOTCOUNT'))
+    else:
+        raise RuntimeError("not TMT/Beaker, could not determine reboot count")
+
+
+def get_test_name():
+    """
+    Return a full (absolute) test name of the currently running test.
+    Ie. '/hardening/oscap/stig'.
+    """
+    if running_in_tmt():
+        return os.environ.get('TMT_TEST_NAME')  # tmt natively
+    elif running_in_beaker():
+        return os.environ.get('TEST')
+    else:
+        raise RuntimeError("not TMT/Beaker, could not determine test name")


### PR DESCRIPTION
This test does remediation + scan on the "host OS", the operating system running the test itself. Basically equivalent to the old "machine-hardening" test.

Supporting code (reboot, etc.) is in separate commits.

I'm not super happy with the random failures, and there are probably more that will pop up, but until we have a better way to investigate them (switch to parsing results from results ARF XML, which should also contain remediation shell script output).