### PR TITLE
Use `default` libvirt network, don't define `contest-net`

### DIFF
--- a/lib/util/environment.py
+++ b/lib/util/environment.py
@@ -46,7 +46,7 @@ def get_test_name():
     # under Restraint (Beaker, OSCI, etc.)
     name = os.environ.get('RSTRNT_TASKNAME', '')
     # - without leading '(gitrepo) '
-    match = re.fullmatch('\([^\)]*\) (/.+)', name)
+    match = re.fullmatch(r'\([^\)]*\) (/.+)', name)
     if match:
         return match.group(1)
     # unknown


### PR DESCRIPTION
The main reason is that libvirt can only have one NATed network, so the old code fails when run on a typical OS with the
```
libvirt-daemon-config-network
```
RPM package installed, which itself brings the `default` network.

Unfortunately, the packaged 'default' network is not good enough for us - we need

1. quick snapshot restores (stp disabled)
1. long lease expiry times (so a restored guest still has an IP addr)
1. ideally a greater IP addr range (so we can re-run many guest reinstallations, ie. Anaconda installs, without exhausting the pool)

But we don't want to render the host's libvirt networking useless for common tasks - ideally the user would not notice a difference to the RPM-packaged default network, ie. for manual virt-manager use.

So re-define the `default` network (if it exists) with the requirements above, while keeping it around for the user to manually use.