### PR TITLE
Add a test for `oscap --fetch-remote-resources`

### DIFF
--- a/static-checks/fetch-remote-resources/main.fmf
+++ b/static-checks/fetch-remote-resources/main.fmf
@@ -1,0 +1,11 @@
+summary: Try oscap --fetch-remote-resources, report errors
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 5m
+tag:
+  - CI-Tier-1
+extra-summary: /CoreOS/scap-security-guide/static-checks/fetch-remote-resources
+extra-nitrate: TC#0615612
+id: 84ee7121-2dd0-4e7d-8f64-bf74dff83f6f

--- a/static-checks/fetch-remote-resources/test.py
+++ b/static-checks/fetch-remote-resources/test.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+from lib import util, results
+
+
+res = util.subprocess_run(['oscap', 'info', '--fetch-remote-resources', util.get_datastream()])
+
+status = 'pass' if res.returncode == 0 else 'fail'
+
+results.report_and_exit(status)


### PR DESCRIPTION
This fails on the "old" version of https://github.com/ComplianceAsCode/content/pull/10842/files and passes on the "new" version of it.

Should be useful for keeping track of when things break again.