### PR TITLE
use 'fail' instead of 'error' for unexpected pass

### DIFF
--- a/WAIVERS.md
+++ b/WAIVERS.md
@@ -83,7 +83,7 @@ The waiving file format above therefore serves as a generic "matching logic",
 and it's up to the library code to interpret what a match means.
 
 - no match = no change
-- match + pass = error (unexpected pass)
+- match + pass = fail (unexpected pass)
 - match + fail = warn (waived fail)
 - match + error = warn (waived error)
 
@@ -121,7 +121,7 @@ returning `False` if the RPM is not installed.
 ### Expecting both `pass` and `fail`/`error`
 
 Sometimes, failures or errors are not reliable and happen only occassionally.
-This means a waive section might be throwing a lot of "unexpected pass" errors
+This means a waive section might be throwing a lot of "unexpected pass" failures
 and be rendered useless.
 
 To fix this, pass `sometimes=True` to `Match()`, which tells the waiving code

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -214,7 +214,7 @@ def rewrite_result(status, name, note, new_status='warn'):
         if matched.sometimes:
             return (status, name, add_note(f"waived {status}"))
         else:
-            return ('error', name, add_note("waive: expected fail/error, got pass"))
+            return ('fail', name, add_note("waive: expected fail/error, got pass"))
 
     # fail or error
     return (new_status, name, add_note(f"waived {status}"))


### PR DESCRIPTION
This helps to indicate that the issue comes from testing/waiving logic, and not from a test bug / traceback / other setup problem.

Logically speaking, handling unexpected pass is handling a valid test result, so pass/fail (test logic related statuses) makes more sense from that PoV as well.