### PR TITLE
Remove a waiver of audit_rules_privileged_commands

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -221,8 +221,4 @@
 /hardening/anaconda/with-gui/[^/]+/service_rpcbind_disabled
     Match(rhel == 8, sometimes=True)
 
-# https://github.com/ComplianceAsCode/content/issues/10938
-/hardening/host-os/oscap/anssi_nt28_high/audit_rules_privileged_commands
-    rhel == 7 and arch == 'ppc64le'
-
 # vim: syntax=python


### PR DESCRIPTION
This strange fail has been caused by Dracut temporary files but in https://github.com/ComplianceAsCode/content/pull/11246 we blocked these files in the OVAL, so now the rule won't fail randomly and therefore we don't need the waiver.

Related to: https://issues.redhat.com/browse/RHEL-11938