### PR TITLE
Revert "add /lib and /conf to test requires"

### DIFF
--- a/main.fmf
+++ b/main.fmf
@@ -1,10 +1,6 @@
 require:
   - openscap-scanner
   - scap-security-guide
-  - type: file
-    pattern: /lib
-  - type: file
-    pattern: /conf
 
 # shared by all tests
 recommend:


### PR DESCRIPTION
This reverts commit 7b30ece5aeb68502adc946b75b33ec05334b95bf.
OSCI has old `tmt-1.23` which doesn't support `type: file` yet. We need to revert it back for now.