### PR TITLE
Run `HVM=1` tests only on x86_64 systems

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -17,6 +17,10 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
+adjust:
+    when: arch != x86_64
+    enabled: false
+    because: HVM support is only on x86_64 systems
 tag:
   - Kickstarts
   - max1
@@ -24,7 +28,7 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -35,7 +39,7 @@ tag:
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -74,7 +78,7 @@ tag:
 /cui:
     environment+:
         PROFILE: cui
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
@@ -99,7 +103,7 @@ tag:
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -117,7 +121,7 @@ tag:
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: >
@@ -138,7 +142,7 @@ tag:
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    adjust:
+    adjust+:
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
@@ -148,7 +152,7 @@ tag:
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -18,9 +18,9 @@ extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
 adjust:
-    when: arch != x86_64
+  - when: arch != x86_64
     enabled: false
-    because: HVM support is only on x86_64 systems
+    because: we want to run virtualization on x86_64 only
 tag:
   - Kickstarts
   - max1
@@ -29,7 +29,7 @@ tag:
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_high
@@ -40,7 +40,7 @@ tag:
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_nt28_high
@@ -79,7 +79,7 @@ tag:
     environment+:
         PROFILE: cui
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cui
@@ -104,7 +104,7 @@ tag:
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ism_o
@@ -122,7 +122,7 @@ tag:
     environment+:
         PROFILE: pci-dss
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: >
             RHEL-7 kickstart has a non-standard name and we decided that
@@ -143,7 +143,7 @@ tag:
     environment+:
         PROFILE: stig_gui
     adjust+:
-        enabled: false
+      - enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
     extra-nitrate: TC#0615403
@@ -153,7 +153,7 @@ tag:
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ccn_advanced

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -10,7 +10,7 @@ tag-:
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_bp28_high
@@ -21,7 +21,7 @@ tag-:
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_nt28_high
@@ -32,7 +32,7 @@ tag-:
     environment+:
         PROFILE: cis
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -44,7 +44,7 @@ tag-:
     environment+:
         PROFILE: cis_server_l1
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -102,7 +102,7 @@ tag-:
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ism_o
@@ -113,7 +113,7 @@ tag-:
     environment+:
         PROFILE: ospp
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: >
             not supported on RHEL-8 according to RHEL documentation,
@@ -126,7 +126,7 @@ tag-:
     environment+:
         PROFILE: pci-dss
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: >
             RHEL-7 kickstart has a non-standard name and we decided that
@@ -140,7 +140,7 @@ tag-:
     environment+:
         PROFILE: stig
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -162,7 +162,7 @@ tag-:
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ccn_advanced

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -9,7 +9,7 @@ tag-:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -20,7 +20,7 @@ tag-:
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -31,7 +31,7 @@ tag-:
 /cis:
     environment+:
         PROFILE: cis
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -43,7 +43,7 @@ tag-:
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -71,7 +71,7 @@ tag-:
 /cui:
     environment+:
         PROFILE: cui
-    adjust:
+    adjust+:
       - when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
@@ -101,7 +101,7 @@ tag-:
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -112,7 +112,7 @@ tag-:
 /ospp:
     environment+:
         PROFILE: ospp
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: >
@@ -125,7 +125,7 @@ tag-:
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: >
@@ -139,7 +139,7 @@ tag-:
 /stig:
     environment+:
         PROFILE: stig
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
@@ -161,7 +161,7 @@ tag-:
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -25,9 +25,9 @@ extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
 adjust:
-    when: arch != x86_64
+  - when: arch != x86_64
     enabled: false
-    because: HVM support is only on x86_64 systems
+    because: we want to run virtualization on x86_64 only
 tag:
   - max1
 
@@ -35,7 +35,7 @@ tag:
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_bp28_high
@@ -46,7 +46,7 @@ tag:
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_nt28_high
@@ -85,7 +85,7 @@ tag:
     environment+:
         PROFILE: cui
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cui
@@ -110,7 +110,7 @@ tag:
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ism_o
@@ -128,7 +128,7 @@ tag:
     environment+:
         PROFILE: pci-dss
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: >
             RHEL-7 kickstart has a non-standard name and we decided that
@@ -149,7 +149,7 @@ tag:
     environment+:
         PROFILE: stig_gui
     adjust+:
-        enabled: false
+      - enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui
     extra-nitrate: TC#0615431
@@ -159,7 +159,7 @@ tag:
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ccn_advanced

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -24,13 +24,17 @@ recommend+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
+adjust:
+    when: arch != x86_64
+    enabled: false
+    because: HVM support is only on x86_64 systems
 tag:
   - max1
 
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -41,7 +45,7 @@ tag:
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -80,7 +84,7 @@ tag:
 /cui:
     environment+:
         PROFILE: cui
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
@@ -105,7 +109,7 @@ tag:
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -123,7 +127,7 @@ tag:
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: >
@@ -144,7 +148,7 @@ tag:
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    adjust:
+    adjust+:
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui
@@ -154,7 +158,7 @@ tag:
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -5,7 +5,7 @@ duration: 2h
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -16,7 +16,7 @@ duration: 2h
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -27,7 +27,7 @@ duration: 2h
 /cis:
     environment+:
         PROFILE: cis
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -39,7 +39,7 @@ duration: 2h
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -65,7 +65,7 @@ duration: 2h
 /cui:
     environment+:
         PROFILE: cui
-    adjust:
+    adjust+:
       - when: distro == rhel-7
         enabled: false
         because: CUI doesn't have a kickstart on RHEL-7
@@ -95,7 +95,7 @@ duration: 2h
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -106,7 +106,7 @@ duration: 2h
 /ospp:
     environment+:
         PROFILE: ospp
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: >
@@ -119,7 +119,7 @@ duration: 2h
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: >
@@ -133,7 +133,7 @@ duration: 2h
 /stig:
     environment+:
         PROFILE: stig
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
@@ -153,7 +153,7 @@ duration: 2h
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -6,7 +6,7 @@ duration: 2h
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_bp28_high
@@ -17,7 +17,7 @@ duration: 2h
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_nt28_high
@@ -28,7 +28,7 @@ duration: 2h
     environment+:
         PROFILE: cis
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -40,7 +40,7 @@ duration: 2h
     environment+:
         PROFILE: cis_server_l1
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -96,7 +96,7 @@ duration: 2h
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ism_o
@@ -107,7 +107,7 @@ duration: 2h
     environment+:
         PROFILE: ospp
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: >
             not supported on RHEL-8 according to RHEL documentation,
@@ -120,7 +120,7 @@ duration: 2h
     environment+:
         PROFILE: pci-dss
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: >
             RHEL-7 kickstart has a non-standard name and we decided that
@@ -134,7 +134,7 @@ duration: 2h
     environment+:
         PROFILE: stig
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -154,7 +154,7 @@ duration: 2h
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ccn_advanced

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -18,9 +18,9 @@ extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
 adjust:
-    when: arch != x86_64
+  - when: arch != x86_64
     enabled: false
-    because: HVM support is only on x86_64 systems
+    because: we want to run virtualization on x86_64 only
 tag:
   - max1
 
@@ -28,7 +28,7 @@ tag:
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_high
@@ -39,7 +39,7 @@ tag:
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_nt28_high
@@ -99,7 +99,7 @@ tag:
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ism_o
@@ -131,7 +131,7 @@ tag:
     environment+:
         PROFILE: stig_gui
     adjust+:
-        enabled: false
+      - enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
     extra-nitrate: TC#0615474
@@ -141,7 +141,7 @@ tag:
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ccn_advanced

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -17,13 +17,17 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
+adjust:
+    when: arch != x86_64
+    enabled: false
+    because: HVM support is only on x86_64 systems
 tag:
   - max1
 
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -34,7 +38,7 @@ tag:
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -94,7 +98,7 @@ tag:
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -126,7 +130,7 @@ tag:
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    adjust:
+    adjust+:
         enabled: false
         because: not supported without GUI, use stig instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
@@ -136,7 +140,7 @@ tag:
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -5,7 +5,7 @@ duration: 2h
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
@@ -16,7 +16,7 @@ duration: 2h
 /anssi_nt28_high:
     environment+:
         PROFILE: anssi_nt28_high
-    adjust:
+    adjust+:
         when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
@@ -27,7 +27,7 @@ duration: 2h
 /cis:
     environment+:
         PROFILE: cis
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -39,7 +39,7 @@ duration: 2h
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -65,7 +65,7 @@ duration: 2h
 /cui:
     environment+:
         PROFILE: cui
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: >
@@ -92,7 +92,7 @@ duration: 2h
 /ism_o:
     environment+:
         PROFILE: ism_o
-    adjust:
+    adjust+:
         when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
@@ -103,7 +103,7 @@ duration: 2h
 /ospp:
     environment+:
         PROFILE: ospp
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: >
@@ -123,7 +123,7 @@ duration: 2h
 /stig:
     environment+:
         PROFILE: stig
-    adjust:
+    adjust+:
         enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
@@ -143,7 +143,7 @@ duration: 2h
 /ccn_advanced:
     environment+:
         PROFILE: ccn_advanced
-    adjust:
+    adjust+:
         when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -6,7 +6,7 @@ duration: 2h
     environment+:
         PROFILE: anssi_bp28_high
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: RHEL-7 has anssi_nt28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_bp28_high
@@ -17,7 +17,7 @@ duration: 2h
     environment+:
         PROFILE: anssi_nt28_high
     adjust+:
-        when: distro >= rhel-8
+      - when: distro >= rhel-8
         enabled: false
         because: RHEL-8 and newer have anssi_bp28_high instead
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_nt28_high
@@ -28,7 +28,7 @@ duration: 2h
     environment+:
         PROFILE: cis
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -40,7 +40,7 @@ duration: 2h
     environment+:
         PROFILE: cis_server_l1
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
@@ -66,7 +66,7 @@ duration: 2h
     environment+:
         PROFILE: cui
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: >
             not supported on RHEL-8 according to RHEL documentation,
@@ -93,7 +93,7 @@ duration: 2h
     environment+:
         PROFILE: ism_o
     adjust+:
-        when: distro == rhel-7
+      - when: distro == rhel-7
         enabled: false
         because: doesn't exist on RHEL-7
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ism_o
@@ -104,7 +104,7 @@ duration: 2h
     environment+:
         PROFILE: ospp
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: >
             not supported on RHEL-8 according to RHEL documentation,
@@ -124,7 +124,7 @@ duration: 2h
     environment+:
         PROFILE: stig
     adjust+:
-        enabled: false
+      - enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
@@ -144,7 +144,7 @@ duration: 2h
     environment+:
         PROFILE: ccn_advanced
     adjust+:
-        when: distro <= rhel-8
+      - when: distro <= rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
     extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ccn_advanced


### PR DESCRIPTION
Disable tests with `HVM=1` hardware requirement on non-x86_64 architectures, because by default tests are scheduled on all architectures.