### PR TITLE
Add imagebuilder waivers

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -14,26 +14,6 @@ test_name = util.get_test_name()
 
 # Hardenings via Ansible
 if re.fullmatch('/hardening.*/ansible/.*', test_name):
-    excludes = [
-        # TODO:
-        #'ensure_gpgcheck_globally_activated',
-        #'ensure_gpgcheck_local_packages',
-        #'ensure_gpgcheck_never_disabled',
-        #'ensure_gpgcheck_repo_metadata',
-        #'ensure_redhat_gpgkey_installed',
-        #'no_direct_root_logins',
-        #'set_firewalld_default_zone',
-        #'firewalld_sshd_disabled',
-        #'service_sshd_disabled',
-        #'iptables_sshd_disabled',
-        #'sshd_disable_root_login',
-        #'sshd_disable_empty_passwords',
-        #'disable_host_auth',
-        #'harden_sshd_crypto_policy',
-        #'configure_etc_hosts_deny',
-        #'sudo_add_noexec',
-        #'accounts_password_set_max_life_existing',
-    ]
     if versions.rhel.is_centos():
         excludes += [
             # https://github.com/ComplianceAsCode/content/issues/8480

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -1,13 +1,15 @@
 # requires running firewalld (firewall-cmd) and NetworkManager,
 # which are not available in their final form in the Anaconda environment
 # - see https://github.com/ComplianceAsCode/content/issues/9746
+#       https://github.com/ComplianceAsCode/content/issues/11318
 /hardening/anaconda(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
-    rhel >= 8
-# similar case for RHEL 9
+/hardening/image-builder(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
 # https://github.com/ComplianceAsCode/content/issues/10939
-/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_restricted
-/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_trusted
-    rhel >= 9
+# https://github.com/ComplianceAsCode/content/issues/10613
+/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
+# https://github.com/ComplianceAsCode/content/issues/11564
+/hardening/image-builder(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
+    rhel >= 8
 
 # https://github.com/OpenSCAP/openscap/issues/1880
 # needs to be remediated more than once due to rule ordering issues
@@ -27,8 +29,6 @@
 /hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
 /hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
     Match(rhel == 8, sometimes=True)
-
-
 
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
 # and a later enable_authselect remediation breaks it
@@ -91,10 +91,6 @@
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
     True
-
-# https://github.com/ComplianceAsCode/content/issues/10613
-/hardening/anaconda(/with-gui)?/cis[^/]*/firewalld_loopback_traffic_(restricted|trusted)
-    rhel == 9
 
 # RHEL-9 is not FIPS certified yet
 /hardening/.+/aide_use_fips_hashes
@@ -219,5 +215,50 @@
 # https://github.com/ComplianceAsCode/content/issues/10938
 /hardening/host-os/oscap/anssi_nt28_high/audit_rules_privileged_commands
     rhel == 7 and arch == 'ppc64le'
+
+# Image Builder errors
+#
+# https://issues.redhat.com/browse/RHEL-24246
+/hardening/image-builder/anssi_bp28_high
+    status == 'error' and 'TimeoutError' in note
+# 'composer-cli compose start' fails with:
+# OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
+/hardening/image-builder/ccn_advanced
+    status == 'error'
+# https://github.com/ComplianceAsCode/content/issues/11344
+/hardening/image-builder/cis[^/]*
+    rhel == 9 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24246
+/hardening/image-builder/cui
+    rhel == 8 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24441 on 'squid'
+/hardening/image-builder/e8
+    rhel == 9 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24441 on 'telnet'
+/hardening/image-builder/hipaa
+    rhel == 9 and status == 'error'
+# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'snmpd'
+/hardening/image-builder/ism_o
+    rhel == 9 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24246
+/hardening/image-builder/ospp
+    rhel == 8 and status == 'error'
+# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'autofs'
+# RHEL-8: https://issues.redhat.com/browse/RHEL-24246
+/hardening/image-builder/stig
+    status == 'error'
+
+# Image Builder failures
+#
+# https://github.com/ComplianceAsCode/content/issues/11565
+/hardening/image-builder/.*/audit_rules_privileged_commands
+    True
+# https://github.com/ComplianceAsCode/content/issues/11566
+/hardening/image-builder/hipaa/sebool_selinuxuser_execstack
+    rhel == 8
+# https://github.com/ComplianceAsCode/content/issues/11567
+/hardening/image-builder/.*/enable_dracut_fips_module
+/hardening/image-builder/.*/enable_fips_mode
+    True
 
 # vim: syntax=python

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -3,8 +3,10 @@
 # - see https://github.com/ComplianceAsCode/content/issues/9746
 /hardening/anaconda(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
 # https://github.com/ComplianceAsCode/content/issues/10939
-/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_restricted
-/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_trusted
+# https://github.com/ComplianceAsCode/content/issues/10613
+/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
+# https://github.com/ComplianceAsCode/content/issues/11564
+/hardening/image-builder(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
     rhel >= 8
 
 # https://github.com/OpenSCAP/openscap/issues/1880
@@ -31,8 +33,6 @@
     Match(rhel >= 8, sometimes=True)
 /hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
     Match(rhel == 8, sometimes=True)
-
-
 
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
 # and a later enable_authselect remediation breaks it
@@ -101,10 +101,6 @@
 # https://issues.redhat.com/browse/RHEL-24335
 /hardening/anaconda/with-gui/[^/]+/service_bluetooth_disabled
     rhel >= 8
-
-# https://github.com/ComplianceAsCode/content/issues/10613
-/hardening/anaconda(/with-gui)?/cis[^/]*/firewalld_loopback_traffic_(restricted|trusted)
-    rhel == 9
 
 # RHEL-9 is not FIPS certified yet
 /hardening/.+/aide_use_fips_hashes
@@ -224,5 +220,54 @@
 # not sure what enables the service, but second remediation fixes the problem
 /hardening/anaconda/with-gui/[^/]+/service_rpcbind_disabled
     Match(rhel == 8, sometimes=True)
+
+# Image Builder errors
+#
+# https://issues.redhat.com/browse/RHEL-24246
+/hardening/image-builder/anssi_bp28_high
+    status == 'error' and 'TimeoutError' in note
+# 'composer-cli compose start' fails with:
+# OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
+# TODO: Evgeny will discuss this with Marek
+/hardening/image-builder/ccn_advanced
+    status == 'error'
+# compose building fails on oscap with:
+# Fatal: can't open /dev/urandom: No such file or directory
+# TODO: Evgeny will investigate
+/hardening/image-builder/cui
+    rhel == 8 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24441 on 'squid'
+/hardening/image-builder/e8
+    rhel == 9 and status == 'error'
+# https://issues.redhat.com/browse/RHEL-24441 on 'telnet'
+/hardening/image-builder/hipaa
+    rhel == 9 and status == 'error'
+# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'snmpd'
+# RHEL-8: Fatal: can't open /dev/urandom: No such file or directory
+/hardening/image-builder/ism_o
+    status == 'error'
+# Fatal: can't open /dev/urandom: No such file or directory
+/hardening/image-builder/ospp
+    rhel == 8 and status == 'error'
+# https://github.com/ComplianceAsCode/content/issues/11568
+/hardening/image-builder/pci-dss
+    status == 'error'
+# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'autofs'
+# RHEL-8: Fatal: can't open /dev/urandom: No such file or directory
+/hardening/image-builder/stig
+    status == 'error'
+
+# Image Builder failures
+#
+# https://github.com/ComplianceAsCode/content/issues/11565
+/hardening/image-builder/.*/audit_rules_privileged_commands
+    True
+# https://github.com/ComplianceAsCode/content/issues/11566
+/hardening/image-builder/hipaa/sebool_selinuxuser_execstack
+    rhel == 8
+# https://github.com/ComplianceAsCode/content/issues/11567
+/hardening/image-builder/.*/enable_dracut_fips_module
+/hardening/image-builder/.*/enable_fips_mode
+    True
 
 # vim: syntax=python

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -31,8 +31,8 @@ adjust:
     enabled: false
     because: there is no OSBuild or Image Builder on RHEL-7
 tag:
-  - NoProductization
-  - NoStabilization
+  - max1
+  - daily
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/image-builder/with-gui.fmf
+++ b/hardening/image-builder/with-gui.fmf
@@ -1,6 +1,10 @@
 environment+:
     USE_SERVER_WITH_GUI: 1
 duration: 2h
+# TODO: remove these https://issues.redhat.com/browse/RHEL-24246 is fixed
+tag:
+  - NoProductization
+  - NoStabilization
 
 /anssi_bp28_high:
     environment+:

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -115,17 +115,16 @@ class Compose:
         lines = iter(out.strip('\n').split('\n'))
         next(lines)  # skip header (first line)
         for line in lines:
-            #util.log(f'GOT LINE: {line}')
-            #util.log(fr'''GOT LINE SPLIT: {repr(re.split('[ ]+', line))}''')
             entry = self._Entry(*re.split(r'[ \t]+', line))
             if filter(entry):
                 return entry
         return None
-        #raise FileNotFoundError(f"no compose with blueprint {blueprint_name} found")
 
     @classmethod
     def _wait_for_finished(self, blueprint_name, timeout=600, sleep=1):
         entry = self._get_status(lambda x: x.blueprint == blueprint_name)
+        if not entry:
+            raise FileNotFoundError(f"compose for {blueprint_name} not found in list")
         util.log(f"waiting for compose {entry.id} to be built")
         end_time = datetime.now() + timedelta(seconds=timeout)
         while datetime.now() < end_time:

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -37,6 +37,7 @@ import time
 import collections
 from pathlib import Path
 
+from conf import remediation
 from . import util, dnf, virt
 
 
@@ -310,9 +311,7 @@ class Guest(virt.Guest):
             # add openscap hardening, honor global excludes
             if profile:
                 blueprint.add_openscap(self.DATASTREAM, profile)
-                #excludes = conf.remediation_excludes.host_os  # TEMP, TODO
-                excludes = []
-                blueprint.add_openscap_tailoring(unselected=excludes)
+                blueprint.add_openscap_tailoring(unselected=remediation.excludes)
 
         http_port = 8091
         disk_path = Path(f'{virt.GUEST_IMG_DIR}/{self.name}.img')

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -35,7 +35,6 @@ import platform
 import shutil
 import time
 import collections
-from datetime import datetime, timedelta
 from pathlib import Path
 
 from . import util, dnf, virt
@@ -121,20 +120,18 @@ class Compose:
         return None
 
     @classmethod
-    def _wait_for_finished(self, blueprint_name, timeout=600, sleep=1):
+    def _wait_for_finished(self, blueprint_name, sleep=1):
         entry = self._get_status(lambda x: x.blueprint == blueprint_name)
         if not entry:
             raise FileNotFoundError(f"compose for {blueprint_name} not found in list")
         util.log(f"waiting for compose {entry.id} to be built")
-        end_time = datetime.now() + timedelta(seconds=timeout)
-        while datetime.now() < end_time:
+        new = entry
+        while new.status not in self.FINISHED_STATUSES:
             new = self._get_status(lambda x: x.id == entry.id)
             if not new:
                 raise FileNotFoundError(f"compose {entry.id} disappeared")
-            if new.status in self.FINISHED_STATUSES:
-                return new
             time.sleep(sleep)
-        raise TimeoutError("wait for compose timed out")
+        return new
 
     @classmethod
     @contextlib.contextmanager

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -110,6 +110,7 @@ INSTALL_FAILURES = [
     br"There was an error running the kickstart script",
     br"Aborting the installation",
     br"Something went wrong during the final hardening",
+    br"Non interactive installation failed",
     # RHEL-7 ignores inst.noninteractive
     br"Please respond ",
 ]


### PR DESCRIPTION
(Probably go commit by commit.)

These waivers result in both RHEL-8 and RHEL-9, and both downstream (currently old `scap-security-guide` RPM) and upstream (latest CaC/content) somewhat working, in that there should be no `error` or `fail`.

I'd like to run these regularly (daily? weekly?) to catch improvements as they happen, both on the RHEL side with OSBuild, and on the content side as Github issues get fixed. As such, the tags were copied from `/hardening/anaconda`.