### PR TITLE
Add 'daily' tag to hardening/ansible and hardening/oscap tests.

### DIFF
--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -30,6 +30,7 @@ adjust:
     because: we want to run virtualization on x86_64 only
 tag:
   - max1
+  - daily
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -23,6 +23,7 @@ adjust:
     because: we want to run virtualization on x86_64 only
 tag:
   - max1
+  - daily
 
 /anssi_bp28_high:
     environment+:


### PR DESCRIPTION
Include both test cases to daily productization. They should be in good shape and for Ansible this is currently the only tests we have as hardening/host-os/ansible is [disabled](https://github.com/RHSecurityCompliance/contest/blob/main/hardening/host-os/ansible/main.fmf#L26).