### PR TITLE
RHEL7 waiving and test skipping

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -46,7 +46,7 @@
 /hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
 # https://github.com/ComplianceAsCode/content/issues/10938
 /hardening/host-os/oscap/[^/]+/postfix_network_listening_disabled
-    rhel == 7
+    Match(rhel == 7, sometimes=True)
 
 # caused by one of:
 # - bz1778661 (abrt)

--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -6,6 +6,10 @@ environment+:
 duration: 15m
 tag:
   - CI-Beaker
+adjust:
+  - when: distro == rhel-7 and arch == s390x or distro == rhel-7 and arch == ppc64
+    enabled: false
+    because: EPEL is not available for s390x/ppc64
 extra-summary: /CoreOS/scap-security-guide/scanning/oscap-eval
 extra-nitrate: TC#0615489
 id: 12ccbda9-d7e4-4331-a74d-14f9abdd9374

--- a/static-checks/ansible/allowed-modules/main.fmf
+++ b/static-checks/ansible/allowed-modules/main.fmf
@@ -23,6 +23,9 @@ adjust:
   - when: distro >= rhel-7 and arch == aarch64
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64
+  - when: distro == rhel-7 and arch == s390x or distro == rhel-7 and arch == ppc64
+    enabled: false
+    because: EPEL is not available for s390x/ppc64
 extra-summary: /CoreOS/scap-security-guide/static-checks/ansible/allowed-modules
 extra-nitrate: TC#0615492
 id: 2081f398-38e2-4404-94c4-b88f2e73ccb0

--- a/static-checks/fetch-remote-resources/main.fmf
+++ b/static-checks/fetch-remote-resources/main.fmf
@@ -6,6 +6,10 @@ environment+:
 duration: 5m
 tag:
   - CI-Tier-1
+adjust:
+  - when: distro == rhel-7 and arch == s390x or distro == rhel-7 and arch == ppc64
+    enabled: false
+    because: EPEL is not available for s390x/ppc64
 extra-summary: /CoreOS/scap-security-guide/static-checks/fetch-remote-resources
 extra-nitrate: TC#0615612
 id: 84ee7121-2dd0-4e7d-8f64-bf74dff83f6f

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -12,6 +12,10 @@ recommend+:
   - yum-builddep
 tag:
   - CI-Tier-1
+adjust:
+  - when: distro == rhel-7 and arch == s390x or distro == rhel-7 and arch == ppc64
+    enabled: false
+    because: EPEL is not available for s390x/ppc64
 extra-summary: /CoreOS/scap-security-guide/static-checks/rpmbuild-ctest
 extra-nitrate: TC#0615490
 id: 87442db1-5e7a-4c3f-93fa-1e37b233721e


### PR DESCRIPTION
During regression run review, I've noticed `postfix_network_listening_disabled` passes all the time and the rule isn't affected by any other rule.

Also couple of all arch tests are failing on s390x/ppc64 on `ModuleNotFoundError: No module named 'urllib3'`. It's caused by missing EPEL there, so skip them.