### PR TITLE
don't remediate ensure_gpgcheck_never_disabled on host-os

### DIFF
--- a/conf/remediation_excludes.py
+++ b/conf/remediation_excludes.py
@@ -31,4 +31,8 @@ ansible_skip_tags = [
 host_os = [
     # required by TMT
     'package_rsync_removed',
+    # needed by restraint to install a Beaker test RPM containing
+    # /distribution/errata/cleanup on the hardened system, because the test RPM
+    # doesn't have any signatures
+    'ensure_gpgcheck_never_disabled',
 ]


### PR DESCRIPTION
The waiver is already there, possibly due to Beaker-specific repositories having explicit `gpgcheck=0` in addition to the `dnf.conf` setting.