### PR TITLE
Limit `/hardening/anaconda/with-gui` to GUI-relevant profiles in CI

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -153,3 +153,5 @@ tag:
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ccn_advanced
+    extra-nitrate: TC#0615550
+    id: de88ef36-6433-4e03-83c5-cb234683cc88

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -2,6 +2,10 @@ environment+:
     USE_SERVER_WITH_GUI: 1
 duration: 2h
 
+# do not run GUI tests in CI unless explicitly mentioned below
+tag-:
+  - Kickstarts
+
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
@@ -58,6 +62,8 @@ duration: 2h
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
+    tag+:
+      - Kickstarts
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l2
     extra-nitrate: TC#0615409
     id: 93c3eba2-b612-4c9f-a755-b440d66b1c90
@@ -146,6 +152,8 @@ duration: 2h
 /stig_gui:
     environment+:
         PROFILE: stig_gui
+    tag+:
+      - Kickstarts
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig_gui
     extra-nitrate: TC#0615417
     id: 3289b917-ca54-469c-8bce-f1db3c705239

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -166,3 +166,5 @@ tag-:
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ccn_advanced
+    extra-nitrate: TC#0615551
+    id: 15392a8c-5e38-4d48-8622-bca57c0056af

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -159,3 +159,5 @@ tag:
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ccn_advanced
+    extra-nitrate: TC#0615552
+    id: b9c5b67c-73a9-4aad-a4e1-aaadc0c6a18b

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -158,3 +158,5 @@ duration: 2h
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ccn_advanced
+    extra-nitrate: TC#0615553
+    id: 585d1dbd-63c8-4d53-a217-eaf935f4a7ce

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -153,3 +153,5 @@ enabled: false
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ccn_advanced
+    extra-nitrate: TC#0615554
+    id: 1b9e4188-f07f-4a57-a3df-471d1d05ca91

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -137,3 +137,5 @@ adjust:
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ccn_advanced
+    extra-nitrate: TC#0615555
+    id: d156c98b-30de-4af2-a4b7-5224079681da

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -141,3 +141,5 @@ tag:
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ccn_advanced
+    extra-nitrate: TC#0615556
+    id: 2aea8f2f-de4c-49c0-a012-86175698e18e

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -148,3 +148,5 @@ duration: 2h
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ccn_advanced
+    extra-nitrate: TC#0615557
+    id: f73289ae-643d-4cf0-bf01-e1b31cdefd40


### PR DESCRIPTION
The Anaconda GUI testing takes a long time, so it makes sense to limit it only to profiles which significantly benefit from it, in CI. We still want those other profiles to be eventually tested with GUI, just not in CI.

Since https://github.com/RHSecurityCompliance/contest/pull/34 was blocking early erratum runs, I've included a minimal version of it in this PR, without the newline/comment removal, and rebased on top of the recent `adjust+` changes, which caused conflicts with https://github.com/RHSecurityCompliance/contest/pull/34 .