### PR TITLE
For RHEL7 generate also XCCDF results

### DIFF
--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -39,10 +39,13 @@ with g.booted():
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
     redir = '2>&1' if versions.oscap >= 1.3 else ''
+    # RHEL-7 HTML report doesn't contain OVAL findings by default
+    oval_results = '' if versions.oscap >= 1.3 else '--results results.xml --oval-results'
 
     # scan the remediated system
     proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile} --progress '
-                               f'--report report.html /root/openscap_data/contest-ds.xml {redir}')
+                               f'--report report.html {oval_results} '
+                               f'/root/openscap_data/contest-ds.xml {redir}')
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -61,11 +61,13 @@ with g.snapshotted():
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
     redir = '2>&1' if versions.oscap >= 1.3 else ''
+    # RHEL-7 HTML report doesn't contain OVAL findings by default
+    oval_results = '' if versions.oscap >= 1.3 else '--results results.xml --oval-results'
 
     # scan the remediated system
     g.copy_to(util.get_datastream(), 'contest-ds.xml')
     proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile_full} --progress '
-                               f'--report report.html contest-ds.xml {redir}')
+                               f'--report report.html {oval_results} contest-ds.xml {redir}')
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -54,11 +54,13 @@ else:
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = ['--verbose', 'INFO'] if versions.oscap >= 1.3 else []
     redir = {'stderr': subprocess.STDOUT} if versions.oscap >= 1.3 else {}
+    # RHEL-7 HTML report doesn't contain OVAL findings by default
+    oval_results = [] if versions.oscap >= 1.3 else ['--results', 'results.xml', '--oval-results']
 
     # scan the remediated system
     cmd = [
         'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
-        '--progress', '--report', 'report.html',
+        '--progress', '--report', 'report.html', *oval_results,
         util.get_datastream(),
     ]
     proc, lines = util.subprocess_stream(cmd, **redir)

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -51,11 +51,13 @@ else:
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = ['--verbose', 'INFO'] if versions.oscap >= 1.3 else []
     redir = {'stderr': subprocess.STDOUT} if versions.oscap >= 1.3 else {}
+    # RHEL-7 HTML report doesn't contain OVAL findings by default
+    oval_results = [] if versions.oscap >= 1.3 else ['--results', 'results.xml', '--oval-results']
 
     # scan the remediated system
     cmd = [
         'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
-        '--progress', '--report', 'report.html',
+        '--progress', '--report', 'report.html', *oval_results,
         new_ds,
     ]
     proc, lines = util.subprocess_stream(cmd, **redir)

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -36,10 +36,12 @@ with g.snapshotted():
     # old RHEL-7 oscap mixes errors into --progress rule names without a newline
     verbose = '--verbose INFO' if versions.oscap >= 1.3 else ''
     redir = '2>&1' if versions.oscap >= 1.3 else ''
+    # RHEL-7 HTML report doesn't contain OVAL findings by default
+    oval_results = '' if versions.oscap >= 1.3 else '--results results.xml --oval-results'
 
     # scan the remediated system
     proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile} --progress '
-                               f'--report report.html contest-ds.xml {redir}')
+                               f'--report report.html {oval_results} contest-ds.xml {redir}')
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")


### PR DESCRIPTION
Old openscap in RHEL7 doesn't put OVAL findings to HTML report. To make investigation easier there, include XCCDF results from `--results`.