### PR TITLE
waive rule service_rpcbind_disabled in all anaconda tests with gui

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -209,7 +209,7 @@
 
 # https://github.com/ComplianceAsCode/content/issues/10901
 # not sure what enables the service, but second remediation fixes the problem
-/hardening/anaconda/with-gui/cis_workstation_l2/service_rpcbind_disabled
+/hardening/anaconda/with-gui/[^/]+/service_rpcbind_disabled
     Match(rhel == 8, sometimes=True)
 
 # vim: syntax=python


### PR DESCRIPTION
rule appeared failing also in cis_ws_l1, therefore we can expect it failing in other profiles if present