### PR TITLE
Add aide_use_fips_hashes waiver for RHEL9 STIG release.

### DIFF
--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -96,6 +96,10 @@
 /hardening/anaconda(/with-gui)?/cis[^/]*/firewalld_loopback_traffic_(restricted|trusted)
     rhel == 9
 
+# RHEL-9 is not FIPS certified yet
+/hardening/.+/aide_use_fips_hashes
+    rhel == 9
+
 # ssh either doesn't start up, or gets blocked, possibly related
 # to new firewalld rules being added?
 # https://github.com/ComplianceAsCode/content/pull/10573


### PR DESCRIPTION
RHEL9 is not FIPS certified, so it's expected the rule fails.