### PR TITLE
Support DNF variables/metalinks, use firstboot script instead of `%post`

### DIFF
--- a/lib/dnf.py
+++ b/lib/dnf.py
@@ -1,0 +1,117 @@
+import collections
+import configparser
+import requests
+from pathlib import Path
+
+from . import util, versions
+
+try:
+    import dnf
+except ModuleNotFoundError as e:
+    if versions.rhel != 7:
+        raise e from None
+
+_Repo = collections.namedtuple('Repo', ['name', 'baseurl', 'data'])
+
+
+# legacy manual parsing due to RHEL-7 having yum
+def _get_repos_yum():
+    for repofile in Path('/etc/yum.repos.d').iterdir():
+        c = configparser.ConfigParser()
+        c.read(repofile)
+        for section in c.sections():
+            # we need at least these to be defined
+            if not all(x in c[section] for x in ['name', 'baseurl', 'enabled']):
+                continue
+            # no disabled repos
+            if c[section]['enabled'] != '1':
+                continue
+            baseurl = c[section]['baseurl']
+            # no local-only repos that aren't portable to VM guests
+            if baseurl.startswith('file://'):
+                continue
+            # sanity check for (in)valid URLs as Anaconda fails on broken ones
+            elif baseurl.startswith(('http://', 'https://')):
+                reply = requests.head(baseurl, verify=False)
+                if not reply.ok:
+                    continue
+            yield _Repo(name=section, baseurl=baseurl, data=c[section])
+
+
+# dnf up to dnf4
+def _get_repos_dnf():
+    db = dnf.Base()
+    db.read_all_repos()
+    for name, repo in db.repos.items():
+        # no disabled repos
+        if not repo.enabled:
+            continue
+        repo.load()
+        baseurl = repo.remote_location('/')
+        # no local-only repos that aren't portable to VM guests
+        if baseurl.startswith('file://'):
+            continue
+        # sanity check for (in)valid URLs as Anaconda fails on broken ones
+        if baseurl.startswith(('http://', 'https://')):
+            reply = requests.head(baseurl, verify=False)
+            if not reply.ok:
+                continue
+        data = dict(repo.cfg.items(name))
+        yield _Repo(name=name, baseurl=baseurl, data=data)
+
+
+# TODO: the dnf4 API will change (confirmed by developers)
+def _get_repos_dnf5():
+    pass
+
+
+_repos_cache = None
+
+
+# cache dnf repository metadata to avoid long delays on repeated retrieval
+def _get_repos():
+    global _repos_cache
+    if _repos_cache is not None:
+        return _repos_cache
+
+    if versions.rhel == 7:
+        cache = _get_repos_yum()
+    else:
+        cache = _get_repos_dnf()
+
+    _repos_cache = list(cache)
+    return _repos_cache
+
+
+def repo_configs():
+    """
+    Yield tuples of (name,dict) of all enabled repositories on the host,
+    where 'dict' represents repository .conf contents.
+    """
+    for repo in _get_repos():
+        util.log(f"yielding: {repo.name} / {repo.data}")
+        yield (repo.name, repo.data)
+
+
+def repo_urls():
+    """
+    Yield tuples of (name,baseurl) of all enabled repositories on the host.
+    """
+    for repo in _get_repos():
+        yield (repo.name, repo.baseurl)
+
+
+def installable_url():
+    """
+    Return one baseurl usable for installing the currently-running system.
+    """
+    for _, url in repo_urls():
+        util.log(f"considering: {url}")
+        reply = requests.head(url + '/images/install.img', verify=False)
+        if reply.status_code == 200:
+            return url
+        if versions.rhel == 7:
+            reply = requests.head(url + '/LiveOS/squashfs.img', verify=False)
+            if reply.status_code == 200:
+                return url
+    raise RuntimeError("did not find any install-capable repo amongst host repos")

--- a/lib/util/__init__.py
+++ b/lib/util/__init__.py
@@ -12,4 +12,5 @@ from .content      import *  # noqa
 from .environment  import *  # noqa
 from .log          import *  # noqa
 from .sanitization import *  # noqa
+from .ssh          import *  # noqa
 from .subprocess   import *  # noqa

--- a/lib/util/log.py
+++ b/lib/util/log.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from datetime import datetime
 
 
-def log(msg, *, skip_caller=False):
+def log(msg, *, skip_frames=0):
     """
     An intelligent replacement for the basic functionality of the python
     'logging' module. Simply call this function from anywhere and it should
@@ -29,18 +29,17 @@ def log(msg, *, skip_caller=False):
     module.function instead of module.Class.function, due to Python stackframe
     limitations.
 
-    With 'skip_caller', report module or function that called the function
+    With 'skip_frames' > 0, report module or function that called the function
     which called log(), rather than the function which called log(). This is
     useful for lightweight wrappers, as the call of the wrapper gets logged,
     rather than log() inside the wrapper.
+    A value of 1 skips one stack frame, value of 2 skips 2 frames, etc.,
+    not counting the log() function itself.
     """
     stack = inspect.stack()
-    if skip_caller:
-        if stack[1].function == '<module>':
-            raise SyntaxError("can't use skip_caller when called directly from module code")
-        stack = stack[2:]
-    else:
-        stack = stack[1:]
+    if len(stack)-1 <= skip_frames:
+        raise SyntaxError("skip_frames exceeds call stack (frame count)")
+    stack = stack[skip_frames+1:]
 
     # bottom of the stack, or runpy executed module
     for frame_info in stack:

--- a/lib/util/ssh.py
+++ b/lib/util/ssh.py
@@ -1,0 +1,7 @@
+import subprocess
+
+from .subprocess import subprocess_run
+
+def ssh_keygen(path):
+    """Generate private/public keys prefixed by 'path'."""
+    subprocess_run(['ssh-keygen', '-N', '', '-f', path], stdout=subprocess.DEVNULL, check=True)

--- a/lib/util/subprocess.py
+++ b/lib/util/subprocess.py
@@ -19,7 +19,7 @@ def subprocess_run(cmd, **kwargs):
     """
     # when logging, skip current stack frame - report the place we were called
     # from, not util.subprocess_run itself
-    log(f'running: {_format_subprocess_cmd(cmd)}', skip_caller=True)
+    log(f'running: {_format_subprocess_cmd(cmd)}', skip_frames=1)
     return subprocess.run(cmd, **kwargs)
 
 
@@ -32,7 +32,7 @@ def subprocess_stream(cmd, check=False, **kwargs):
 
     To capture both stdout and stderr as yielded lines, use subprocess.STDOUT.
     """
-    log(f'running: {_format_subprocess_cmd(cmd)}', skip_caller=True)
+    log(f'running: {_format_subprocess_cmd(cmd)}', skip_frames=1)
     if versions.rhel == 7 and 'stderr' in kwargs and kwargs['stderr'] == subprocess.STDOUT:
         return _subprocess_stream_rhel7(cmd, check, **kwargs)
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -560,7 +560,7 @@ class Guest:
             To ssh into it, log in (ssh) into the VM host first, then do:
                 ssh -i {self.ssh_keyfile_path} root@{self.ipaddr}
             """)
-        util.log(textwrap.indent(out, '    '), skip_caller=True)
+        util.log(textwrap.indent(out, '    '), skip_frames=1)
 
     @contextlib.contextmanager
     def snapshotted(self):

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -378,7 +378,7 @@ class Guest:
             kickstart.allow_guest_agent()
             kickstart.cache_dnf()
 
-            ssh_keygen(self.ssh_keyfile_path)
+            util.ssh_keygen(self.ssh_keyfile_path)
             with open(f'{self.ssh_keyfile_path}.pub') as f:
                 pubkey = f.read().rstrip()
             kickstart.add_authorized_key(pubkey)
@@ -808,13 +808,6 @@ def virsh(*virsh_args, **run_args):
     # --quiet just skips the buggy trailing newline
     cmd = ['virsh', '--quiet', *virsh_args]
     return subprocess.run(cmd, **run_args)
-
-
-def ssh_keygen(path):
-    """
-    Generate private/public keys prefixed by 'path'.
-    """
-    util.subprocess_run(['ssh-keygen', '-N', '', '-f', path], stdout=DEVNULL, check=True)
 
 
 def translate_ssg_kickstart(profile):


### PR DESCRIPTION
This is mostly preparation for Image Builder, or rather for splitting `lib/virt.py` into sub-files and including virtualization code common to oscap/anaconda/ansible/imagebuilder.