### PR TITLE
Waive service_bluetooth_disabled for Anaconda test on GUI installations

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -96,6 +96,10 @@
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
     True
 
+# https://github.com/ComplianceAsCode/content/issues/11498
+/hardening/anaconda/with-gui/[^/]+/service_bluetooth_disabled
+    True
+
 # https://github.com/ComplianceAsCode/content/issues/10613
 /hardening/anaconda(/with-gui)?/cis[^/]*/firewalld_loopback_traffic_(restricted|trusted)
     rhel == 9


### PR DESCRIPTION
It's only option how to handle that systemd unit is not known by scanner during installation because it reads the status of the installing system, not the status of installed system.

It can't be workarounded by `bluez` package removal as it conflicts with Server with GUI package set.