### PR TITLE
Add new CCN Advanced profile 

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -141,3 +141,12 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
     extra-nitrate: TC#0615403
     id: 9f841ee0-a08c-4b3b-b4bb-4676e41d7f19
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ccn_advanced

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -149,3 +149,12 @@ duration: 2h
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig_gui
     extra-nitrate: TC#0615417
     id: 3289b917-ca54-469c-8bce-f1db3c705239
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ccn_advanced

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -148,3 +148,12 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui
     extra-nitrate: TC#0615431
     id: 9a90982b-ce7f-471e-8ff2-217e7ab5c658
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ccn_advanced

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -149,3 +149,12 @@ duration: 2h
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig_gui
     extra-nitrate: TC#0615445
     id: 2e5aae97-9ded-4055-bef1-38e98cbf9dc8
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ccn_advanced

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -138,3 +138,12 @@ tag:
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig_gui
     extra-nitrate: TC#0615459
     id: cfb0fe65-acf3-4239-8ff6-a4f74aefb591
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ccn_advanced

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -119,3 +119,12 @@ tag:
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig_gui
     extra-nitrate: TC#0615473
     id: af89d34d-5454-4313-a5b3-6ce0bdf09cfc
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ccn_advanced

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -130,3 +130,12 @@ extra-hardware: |
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
     extra-nitrate: TC#0615474
     id: f65796bd-64eb-4c8a-b88b-3cf3b597d073
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ccn_advanced

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -139,3 +139,12 @@ duration: 2h
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig_gui
     extra-nitrate: TC#0615488
     id: 184a8acc-4759-480d-a0b6-948f6df720db
+
+/ccn_advanced:
+    environment+:
+        PROFILE: ccn_advanced
+    adjust:
+        when: distro <= rhel-8
+        enabled: false
+        because: CNN Advanced profile is specific to RHEL 9
+    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ccn_advanced


### PR DESCRIPTION
In this PR, test coverage has been extended in Contest in order to cover the new CCN Advanced profile.

It is important to note that the CNN profile is specific to RHEL9.

All Anaconda, Ansible and OSCAP test (with and without GUI) have been included for the profile testing.