### PR TITLE
Update waives, prepare for real-world use

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ on Red Hat Enterprise Linux.
     This applies to sub-results (`/something` after a test name), results for
     tests themselves (as seen by TMT) are always reported.
 
+- `CONTEST_WAIVERS`
+  - Specify a `conf/waiver-` suffix for a waiver file name inside `conf` to be
+    used for waiving results. Ie. `CONTEST_WAIVERS=upstream` to use
+    `conf/waivers-upstream`. Defaults to `released`.
+
 ## Testing latest upstream content
 
 Note that as the

--- a/conf/waivers
+++ b/conf/waivers
@@ -74,10 +74,6 @@
 /hardening/oscap/[^/]+/package_rear_installed
     Match(rhel <= 8, sometimes=True)
 
-# https://github.com/ComplianceAsCode/content/issues/10592
-/hardening/anaconda/with-gui/cis_workstation_l[12]/file_groupownership_sshd_private_key
-    ssg >= '0.1.68'
-
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled

--- a/conf/waivers
+++ b/conf/waivers
@@ -58,7 +58,6 @@
 # happens on host-os hardening too, probably because Beaker doesn't have
 # firewall enabled or even installed
 /hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
-    ssg >= '0.1.68'
 /hardening/host-os/oscap/[^/]+/service_nftables_disabled
     Match(ssg >= '0.1.68', sometimes=True)
 
@@ -105,6 +104,11 @@
 /hardening/anaconda/with-gui/cis_workstation_l[12]
     Match(status == 'error', sometimes=True)
 
+# Beaker-specific, since all Beaker repositories have gpgcheck=0
+# and these get copied to nested VMs too
+/(hardening|scanning)/.+/ensure_gpgcheck_never_disabled
+    Match(True, sometimes=True)
+
 # probably because Beaker has crond enabled
 # - TODO: shouldn't oscap be able to disable a service via remediation?
 /hardening/host-os/oscap/[^/]+/service_crond_enabled
@@ -142,6 +146,9 @@
 /hardening/ansible/.+/configure_usbguard_auditbackend
 /hardening/ansible/.+/audit_rules_unsuccessful_file_modification
     rhel == 8 or rhel == 9
+# RHEL-8
+/hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding
+    rhel == 8
 # RHEL-7
 /hardening/ansible/.+/sshd_use_strong_ciphers
 /hardening/ansible/.+/sshd_use_strong_macs
@@ -150,18 +157,11 @@
 /hardening/ansible/.+/smartcard_auth
     rhel == 7
 
-# it's weird how specific home_nosuid is - seems to pass for many other
-# profiles, or even for the same profile on different RHELs
-/hardening/ansible(/with-gui)?/anssi_bp28_high/mount_option_home_nosuid
-/hardening/ansible/stig/mount_option_home_nosuid
-    rhel == 9 or rhel == 8
-/hardening/ansible/with-gui/stig_gui/mount_option_home_nosuid
-    rhel == 9
-/hardening/ansible/cui/mount_option_home_nosuid
-/hardening/ansible/ospp/mount_option_home_nosuid
-    rhel == 8
-/hardening/ansible/with-gui/anssi_nt28_high/mount_option_home_nosuid
-    rhel == 7
+# unknown as well, but happens only rarely
+/hardening/ansible/.+/configure_bashrc_exec_tmux
+# home_nosuid failures are just really random across RHEL versions and nightlies
+/hardening/ansible/.+/mount_option_home_nosuid
+    Match(True, sometimes=True)
 
 # only on ism_o, seems to pass everywhere else
 /hardening/ansible(/with-gui)?/ism_o/enable_fips_mode
@@ -182,6 +182,6 @@
 
 # TODO: is this a reported bug?
 /scanning/oscap-eval/ERROR
-    rhel == 7 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
+    rhel <= 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
 
 # vim: syntax=python

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -156,7 +156,7 @@
 /hardening/ansible/with-gui/stig_gui
     status == 'error' and rhel == 8
 
-# TODO: is this a reported bug?
+# https://bugzilla.redhat.com/show_bug.cgi?id=1797653 WONTFIX
 /scanning/oscap-eval/ERROR
     rhel <= 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
 

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -1,0 +1,163 @@
+# requires running firewalld (firewall-cmd) and NetworkManager,
+# which are not available in their final form in the Anaconda environment
+# - see https://github.com/ComplianceAsCode/content/issues/9746
+/hardening/anaconda(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
+    rhel >= 8
+
+# https://github.com/OpenSCAP/openscap/issues/1880
+# needs to be remediated more than once due to rule ordering issues
+/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_exec_tmux
+/hardening/oscap(/with-gui)?/[^/]+/no_tmux_in_shells
+/hardening/oscap(/with-gui)?/[^/]+/configure_usbguard_auditbackend
+/hardening/host-os/oscap/[^/]+/configure_bashrc_exec_tmux
+/hardening/host-os/oscap/[^/]+/no_tmux_in_shells
+/hardening/host-os/oscap/[^/]+/configure_usbguard_auditbackend
+    rhel >= 8
+/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
+/hardening/oscap(/with-gui)?/stig(_gui)?/postfix_prevent_unrestricted_relay
+/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
+/hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
+    rhel == 8
+
+# rule ordering issue - accounts_password_pam_retry is checked first and passes,
+# and a later enable_authselect remediation breaks it
+# - see https://github.com/OpenSCAP/openscap/issues/1880
+/hardening/(anaconda|oscap)/.+/accounts_password_pam_retry
+    rhel >= 8
+/hardening/host-os/oscap/[^/]+/accounts_password_pam_retry
+    Match(rhel >= 8, sometimes=True)
+
+# https://github.com/ComplianceAsCode/content/pull/10499
+# these are missing the required partitions, making the oscap Anaconda addon
+# error out during remediaton
+/hardening/anaconda/cis_(server|workstation)_l1
+    status == 'error' and note.startswith('RuntimeError: installation failed')
+
+# bz1828871, won't be fixed on rhel7
+# needs to be remediated more than once due to rule ordering issues
+/hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
+    rhel == 7
+
+# caused by one of:
+# - bz1778661 (abrt)
+# - bz2209266 (RHEL-9 gdm)
+# - bz2209294 (RHEL-7 gdm, different issue)
+/hardening/.+/rpm_verify_(ownership|permissions)
+    Match(True, sometimes=True)
+
+# bz1825810 or maybe bz1929805
+# can be reproduced mostly reliably (95%) both via anaconda and oscap CLI,
+# but apparently we don't really care about old releases
+/hardening/[^/]+/with-gui/stig_gui/sysctl_net_ipv4_ip_forward
+    Match(rhel == 7, sometimes=True)
+/hardening/[^/]+/with-gui/cis_workstation_[^/]+/sysctl_net_ipv4_ip_forward
+    rhel == 8
+
+# caused by us not caring whether the VM has it installed,
+# - remediation should fix it, but doesn't -- possibly caused by
+#   https://github.com/RHSecurityCompliance/contest/issues/15
+/hardening/oscap(/with-gui)?/[^/]+/package_scap-security-guide_installed
+    Match(True, sometimes=True)
+
+# TODO: something new? .. RHEL-8 on e8 and ism_o, RHEL-7 e8
+#  - seems to not happen on latest 8.9 nightlies ??
+#  - on latest 7.9, but upstream 2023/05 content
+/hardening/oscap/[^/]+/package_rear_installed
+    Match(rhel <= 8, sometimes=True)
+
+# RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
+# RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
+/hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
+    True
+
+# TODO: no clue, but not present in new upstream content
+/hardening/oscap/with-gui/pci-dss/smartcard_auth
+    rhel == 7
+
+# OAA just failed without an error, as usual
+# https://issues.redhat.com/browse/OPENSCAP-3321
+# seems to be happening much more reliably with GUI
+/hardening/anaconda/with-gui/cis_workstation_l[12]
+    Match(status == 'error', sometimes=True)
+
+# Beaker-specific, since all Beaker repositories have gpgcheck=0
+# and these get copied to nested VMs too
+/(hardening|scanning)/.+/ensure_gpgcheck_never_disabled
+    Match(True, sometimes=True)
+
+# probably because Beaker has crond enabled
+# - TODO: shouldn't oscap be able to disable a service via remediation?
+/hardening/host-os/oscap/[^/]+/service_crond_enabled
+    Match(True, sometimes=True)
+# same for dnf-automatic and rsyslog (??), is this fully random?
+/hardening/host-os/oscap/[^/]+/package_dnf-automatic_installed
+/hardening/host-os/oscap/[^/]+/timer_dnf-automatic_enabled
+/hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
+    Match(rhel >= 8, sometimes=True)
+
+# TODO: completely unknown, investigate and sort
+#
+# all RHELs
+/hardening/ansible/.+/aide_verify_acls
+/hardening/ansible/.+/aide_verify_ext_attributes
+/hardening/ansible/.+/mount_option_boot_noexec
+/hardening/ansible/.+/mount_option_boot_nosuid
+/hardening/ansible/.+/mount_option_home_noexec
+/hardening/ansible/.+/accounts_password_set_min_life_existing
+/hardening/ansible/.+/audit_rules_usergroup_modification
+    True
+# RHEL-9 only
+/hardening/ansible/.+/aide_scan_notification
+/hardening/ansible/.+/dnf-automatic_apply_updates
+/hardening/ansible/.+/dnf-automatic_security_updates_only
+/hardening/ansible/.+/accounts_polyinstantiated_tmp
+/hardening/ansible/.+/accounts_polyinstantiated_var_tmp
+/hardening/ansible/.+/disable_ctrlaltdel_(burstaction|reboot)
+/hardening/ansible/.+/configure_opensc_card_drivers
+/hardening/ansible/.+/force_opensc_card_drivers
+/hardening/ansible/with-gui/.+/network_nmcli_permissions
+    rhel == 9
+# RHEL-8 or 9
+/hardening/ansible/.+/no_tmux_in_shells
+/hardening/ansible/.+/configure_usbguard_auditbackend
+/hardening/ansible/.+/audit_rules_unsuccessful_file_modification
+    rhel == 8 or rhel == 9
+# RHEL-8
+/hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding
+    rhel == 8
+# RHEL-7
+/hardening/ansible/.+/sshd_use_strong_ciphers
+/hardening/ansible/.+/sshd_use_strong_macs
+/hardening/ansible/.+/audit_rules_for_ospp
+/hardening/ansible/.+/aide_use_fips_hashes
+/hardening/ansible/.+/smartcard_auth
+    rhel == 7
+
+# unknown as well, but happens only rarely
+/hardening/ansible/.+/configure_bashrc_exec_tmux
+# home_nosuid failures are just really random across RHEL versions and nightlies
+/hardening/ansible/.+/mount_option_home_nosuid
+    Match(True, sometimes=True)
+
+# only on ism_o, seems to pass everywhere else
+/hardening/ansible(/with-gui)?/ism_o/enable_fips_mode
+    rhel == 9
+
+# only pci-dss, passes everywhere else
+/hardening/ansible(/with-gui)?/pci-dss/audit_rules_login_events
+    rhel == 8 or rhel == 9
+
+# WARNING: UNPROTECTED PRIVATE KEY FILE!
+/hardening/ansible/with-gui/cis_workstation_l[12]
+    status == 'error'
+
+# ansible-playbook completed, but returned non-0, TODO: investigate
+/hardening/ansible/stig
+/hardening/ansible/with-gui/stig_gui
+    status == 'error' and rhel == 8
+
+# TODO: is this a reported bug?
+/scanning/oscap-eval/ERROR
+    rhel <= 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
+
+# vim: syntax=python

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -169,7 +169,7 @@
 /hardening/ansible/with-gui/stig_gui
     status == 'error' and rhel == 8
 
-# TODO: is this a reported bug?
+# https://bugzilla.redhat.com/show_bug.cgi?id=1797653 WONTFIX
 /scanning/oscap-eval/ERROR
     rhel <= 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
 

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -27,13 +27,6 @@
 /hardening/host-os/oscap/[^/]+/accounts_password_pam_retry
     Match(rhel >= 8, sometimes=True)
 
-# https://github.com/ComplianceAsCode/content/pull/10499
-# these are missing the required partitions, making the oscap Anaconda addon
-# error out during remediaton
-/hardening/anaconda/cis_(server|workstation)_l1
-    ssg < '0.1.68' and status == 'error' and \
-        note.startswith('RuntimeError: installation failed')
-
 # bz1828871, won't be fixed on rhel7
 # needs to be remediated more than once due to rule ordering issues
 /hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
@@ -59,7 +52,7 @@
 # firewall enabled or even installed
 /hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
 /hardening/host-os/oscap/[^/]+/service_nftables_disabled
-    Match(ssg >= '0.1.68', sometimes=True)
+    Match(True, sometimes=True)
 
 # caused by us not caring whether the VM has it installed,
 # - remediation should fix it, but doesn't -- possibly caused by
@@ -78,13 +71,9 @@
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
     True
 
-# TODO: no clue, but not present in new upstream content
-/hardening/oscap/with-gui/pci-dss/smartcard_auth
-    rhel == 7 and ssg < '0.1.68'
-
 # https://github.com/ComplianceAsCode/content/issues/10613
 /hardening/anaconda(/with-gui)?/cis[^/]*/firewalld_loopback_traffic_(restricted|trusted)
-    rhel == 9 and ssg >= '0.1.68'
+    rhel == 9
 
 # ssh either doesn't start up, or gets blocked, possibly related
 # to new firewalld rules being added?
@@ -96,7 +85,7 @@
 # https://github.com/ComplianceAsCode/content/issues/10593
 # https://github.com/ComplianceAsCode/content/issues/10594
 /hardening/oscap/with-gui/cis_workstation_l[12]
-    ssg >= '0.1.68' and status == 'error'
+    status == 'error'
 
 # OAA just failed without an error, as usual
 # https://issues.redhat.com/browse/OPENSCAP-3321

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -5,15 +5,15 @@ environment+:
     PYTHONPATH: ../..
 duration: 1h
 require+:
-    # virt library dependencies
-    - libvirt-daemon
-    - libvirt-daemon-driver-qemu
-    - libvirt-daemon-driver-storage-core
-    - libvirt-daemon-driver-network
-    - firewalld
-    - qemu-kvm
-    - libvirt-client
-    - virt-install
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
@@ -139,3 +139,5 @@ extra-hardware: |
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
+    extra-nitrate: TC#0615403
+    id: 9f841ee0-a08c-4b3b-b4bb-4676e41d7f19

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -4,6 +4,16 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
+require+:
+    # virt library dependencies
+    - libvirt-daemon
+    - libvirt-daemon-driver-qemu
+    - libvirt-daemon-driver-storage-core
+    - libvirt-daemon-driver-network
+    - firewalld
+    - qemu-kvm
+    - libvirt-client
+    - virt-install
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -2,6 +2,7 @@
 
 import os
 
+import httpsrv
 from lib import util, results, virt, oscap, versions
 
 
@@ -29,7 +30,7 @@ oscap_conf = {
 ks.add_oscap(oscap_conf)
 
 # host a HTTP server with a datastream and let the guest download it
-srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 8088)
+srv = httpsrv.BackgroundHTTPServer(virt.NETWORK_HOST, 8088)
 srv.add_file(util.get_datastream(), 'contest-ds.xml')
 with srv:
     g.install(kickstart=ks)

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -10,6 +10,8 @@ duration: 2h
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_bp28_high
+    extra-nitrate: TC#0615404
+    id: 2325cf2f-0fb8-4250-858a-03c62d495011
 
 /anssi_nt28_high:
     environment+:
@@ -19,6 +21,8 @@ duration: 2h
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_nt28_high
+    extra-nitrate: TC#0615405
+    id: 51648412-3473-4ff7-8851-1986d5baf166
 
 /cis:
     environment+:
@@ -29,6 +33,8 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis
+    extra-nitrate: TC#0615406
+    id: e5ecac50-c56a-420d-b815-e8a18a5d6414
 
 /cis_server_l1:
     environment+:
@@ -39,40 +45,52 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_server_l1
+    extra-nitrate: TC#0615407
+    id: 58631255-d82f-4475-856c-9cba991ee86e
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l1
+    extra-nitrate: TC#0615408
+    id: 15a29c70-4d83-49ae-8e1c-06201cb6498a
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l2
+    extra-nitrate: TC#0615409
+    id: 93c3eba2-b612-4c9f-a755-b440d66b1c90
 
 /cui:
     environment+:
         PROFILE: cui
     adjust:
-        - when: distro == rhel-7
-          enabled: false
-          because: CUI doesn't have a kickstart on RHEL-7
-        - when: distro <= rhel-8
-          enabled: false
-          because: >
-              not supported on RHEL-8 according to RHEL documentation,
-              the "Profiles not compatible with Server with GUI" table
+      - when: distro == rhel-7
+        enabled: false
+        because: CUI doesn't have a kickstart on RHEL-7
+      - when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cui
+    extra-nitrate: TC#0615410
+    id: 571513d7-7160-4b73-8eec-9f087a1ddddf
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/e8
+    extra-nitrate: TC#0615411
+    id: 96f2e4ce-92a2-4c41-8bc7-61b06be35d23
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/hipaa
+    extra-nitrate: TC#0615412
+    id: 3cd0f065-b874-4342-b0d7-7d1af70189da
 
 /ism_o:
     environment+:
@@ -82,6 +100,8 @@ duration: 2h
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ism_o
+    extra-nitrate: TC#0615413
+    id: 4577aecc-3186-47d7-9425-b894939ae034
 
 /ospp:
     environment+:
@@ -93,6 +113,8 @@ duration: 2h
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ospp
+    extra-nitrate: TC#0615414
+    id: 916f98e8-4c0d-45e7-85da-f5f6e5150c2c
 
 /pci-dss:
     environment+:
@@ -105,6 +127,8 @@ duration: 2h
             it is too close to EOL to introduce a hacky logic specifically
             for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/pci-dss
+    extra-nitrate: TC#0615415
+    id: ff3ae0c7-fb56-4272-b7c0-c24bb5b1eab2
 
 /stig:
     environment+:
@@ -116,8 +140,12 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig
+    extra-nitrate: TC#0615416
+    id: 87e79307-059d-4c20-a66e-b6ca83d4a1f1
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig_gui
+    extra-nitrate: TC#0615417
+    id: 3289b917-ca54-469c-8bce-f1db3c705239

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -5,22 +5,22 @@ environment+:
     PYTHONPATH: ../..
 duration: 1h
 require+:
-    # virt library dependencies
-    - libvirt-daemon
-    - libvirt-daemon-driver-qemu
-    - libvirt-daemon-driver-storage-core
-    - libvirt-daemon-driver-network
-    - firewalld
-    - qemu-kvm
-    - libvirt-client
-    - virt-install
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
 recommend+:
-    # ansible-core is not available on RHEL-7
-    # ansible is not on RHEL-8+
-    - ansible-core
-    - ansible
-    # needed for the ini_file ansible plugin, and more
-    - rhc-worker-playbook
+  # ansible-core is not available on RHEL-7
+  # ansible is not on RHEL-8+
+  - ansible-core
+  - ansible
+  # needed for the ini_file ansible plugin, and more
+  - rhc-worker-playbook
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
@@ -33,6 +33,8 @@ extra-hardware: |
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_bp28_high
+    extra-nitrate: TC#0615418
+    id: 7d851e6c-3e2f-45ba-8e6c-d65c026533e0
 
 /anssi_nt28_high:
     environment+:
@@ -42,26 +44,36 @@ extra-hardware: |
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_nt28_high
+    extra-nitrate: TC#0615419
+    id: 002df673-ebd6-4eea-8cf0-3a33d9dc3036
 
 /cis:
     environment+:
         PROFILE: cis
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis
+    extra-nitrate: TC#0615420
+    id: c450feb4-8a84-458b-8076-c4fc34c6d420
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_server_l1
+    extra-nitrate: TC#0615421
+    id: d8aac2ce-03f8-49cc-af32-7a762892b15b
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l1
+    extra-nitrate: TC#0615422
+    id: f66247b6-ad88-499f-999f-cee18b20736e
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l2
+    extra-nitrate: TC#0615423
+    id: 33ef4c07-f316-4fef-8319-bc92e674e9fc
 
 /cui:
     environment+:
@@ -71,16 +83,22 @@ extra-hardware: |
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cui
+    extra-nitrate: TC#0615424
+    id: ecd81d95-db3c-4ce0-8bc2-0634a6d10891
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/e8
+    extra-nitrate: TC#0615425
+    id: 57fa0d26-5c60-4f1d-abeb-1fb01c2eea2a
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/hipaa
+    extra-nitrate: TC#0615426
+    id: a630571c-06e9-4d9f-b241-fceac07db427
 
 /ism_o:
     environment+:
@@ -90,11 +108,15 @@ extra-hardware: |
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ism_o
+    extra-nitrate: TC#0615427
+    id: fdf874e0-b9c3-48aa-b72c-8744eb9e82c2
 
 /ospp:
     environment+:
         PROFILE: ospp
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ospp
+    extra-nitrate: TC#0615428
+    id: 67fa598d-8e48-429c-9462-42b1314bc208
 
 /pci-dss:
     environment+:
@@ -107,11 +129,15 @@ extra-hardware: |
             it is too close to EOL to introduce a hacky logic specifically
             for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/pci-dss
+    extra-nitrate: TC#0615429
+    id: b110b2ec-1155-4b9c-a72c-d2430c376544
 
 /stig:
     environment+:
         PROFILE: stig
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig
+    extra-nitrate: TC#0615430
+    id: 557bc116-2952-469f-87a6-a1515df8baa8
 
 /stig_gui:
     environment+:
@@ -120,3 +146,5 @@ extra-hardware: |
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui
+    extra-nitrate: TC#0615431
+    id: 9a90982b-ce7f-471e-8ff2-217e7ab5c658

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -4,6 +4,16 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
+require+:
+    # virt library dependencies
+    - libvirt-daemon
+    - libvirt-daemon-driver-qemu
+    - libvirt-daemon-driver-storage-core
+    - libvirt-daemon-driver-network
+    - firewalld
+    - qemu-kvm
+    - libvirt-client
+    - virt-install
 recommend+:
     # ansible-core is not available on RHEL-7
     # ansible is not on RHEL-8+

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -10,6 +10,8 @@ duration: 2h
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_bp28_high
+    extra-nitrate: TC#0615432
+    id: 70600369-4127-4489-bc67-bad0c41847b9
 
 /anssi_nt28_high:
     environment+:
@@ -19,6 +21,8 @@ duration: 2h
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_nt28_high
+    extra-nitrate: TC#0615433
+    id: 5d691786-4ed4-439c-b26b-fc60a91c00da
 
 /cis:
     environment+:
@@ -29,6 +33,8 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis
+    extra-nitrate: TC#0615434
+    id: 21ada412-9be2-4e32-8c45-1873c3ff5306
 
 /cis_server_l1:
     environment+:
@@ -39,40 +45,52 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_server_l1
+    extra-nitrate: TC#0615435
+    id: 78c09474-e64f-4174-b60b-cf6ea439b590
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l1
+    extra-nitrate: TC#0615436
+    id: 05fb0cea-604f-463c-a48e-2d6c774a0cc5
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l2
+    extra-nitrate: TC#0615437
+    id: e683e50e-8579-4323-99bb-9d14822e069a
 
 /cui:
     environment+:
         PROFILE: cui
     adjust:
-        - when: distro == rhel-7
-          enabled: false
-          because: CUI doesn't have a kickstart on RHEL-7
-        - when: distro <= rhel-8
-          enabled: false
-          because: >
-              not supported on RHEL-8 according to RHEL documentation,
-              the "Profiles not compatible with Server with GUI" table
+      - when: distro == rhel-7
+        enabled: false
+        because: CUI doesn't have a kickstart on RHEL-7
+      - when: distro <= rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cui
+    extra-nitrate: TC#0615438
+    id: c2089407-3b4d-46f7-8172-5e6d2d4c9919
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/e8
+    extra-nitrate: TC#0615439
+    id: 898c7b70-4711-420b-80c5-e79a7a3e8adc
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/hipaa
+    extra-nitrate: TC#0615440
+    id: b493b8b5-41b4-4b77-84b7-962001bf2970
 
 /ism_o:
     environment+:
@@ -82,6 +100,8 @@ duration: 2h
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ism_o
+    extra-nitrate: TC#0615441
+    id: 3cc4f0ee-6dfd-485d-9dd2-f0d841e2eb87
 
 /ospp:
     environment+:
@@ -93,6 +113,8 @@ duration: 2h
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ospp
+    extra-nitrate: TC#0615442
+    id: 28e32d25-2386-4fd7-bfb6-b889b5d5df90
 
 /pci-dss:
     environment+:
@@ -105,6 +127,8 @@ duration: 2h
             it is too close to EOL to introduce a hacky logic specifically
             for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/pci-dss
+    extra-nitrate: TC#0615443
+    id: c1ed3b2a-8ab8-4575-b3b0-19c3f7735ca5
 
 /stig:
     environment+:
@@ -116,8 +140,12 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig
+    extra-nitrate: TC#0615444
+    id: 97abbf39-45a8-45e4-bc03-3e3955d131d2
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig_gui
+    extra-nitrate: TC#0615445
+    id: 2e5aae97-9ded-4055-bef1-38e98cbf9dc8

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -5,12 +5,12 @@ environment+:
     PYTHONPATH: ../../..
 duration: 1h
 recommend+:
-    # ansible-core is not available on RHEL-7
-    # ansible is not on RHEL-8+
-    - ansible-core
-    - ansible
-    # needed for the ini_file ansible plugin, and more
-    - rhc-worker-playbook
+  # ansible-core is not available on RHEL-7
+  # ansible is not on RHEL-8+
+  - ansible-core
+  - ansible
+  # needed for the ini_file ansible plugin, and more
+  - rhc-worker-playbook
 enabled: false
 
 /anssi_bp28_high:
@@ -21,6 +21,8 @@ enabled: false
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/anssi_bp28_high
+    extra-nitrate: TC#0615446
+    id: 3bc79691-409a-47a2-ab09-552b66befd65
 
 /anssi_nt28_high:
     environment+:
@@ -30,26 +32,36 @@ enabled: false
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/anssi_nt28_high
+    extra-nitrate: TC#0615447
+    id: 4c559b2a-a979-4620-b01a-0bf08f4bda80
 
 /cis:
     environment+:
         PROFILE: cis
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis
+    extra-nitrate: TC#0615448
+    id: 91051ca5-3f8a-41a3-a6cf-7b03b561f3d3
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_server_l1
+    extra-nitrate: TC#0615449
+    id: d3e24927-f05d-41b7-a75d-cff02d060163
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l1
+    extra-nitrate: TC#0615450
+    id: b5dc6c8b-2d66-45c7-acfd-b13eb74b21f6
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l2
+    extra-nitrate: TC#0615451
+    id: da6f9fad-ecf6-4c9a-af42-d5d8e21f080b
 
 /cui:
     environment+:
@@ -59,16 +71,22 @@ enabled: false
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cui
+    extra-nitrate: TC#0615452
+    id: b5e079b6-91b0-4815-8f83-e0fc64e90f70
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/e8
+    extra-nitrate: TC#0615453
+    id: 30fbaaba-6989-4b15-b60c-d6523599049b
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/hipaa
+    extra-nitrate: TC#0615454
+    id: bafd98c6-473b-4279-873e-c11165c1cf4b
 
 /ism_o:
     environment+:
@@ -78,11 +96,15 @@ enabled: false
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ism_o
+    extra-nitrate: TC#0615455
+    id: 866ac5c0-8f56-464d-a995-36313c77347a
 
 /ospp:
     environment+:
         PROFILE: ospp
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ospp
+    extra-nitrate: TC#0615456
+    id: f735909d-920c-4e80-84c0-11e723e5f5ea
 
 /pci-dss:
     environment+:
@@ -95,11 +117,15 @@ enabled: false
             it is too close to EOL to introduce a hacky logic specifically
             for this case
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/pci-dss
+    extra-nitrate: TC#0615457
+    id: 5ffdce69-c34c-43ee-a6e5-ada888565f59
 
 /stig:
     environment+:
         PROFILE: stig
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig
+    extra-nitrate: TC#0615458
+    id: 72fd6d33-edf3-4b77-8bba-6f6a2882ea8d
 
 /stig_gui:
     environment+:
@@ -108,3 +134,5 @@ enabled: false
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig_gui
+    extra-nitrate: TC#0615459
+    id: cfb0fe65-acf3-4239-8ff6-a4f74aefb591

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -13,6 +13,8 @@ duration: 1h
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/anssi_bp28_high
+    extra-nitrate: TC#0615460
+    id: 6de66fee-9a46-4652-a421-771e61d3576d
 
 /anssi_nt28_high:
     environment+:
@@ -22,41 +24,57 @@ duration: 1h
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/anssi_nt28_high
+    extra-nitrate: TC#0615461
+    id: 4d397708-4c62-46c2-a8f0-09ddf398bfc5
 
 /cis:
     environment+:
         PROFILE: cis
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis
+    extra-nitrate: TC#0615462
+    id: 3a9226db-8c9d-4958-bea2-15bc836886be
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_server_l1
+    extra-nitrate: TC#0615463
+    id: 4fb3e747-63a8-43c0-9bad-ebd13190480b
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l1
+    extra-nitrate: TC#0615464
+    id: 1e05f676-a224-45de-87ac-9cfc3e19577f
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l2
+    extra-nitrate: TC#0615465
+    id: 86864467-a125-464a-bd30-638cfc535dc0
 
 /cui:
     environment+:
         PROFILE: cui
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cui
+    extra-nitrate: TC#0615466
+    id: bf0a09f8-0809-43e6-bb85-a46566ae99e7
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/e8
+    extra-nitrate: TC#0615467
+    id: 54df232a-ac9a-40d5-bc60-ccf056c53cf7
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/hipaa
+    extra-nitrate: TC#0615468
+    id: 28ce0a42-a450-47a6-b4e2-f88f5cb47c93
 
 /ism_o:
     environment+:
@@ -66,21 +84,29 @@ duration: 1h
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ism_o
+    extra-nitrate: TC#0615469
+    id: 128a3122-a0f8-45b8-8734-575ad25bf97a
 
 /ospp:
     environment+:
         PROFILE: ospp
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ospp
+    extra-nitrate: TC#0615470
+    id: f6f4b2b8-2965-41b6-b1f0-aec59ebc1140
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/pci-dss
+    extra-nitrate: TC#0615471
+    id: 6de810a8-a2fe-4e12-ac72-e19c5d307aac
 
 /stig:
     environment+:
         PROFILE: stig
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig
+    extra-nitrate: TC#0615472
+    id: 5720054d-bbc3-4fe6-b765-56277973f533
 
 /stig_gui:
     environment+:
@@ -89,3 +115,5 @@ duration: 1h
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig_gui
+    extra-nitrate: TC#0615473
+    id: af89d34d-5454-4313-a5b3-6ce0bdf09cfc

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -5,15 +5,15 @@ environment+:
     PYTHONPATH: ../..
 duration: 1h
 require+:
-    # virt library dependencies
-    - libvirt-daemon
-    - libvirt-daemon-driver-qemu
-    - libvirt-daemon-driver-storage-core
-    - libvirt-daemon-driver-network
-    - firewalld
-    - qemu-kvm
-    - libvirt-client
-    - virt-install
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
@@ -128,3 +128,5 @@ extra-hardware: |
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
+    extra-nitrate: TC#0615474
+    id: f65796bd-64eb-4c8a-b88b-3cf3b597d073

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -4,6 +4,16 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
+require+:
+    # virt library dependencies
+    - libvirt-daemon
+    - libvirt-daemon-driver-qemu
+    - libvirt-daemon-driver-storage-core
+    - libvirt-daemon-driver-network
+    - firewalld
+    - qemu-kvm
+    - libvirt-client
+    - virt-install
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -10,6 +10,8 @@ duration: 2h
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_bp28_high
+    extra-nitrate: TC#0615475
+    id: 5c1f431d-990f-4379-963e-924ef8bcf9b2
 
 /anssi_nt28_high:
     environment+:
@@ -19,6 +21,8 @@ duration: 2h
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_nt28_high
+    extra-nitrate: TC#0615476
+    id: 2590b9d4-12fa-4723-97d7-50da3d9e16be
 
 /cis:
     environment+:
@@ -29,6 +33,8 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis
+    extra-nitrate: TC#0615477
+    id: ca3b4846-1360-4c73-ad27-1a669bb2a46b
 
 /cis_server_l1:
     environment+:
@@ -39,16 +45,22 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_server_l1
+    extra-nitrate: TC#0615478
+    id: fb2a6fc0-fa80-468f-85ab-fce898e68af6
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l1
+    extra-nitrate: TC#0615479
+    id: a8bf4338-a3c0-430d-8aea-e494d20cb75a
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l2
+    extra-nitrate: TC#0615480
+    id: 087db3e2-3014-4f3a-8f36-7a2dc63af6a1
 
 /cui:
     environment+:
@@ -60,16 +72,22 @@ duration: 2h
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cui
+    extra-nitrate: TC#0615481
+    id: 79f376c2-e518-4d7d-b62b-44156da7dc79
 
 /e8:
     environment+:
         PROFILE: e8
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/e8
+    extra-nitrate: TC#0615482
+    id: ce009bae-f18d-45a2-ace0-7e9b80f93c42
 
 /hipaa:
     environment+:
         PROFILE: hipaa
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/hipaa
+    extra-nitrate: TC#0615483
+    id: f5c798e1-0c82-4886-a5d8-91f63929efae
 
 /ism_o:
     environment+:
@@ -79,6 +97,8 @@ duration: 2h
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ism_o
+    extra-nitrate: TC#0615484
+    id: 86e0eb89-aca8-4f3c-9dcd-274827153d02
 
 /ospp:
     environment+:
@@ -90,11 +110,15 @@ duration: 2h
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ospp
+    extra-nitrate: TC#0615485
+    id: bf8a040e-23c5-489e-8202-7a2d39828adc
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/pci-dss
+    extra-nitrate: TC#0615486
+    id: 358e4f83-4a83-442b-9f91-4480abe8b85e
 
 /stig:
     environment+:
@@ -106,8 +130,12 @@ duration: 2h
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig
+    extra-nitrate: TC#0615487
+    id: 97922f22-f3a7-4e2a-9dd2-71c34d0400d4
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig_gui
+    extra-nitrate: TC#0615488
+    id: 184a8acc-4759-480d-a0b6-948f6df720db

--- a/lib/util/__init__.py
+++ b/lib/util/__init__.py
@@ -10,7 +10,6 @@ libdir = Path(inspect.getfile(inspect.currentframe())).parent.parent
 
 from .content      import *  # noqa
 from .environment  import *  # noqa
-from .httpsrv      import *  # noqa
 from .log          import *  # noqa
 from .sanitization import *  # noqa
 from .subprocess   import *  # noqa

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -175,28 +175,6 @@ def setup_host():
     if not check_host_virt():
         raise RuntimeError("host has no HVM virtualization support")
 
-    dnf = 'dnf' if shutil.which('dnf') else 'yum'
-
-    host_pkgs = [
-        'libvirt-daemon',
-        'libvirt-daemon-driver-qemu',
-        'libvirt-daemon-driver-storage-core',
-        'libvirt-daemon-driver-network',
-        'firewalld',  # needed for virtual networks to work (?)
-        'qemu-kvm',
-        'libvirt-client',
-        'virt-install',
-    ]
-    # optimize for speed - avoid starting a dnf transaction if everything
-    # is already installed
-    ret = subprocess.run(['rpm', '--quiet', '-q'] + host_pkgs)
-    if ret.returncode != 0:
-        util.log("installing libvirt + qemu")
-        cmd = [dnf, '-y', '--nogpgcheck', '--setopt=install_weak_deps=False', 'install']
-        util.subprocess_run(cmd + host_pkgs, check=True)
-        # free up some disk space
-        util.subprocess_run([dnf, 'clean', 'packages'], check=True)
-
     ret = subprocess.run(['systemctl', 'is-active', '--quiet', 'libvirtd'])
     if ret.returncode != 0:
         util.subprocess_run(['systemctl', 'start', 'libvirtd'], check=True)

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -12,8 +12,6 @@ from . import util, versions
 
 _sections_cache = None
 
-WAIVE_FILE = Path(util.libdir).parent / 'conf' / 'waivers'
-
 
 class _PushbackIterator:
     """
@@ -128,6 +126,14 @@ def _parse_waive_file(stream):
     return sections
 
 
+def _open_waive_file():
+    preferred = os.environ.get('CONTEST_WAIVERS', 'released')
+    waive_file = Path(util.libdir).parent / 'conf' / f'waivers-{preferred}'
+    if not waive_file.exists():
+        raise FileNotFoundError(f"{waive_file.name} doesn't exist in 'conf'")
+    return open(waive_file)
+
+
 class Match:
     """
     A True/False result with additional metadata, returned from
@@ -144,7 +150,7 @@ class Match:
 def match_result(status, name, note):
     global _sections_cache
     if _sections_cache is None:
-        with open(WAIVE_FILE) as f:
+        with _open_waive_file() as f:
             _sections_cache = _parse_waive_file(f)
 
     # make sure "'someting' in name" always works

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -43,23 +43,23 @@ class _PushbackIterator:
 
 class WaiveParseError(SyntaxError):
     """
-    Easy waive file syntax error reporting, with line numbers derived
+    Easy waiver file syntax error reporting, with line numbers derived
     from _PushbackIterator style counter.
     """
     def __init__(self, meta, msg):
-        super().__init__(f"waive line {meta.counter}: {msg}")
+        super().__init__(f"waiver line {meta.counter}: {msg}")
 
 
 def _compile_eval(meta, code):
     if not code.strip():
         raise WaiveParseError(meta, "empty python block code ending here")
     try:
-        return compile(textwrap.dedent(code), 'waivecode', 'eval')
+        return compile(textwrap.dedent(code), 'waivercode', 'eval')
     except Exception:
-        raise WaiveParseError(meta, "compiling waive python code failed")
+        raise WaiveParseError(meta, "compiling waiver python code failed")
 
 
-def _parse_waive_file(stream):
+def _parse_waiver_file(stream):
     sections = []
     regexes = set()
     python_code = ''
@@ -126,12 +126,12 @@ def _parse_waive_file(stream):
     return sections
 
 
-def _open_waive_file():
+def _open_waiver_file():
     preferred = os.environ.get('CONTEST_WAIVERS', 'released')
-    waive_file = Path(util.libdir).parent / 'conf' / f'waivers-{preferred}'
-    if not waive_file.exists():
-        raise FileNotFoundError(f"{waive_file.name} doesn't exist in 'conf'")
-    return open(waive_file)
+    waiver_file = Path(util.libdir).parent / 'conf' / f'waivers-{preferred}'
+    if not waiver_file.exists():
+        raise FileNotFoundError(f"{waiver_file.name} doesn't exist in 'conf'")
+    return open(waiver_file)
 
 
 class Match:
@@ -150,8 +150,8 @@ class Match:
 def match_result(status, name, note):
     global _sections_cache
     if _sections_cache is None:
-        with _open_waive_file() as f:
-            _sections_cache = _parse_waive_file(f)
+        with _open_waiver_file() as f:
+            _sections_cache = _parse_waiver_file(f)
 
     # make sure "'someting' in name" always works
     if name is None:
@@ -186,7 +186,7 @@ def match_result(status, name, note):
 
             if not isinstance(ret, Match):
                 if not isinstance(ret, bool):
-                    raise RuntimeError(f"waive python code did not return bool or Match: {ret}")
+                    raise RuntimeError(f"waiver python code did not return bool or Match: {ret}")
                 ret = Match(ret)
 
             if ret:

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -131,6 +131,7 @@ def _open_waiver_file():
     waiver_file = Path(util.libdir).parent / 'conf' / f'waivers-{preferred}'
     if not waiver_file.exists():
         raise FileNotFoundError(f"{waiver_file.name} doesn't exist in 'conf'")
+    util.log(f"using {waiver_file} for waiving")
     return open(waiver_file)
 
 

--- a/plans/upstream-copr.fmf
+++ b/plans/upstream-copr.fmf
@@ -41,6 +41,10 @@ adjust+:
                     # yum upgrades on install by default
                     yum -y install scap-security-guide
                 fi
+
+    - environment+:
+          CONTEST_WAIVERS: upstream
+
     - finish+:
           - how: shell
             script: |

--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -4,3 +4,5 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 15m
+extra-nitrate: TC#0615489
+id: 12ccbda9-d7e4-4331-a74d-14f9abdd9374

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -5,8 +5,10 @@ environment+:
     PYTHONPATH: ../..
 duration: 30m
 require+:
-    - rpm-build
+  - rpm-build
 recommend+:
-    - dnf-utils
-    - yum-utils
-    - yum-builddep
+  - dnf-utils
+  - yum-utils
+  - yum-builddep
+extra-nitrate: TC#0615490
+id: 87442db1-5e7a-4c3f-93fa-1e37b233721e


### PR DESCRIPTION
This hopefully prepares contest for use, replacing Beakerlib-based tests.

The waivers were updated to match current upstream state (2 commits), and given enough re-runs to filter out random openscap crashes/freezes, they should return no failures. Due to hardware limitations, `/hardening/host-os` wasn't as rigorously tested.

Then there's the waiver file split - while we don't have a perfect process/idea defined for how/when to move `upstream` to `released`, we can likely deal with that while defining (updating?) a new downstreaming process. I feel the split makes the state more predictable, as changes to `waivers-upstream` have no chance to accidentally affect `waivers-released`, which is a risk when both stay in the same file. Amongst other things.

Finally, all the new tests have been exported to TCMS/Nitrate and the FMF files carefully hand-edited to keep comments, empty lines, and proper line breaks for `because:`.  
The indent change comes from TMT, so I left it in. No clue if that's a recent TMT change (shifting lists 2 spaces left, to keep the visual indent at 4 spaces), possibly so.