### PR TITLE
Update waivers for configure_bashrc_tmux

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -10,6 +10,7 @@
 # https://github.com/OpenSCAP/openscap/issues/1880
 # needs to be remediated more than once due to rule ordering issues
 /hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_exec_tmux
+/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
 /hardening/oscap(/with-gui)?/[^/]+/no_tmux_in_shells
 /hardening/oscap(/with-gui)?/[^/]+/configure_usbguard_auditbackend
 /hardening/oscap(/with-gui)?/[^/]+/configure_tmux_lock_after_time
@@ -19,16 +20,15 @@
 /hardening/host-os/oscap/[^/]+/configure_tmux_lock_command
 /hardening/host-os/oscap/[^/]+/configure_tmux_lock_keybinding
     rhel >= 8
-/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
 /hardening/oscap(/with-gui)?/stig(_gui)?/postfix_prevent_unrestricted_relay
     rhel == 8
 
 # same issue, but host-os seems to be a lot more random in this
 /hardening/host-os/oscap/[^/]+/configure_bashrc_exec_tmux
+/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
 /hardening/host-os/oscap/[^/]+/no_tmux_in_shells
 /hardening/host-os/oscap/[^/]+/configure_usbguard_auditbackend
     Match(rhel >= 8, sometimes=True)
-/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
 /hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
     Match(rhel == 8, sometimes=True)
 


### PR DESCRIPTION
After merging https://github.com/ComplianceAsCode/content/pull/11561, the rule configure_bashrc_tmux is included in RHEL 9 STIG, therefore, the waiver applicability should be extended to RHEL 9. This problem has been reported by:
https://github.com/ComplianceAsCode/content/issues/11569