### PR TITLE
Various changes to make Ansible host-os tests ready for Github CI (CentOS)

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -53,5 +53,10 @@ def excludes():
                 'configure_crypto_policy',
                 'enable_fips_mode',
             ]
+        if versions.rhel.major == 7:
+            rules += [
+                # On Testing Farm, login as 'root' doesn't work with fips enabled in grub2
+                'grub2_enable_fips_mode',
+            ]
 
     return rules

--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -47,5 +47,11 @@ def excludes():
             'ensure_gpgcheck_never_disabled',
             'ensure_gpgcheck_repo_metadata',
         ]
+        # Remove when CentOS repos use at least 3072b RSA key
+        if versions.rhel.major == 9 and re.fullmatch('/hardening/host-os/.*/ospp', test_name):
+            rules += [
+                'configure_crypto_policy',
+                'enable_fips_mode',
+            ]
 
     return rules

--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -36,4 +36,16 @@ def excludes():
             'package_rsync_removed',
         ]
 
+    # CentOS specific
+    if versions.rhel.is_centos():
+        rules += [
+            # https://github.com/ComplianceAsCode/content/issues/8480
+            'ensure_redhat_gpgkey_installed',
+            # Testing Farm repositories are without GPG signature
+            'ensure_gpgcheck_globally_activated',
+            'ensure_gpgcheck_local_packages',
+            'ensure_gpgcheck_never_disabled',
+            'ensure_gpgcheck_repo_metadata',
+        ]
+
     return rules

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -1,7 +1,7 @@
 # remediation for this is globally disabled in Contest,
 # see conf/remediation.py
 /hardening/.*/accounts_password_set_max_life_existing
-    True
+    Match(True, sometimes=True)
 
 # requires running firewalld (firewall-cmd) and NetworkManager,
 # which are not available in their final form in the Anaconda environment
@@ -110,7 +110,7 @@
 /hardening/host-os/oscap/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit)_(noexec|nosuid|nodev|usrquota|grpquota)
 /hardening/host-os/oscap/.+/mount_option_boot_efi_nosuid
 # likely something caused by restraint / Beaker test env 
-/hardening/host-os/oscap/.+/file_permissions_unauthorized_world_writable
+/hardening/host-os/.+/file_permissions_unauthorized_world_writable
 # Beaker and host-os seem to randomly fail any services enabled
 # or packages installed - TODO investigate remediation script outputs
 # to figure out why
@@ -154,27 +154,27 @@
 /hardening/ansible/.+/audit_rules_usergroup_modification
     True
 # RHEL-9 only
-/hardening/ansible/.+/dnf-automatic_apply_updates
-/hardening/ansible/.+/dnf-automatic_security_updates_only
-/hardening/ansible/.+/accounts_polyinstantiated_tmp
-/hardening/ansible/.+/accounts_polyinstantiated_var_tmp
-/hardening/ansible/.+/force_opensc_card_drivers
+/hardening(/host-os)?/ansible/.+/dnf-automatic_apply_updates
+/hardening(/host-os)?/ansible/.+/dnf-automatic_security_updates_only
+/hardening(/host-os)?/ansible/.+/accounts_polyinstantiated_tmp
+/hardening(/host-os)?/ansible/.+/accounts_polyinstantiated_var_tmp
+/hardening(/host-os)?/ansible/.+/force_opensc_card_drivers
 /hardening/ansible/with-gui/.+/network_nmcli_permissions
     rhel == 9
 # RHEL-8 or 9
-/hardening/ansible/.+/no_tmux_in_shells
-/hardening/ansible/.+/configure_usbguard_auditbackend
-/hardening/ansible/.+/audit_rules_unsuccessful_file_modification
+/hardening(/host-os)?/ansible/.+/no_tmux_in_shells
+/hardening(/host-os)?/ansible/.+/configure_usbguard_auditbackend
+/hardening(/host-os)?/ansible/.+/audit_rules_unsuccessful_file_modification
     rhel == 8 or rhel == 9
 # RHEL-8
 /hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding
     rhel == 8
 # RHEL-7
-/hardening/ansible/.+/sshd_use_strong_ciphers
-/hardening/ansible/.+/sshd_use_strong_macs
-/hardening/ansible/.+/audit_rules_for_ospp
-/hardening/ansible/.+/aide_use_fips_hashes
-/hardening/ansible/.+/smartcard_auth
+/hardening(/host-os)?/ansible/.+/sshd_use_strong_ciphers
+/hardening(/host-os)?/ansible/.+/sshd_use_strong_macs
+/hardening(/host-os)?/ansible/.+/audit_rules_for_ospp
+/hardening(/host-os)?/ansible/.+/aide_use_fips_hashes
+/hardening(/host-os)?/ansible/.+/smartcard_auth
     rhel == 7
 
 # unknown as well, but happens only rarely

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -1,11 +1,11 @@
 # remediation for this is globally disabled in Contest,
 # see conf/remediation.py
 /hardening/.*/accounts_password_set_max_life_(existing|root)
-    True
+    Match(True, sometimes=True)
 # RHEL-7 only, because RHEL-8+ check for rsync-daemon,
 # while TMT only needs the 'rsync' command executed via ssh,
 # so remove the remediation exception + waiver on RHEL-8+
-/hardening/host-os/oscap/[^/]+/package_rsync_removed
+/hardening/host-os/.+/[^/]+/package_rsync_removed
     rhel == 7
 
 # requires running firewalld (firewall-cmd) and NetworkManager,
@@ -121,7 +121,7 @@
 /hardening/host-os/oscap/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit)_(noexec|nosuid|nodev|usrquota|grpquota)
 /hardening/host-os/oscap/.+/mount_option_boot_efi_nosuid
 # likely something caused by restraint / Beaker test env 
-/hardening/host-os/oscap/.+/file_permissions_unauthorized_world_writable
+/hardening/host-os/.+/file_permissions_unauthorized_world_writable
 # Beaker and host-os seem to randomly fail any services enabled
 # or packages installed - TODO investigate remediation script outputs
 # to figure out why
@@ -165,26 +165,26 @@
 /hardening/ansible/.+/audit_rules_usergroup_modification
     True
 # RHEL-9 only
-/hardening/ansible/.+/dnf-automatic_apply_updates
-/hardening/ansible/.+/dnf-automatic_security_updates_only
-/hardening/ansible/.+/accounts_polyinstantiated_tmp
-/hardening/ansible/.+/accounts_polyinstantiated_var_tmp
-/hardening/ansible/.+/force_opensc_card_drivers
+/hardening(/host-os)?/ansible/.+/dnf-automatic_apply_updates
+/hardening(/host-os)?/ansible/.+/dnf-automatic_security_updates_only
+/hardening(/host-os)?/ansible/.+/accounts_polyinstantiated_tmp
+/hardening(/host-os)?/ansible/.+/accounts_polyinstantiated_var_tmp
+/hardening(/host-os)?/ansible/.+/force_opensc_card_drivers
 /hardening/ansible/with-gui/.+/network_nmcli_permissions
     rhel == 9
 # RHEL-8 or 9
-/hardening/ansible/.+/no_tmux_in_shells
-/hardening/ansible/.+/configure_usbguard_auditbackend
-/hardening/ansible/.+/audit_rules_unsuccessful_file_modification
+/hardening(/host-os)?/ansible/.+/no_tmux_in_shells
+/hardening(/host-os)?/ansible/.+/configure_usbguard_auditbackend
+/hardening(/host-os)?/ansible/.+/audit_rules_unsuccessful_file_modification
     rhel == 8 or rhel == 9
 # RHEL-8
 /hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding
     rhel == 8
 # RHEL-7
-/hardening/ansible/.+/sshd_use_strong_ciphers
-/hardening/ansible/.+/audit_rules_for_ospp
-/hardening/ansible/.+/aide_use_fips_hashes
-/hardening/ansible/.+/smartcard_auth
+/hardening(/host-os)?/ansible/.+/sshd_use_strong_ciphers
+/hardening(/host-os)?/ansible/.+/audit_rules_for_ospp
+/hardening(/host-os)?/ansible/.+/aide_use_fips_hashes
+/hardening(/host-os)?/ansible/.+/smartcard_auth
     rhel == 7
 
 # unknown as well, but happens only rarely
@@ -303,5 +303,24 @@
 /static-checks/html-links/http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
     True
 
+# CentOS-specific waivers
+#
+# Rules checking if OS is FIPS certified
+/hardening/host-os/.+/sshd_use_approved_.+
+/hardening/host-os/.+/package_dracut-fips_installed
+/hardening/host-os/.+/grub2_enable_fips_mode
+/hardening/host-os/.+/aide_use_fips_hashes
+    rhel.is_centos()
+
+# Remediations are unselected for CentOS, but they might pass outside Testing Farm
+/hardening/host-os/.+/ensure_gpgcheck_globally_activated
+/hardening/host-os/.+/ensure_gpgcheck_local_packages
+/hardening/host-os/.+/ensure_gpgcheck_never_disabled
+/hardening/host-os/.+/ensure_gpgcheck_repo_metadata
+    Match(rhel.is_centos(), sometimes=True)
+
+/hardening/host-os/.+/ospp/enable_fips_mode
+/hardening/host-os/.*/ospp/configure_crypto_policy
+    rhel.is_centos() and rhel == 9
 
 # vim: syntax=python

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -7,10 +7,6 @@ duration: 1h
 require+:
   - openscap-scanner
 recommend+:
-  # ansible-core is not available on RHEL-7
-  # ansible is not on RHEL-8+
-  - ansible-core
-  - ansible
   # needed for the ini_file ansible plugin, and more
   - rhc-worker-playbook
 tag:
@@ -20,6 +16,12 @@ adjust:
   - when: distro >= rhel-7 and arch == aarch64
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64
+  - when: distro == rhel-7 or distro == centos-7
+    require+:
+      - ansible
+  - when: distro >= rhel-8 or distro >= centos-8
+    require+:
+      - ansible-core
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -21,12 +21,6 @@ adjust:
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64
 
-# Disabled for now because most (all?) of the failures are identical with
-# VM-using tests, /hardening/ansible, and we would prefer the waivers for
-# those tests to be categorized or bugs fixed, before we extend the test
-# matrix with this host-os ansible test.
-enabled: false
-
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -11,7 +11,6 @@ recommend+:
   - rhc-worker-playbook
 tag:
   - destructive
-  - daily
 adjust:
   - when: distro >= rhel-7 and arch == aarch64
     enabled: false

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -46,7 +46,7 @@ else:
 
     # scan the remediated system
     cmd = [
-        'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
+        'oscap', 'xccdf', 'eval', *verbose, '--profile', profile_full,
         '--progress', '--report', 'report.html', *oval_results,
         util.get_datastream(),
     ]


### PR DESCRIPTION
Testing Farm repos are not gpg signed, thus unselect those rules from remediations and waive their results.

Enable `/host-os/ansible` as we want to run it in Github CI (that's the only option how to test Ansible remediations in upstream, VM-based tests are not allowed). For that, update also waivers to include `host-os/ansible`.


Bugfixes:
- final scan is performed with final datastream, not with custom datastream where rules might be unselected - to see those rules in final scan (waivers for such rules are expected)
- use full profile name in test to avoid multiple profile matches