### PR TITLE
remove `enable_fips_mode waiver` as it passes on latest RHEL9 compose

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -197,10 +197,6 @@
 /hardening/ansible/.+/mount_option_home_nosuid
     Match(True, sometimes=True)
 
-# only on ism_o, seems to pass everywhere else
-/hardening/ansible(/with-gui)?/ism_o/enable_fips_mode
-    rhel == 9
-
 # only pci-dss, passes everywhere else
 /hardening/ansible(/with-gui)?/pci-dss/audit_rules_login_events
     rhel == 8 or rhel == 9


### PR DESCRIPTION
In last weekly productization, `enable_fips_mode` rule fails because of `pass` result
```
fail: enable_fips_mode (waive: expected fail/error, got pass) 
```
I did couple of re-runs on latest 9.3 composes and still got same result.

Only recent SSG `enable_fips_mode` rule update I found is https://github.com/ComplianceAsCode/content/pull/11026 but it shouldn't affect remediation. Thus, I guess the change comes from compose update.