### PR TITLE
Add `/per-rule` test for running `automatus.py` in rule mode

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -270,4 +270,26 @@
 /hardening/image-builder/.*/enable_fips_mode
     True
 
+# /per-rule (Automatus rule mode) waivers
+# - these intentionally don't apply to /per-rule/from-env (ad-hoc RULE run)
+#
+# TODO: all of these are unknown and need investigation
+/per-rule/[^/]+/accounts_password_set_max_life_root/correct.pass
+/per-rule/[^/]+/accounts_password_set_max_life_root/wrong.fail
+/per-rule/[^/]+/postfix_client_configure_mail_alias/correct.pass
+    True
+/per-rule/[^/]+/grub2_audit_backlog_limit_argument/correct_grubenv.pass
+/per-rule/[^/]+/grub2_password/invalid_username.fail
+/per-rule/[^/]+/harden_sshd_ciphers_openssh_conf_crypto_policy/stig_correct.pass
+/per-rule/[^/]+/harden_sshd_ciphers_openssh_conf_crypto_policy/stig_correct_followed_by_incorrect_commented.pass
+/per-rule/[^/]+/sudo_add_umask/0027_var_multiple_values.pass
+    rhel == 8
+/per-rule/[^/]+/directory_permissions_var_log_audit/correct_value_0700.pass
+/per-rule/[^/]+/directory_permissions_var_log_audit/incorrect_value_0700.fail
+/per-rule/[^/]+/dconf_gnome_lock_screen_on_smartcard_removal/wrong_value.fail
+/per-rule/[^/]+/file_ownership_var_log_audit_stig/correct_value_default_file.pass
+/per-rule/[^/]+/tftpd_uses_secure_mode/correct.pass
+/per-rule/[^/]+/tftpd_uses_secure_mode/wrong.fail
+    rhel == 9
+
 # vim: syntax=python

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -228,12 +228,12 @@
     status == 'error' and 'TimeoutError' in note
 # 'composer-cli compose start' fails with:
 # OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
-# TODO: Evgeny will discuss this with Marek
+# https://issues.redhat.com/browse/RHEL-25574
 /hardening/image-builder/ccn_advanced
     status == 'error'
 # compose building fails on oscap with:
 # Fatal: can't open /dev/urandom: No such file or directory
-# TODO: Evgeny will investigate
+# https://github.com/osbuild/osbuild/pull/1590
 /hardening/image-builder/cui
     rhel == 8 and status == 'error'
 # https://issues.redhat.com/browse/RHEL-24441 on 'squid'

--- a/lib/results.py
+++ b/lib/results.py
@@ -13,7 +13,6 @@ Beaker uses the HTTP API, connecting to a local labcontroller.
 
 import os
 import sys
-import re
 import shutil
 import requests
 from pathlib import Path
@@ -43,18 +42,10 @@ def _compose_results_yaml(keyvals):
     it = iter(keyvals.items())
     # prefix first item with '-'
     key, value = next(it)
-    out = f'- {key}: {printval(value)}\n'
+    out = f'- "{key}": {printval(value)}\n'
     for key, value in it:
-        out += f'  {key}: {printval(value)}\n'
+        out += f'  "{key}": {printval(value)}\n'
     return out
-
-
-def _sanitize_yaml_id(string):
-    """
-    Remove anything that shouldn't appear in a YAML identifier (ie. key name),
-    whether the limitation comes from YAML itself, or its use by TMT.
-    """
-    return re.sub(r'[^\w/ _-]', '', string, flags=re.A).strip()
 
 
 def have_tmt_api():
@@ -206,7 +197,7 @@ def report(status, name=None, note=None, logs=None, *, add_output=True):
 
     # apply to all report variants
     if name:
-        name = _sanitize_yaml_id(name)
+        name = util.make_printable(name)
     if note:
         note = util.make_printable(note)
 

--- a/lib/util/subprocess.py
+++ b/lib/util/subprocess.py
@@ -22,6 +22,14 @@ def subprocess_run(cmd, **kwargs):
     return subprocess.run(cmd, **kwargs)
 
 
+def subprocess_Popen(cmd, **kwargs):
+    """
+    A simple wrapper for the real subprocess.Popen() that logs the command used.
+    """
+    util.log(f'running: {_format_subprocess_cmd(cmd)}', skip_frames=1)
+    return subprocess.Popen(cmd, **kwargs)
+
+
 def subprocess_stream(cmd, check=False, **kwargs):
     """
     Run 'cmd' via subprocess.Popen() and return an iterator over any lines

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -347,7 +347,7 @@ class Guest:
         # if exists, all snapshot preparation processes were successful
         self.snapshot_ready_path = f'{GUEST_IMG_DIR}/{name}.ready'
 
-    def install(self, location=None, kickstart=None, ks_verbatim=False):
+    def install(self, location=None, kickstart=None, ks_verbatim=False, disk_format='raw'):
         """
         Install a new guest, to a shut down state.
 
@@ -395,8 +395,8 @@ class Guest:
             else:
                 kickstart.add_packages([util.RpmPack.NAME])
 
-        disk_path = f'{GUEST_IMG_DIR}/{self.name}.img'
-        disk_format = 'raw'
+        disk_extension = 'qcow2' if disk_format == 'qcow2' else 'img'
+        disk_path = f'{GUEST_IMG_DIR}/{self.name}.{disk_extension}'
         cpus = os.cpu_count() or 1
 
         with contextlib.ExitStack() as stack:

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -1,0 +1,126 @@
+summary: Runs content unit tests for every rule in every supported RHEL profile
+description: |-
+    Downloads and builds a content source, unless provided via CONTENT_SOURCE
+    as a path to a directory. This can be either built (with 'build') or unbuilt
+    source code - the test will detect and build the content if necessary.
+    It then runs automatus.py in rule mode on every rule from every profile
+    built for the current platform.
+    The RULE variable (with space-separated one or more rule names) can be used
+    to override this and run tests for only specific rule(s).
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ..
+    TOTAL_SLICES: 15
+duration: 3h
+require+:
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
+  - rpm-build
+  - createrepo
+  # for builddep on scap-security-guide.spec
+  - python-srpm-macros
+  # automatus dependencies (oscap-ssh, etc.)
+  - openscap-utils
+extra-hardware: |
+    keyvalue = HVM=1
+    hostrequire = memory>=3720
+adjust:
+  - when: arch != x86_64
+    enabled: false
+    because: we want to run virtualization on x86_64 only
+  - when: distro == rhel-7
+    enabled: false
+    because: the code is not compatible with RHEL-7 yum/python
+tag:
+  - max1
+  - daily
+
+# for use with the RULE environment variable
+/from-env:
+    tag:
+      - NoProductization
+      - NoStabilization
+    extra-summary: /CoreOS/scap-security-guide/per-rule/from-env
+
+/1:
+    environment+:
+        SLICE: 1
+    extra-summary: /CoreOS/scap-security-guide/per-rule/1
+
+/2:
+    environment+:
+        SLICE: 2
+    extra-summary: /CoreOS/scap-security-guide/per-rule/2
+
+/3:
+    environment+:
+        SLICE: 3
+    extra-summary: /CoreOS/scap-security-guide/per-rule/3
+
+/4:
+    environment+:
+        SLICE: 4
+    extra-summary: /CoreOS/scap-security-guide/per-rule/4
+
+/5:
+    environment+:
+        SLICE: 5
+    extra-summary: /CoreOS/scap-security-guide/per-rule/5
+
+/6:
+    environment+:
+        SLICE: 6
+    extra-summary: /CoreOS/scap-security-guide/per-rule/6
+
+/7:
+    environment+:
+        SLICE: 7
+    extra-summary: /CoreOS/scap-security-guide/per-rule/7
+
+/8:
+    environment+:
+        SLICE: 8
+    extra-summary: /CoreOS/scap-security-guide/per-rule/8
+
+/9:
+    environment+:
+        SLICE: 9
+    extra-summary: /CoreOS/scap-security-guide/per-rule/9
+
+/10:
+    environment+:
+        SLICE: 10
+    extra-summary: /CoreOS/scap-security-guide/per-rule/10
+
+/11:
+    environment+:
+        SLICE: 11
+    extra-summary: /CoreOS/scap-security-guide/per-rule/11
+
+/12:
+    environment+:
+        SLICE: 12
+    extra-summary: /CoreOS/scap-security-guide/per-rule/12
+
+/13:
+    environment+:
+        SLICE: 13
+    extra-summary: /CoreOS/scap-security-guide/per-rule/13
+
+/14:
+    environment+:
+        SLICE: 14
+    extra-summary: /CoreOS/scap-security-guide/per-rule/14
+
+/15:
+    environment+:
+        SLICE: 15
+    extra-summary: /CoreOS/scap-security-guide/per-rule/15

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import re
+import subprocess
+import contextlib
+import tempfile
+import textwrap
+import distutils.dir_util
+from pathlib import Path
+
+from lib import util, results, oscap, virt, versions, dnf
+from conf import partitions
+
+
+@contextlib.contextmanager
+def get_content():
+    from_env = os.environ.get('CONTENT_SOURCE')
+    if from_env:
+        content = Path(from_env)
+        build_dir = content / 'build'
+
+        # if it has built content
+        if (build_dir / 'Makefile').exists():
+            util.log(f"using pre-built content: {build_dir}")
+            yield content
+
+        # manually build the source
+        else:
+            util.log(f"building content from source: {content}")
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # TODO: this should be shutil.copytree(.., dirs_exist_ok=True) on python 3.8+
+                distutils.dir_util.copy_tree(content, tmpdir)
+                util.log(f"using {tmpdir} as content source")
+                # install dependencies
+                cmd = ['dnf', '-y', 'builddep', '--spec', 'scap-security-guide.spec']
+                util.subprocess_run(cmd, check=True, cwd=tmpdir)
+                # build content
+                cmd = ['./build_product', f'rhel{versions.rhel.major}']
+                util.subprocess_run(cmd, check=True, cwd=tmpdir)
+                yield Path(tmpdir)
+
+    else:
+        # fall back to SRPM
+        with dnf.download_rpm('scap-security-guide', source=True) as src_rpm:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # install dependencies
+                cmd = ['dnf', '-y', 'builddep', '--srpm', src_rpm]
+                util.subprocess_run(cmd, check=True, cwd=tmpdir)
+                # extract + patch SRPM
+                cmd = ['rpmbuild', '-rp', '--define', f'_topdir {tmpdir}', src_rpm]
+                util.subprocess_run(cmd, check=True)
+                # get path to the extracted content
+                # - parse name+version from the SRPM instead of glob(BUILD/*)
+                #   because of '-rhel6' content on RHEL-8
+                ret = util.subprocess_run(
+                    ['rpm', '-q', '--qf', '%{NAME}-%{VERSION}', '-p', src_rpm],
+                    check=True, stdout=subprocess.PIPE, universal_newlines=True, cwd=tmpdir,
+                )
+                name_version = ret.stdout.strip()
+                extracted = Path(tmpdir) / 'BUILD' / name_version
+                util.log(f"using {extracted} as content source")
+                if not extracted.exists():
+                    raise FileNotFoundError(f"{extracted} not in extracted/patched SRPM")
+                # build content
+                # TODO: temporary, see https://github.com/ComplianceAsCode/content/pull/11606
+                (extracted / 'build').mkdir(exist_ok=True)
+                cmd = ['./build_product', f'rhel{versions.rhel.major}']
+                util.subprocess_run(cmd, check=True, cwd=extracted)
+                yield extracted
+
+
+def slice_list(full_list, divident, divisor):
+    """
+    Slice a 'full_list' into approx. equally-sized 'divisor' parts,
+    return the 'divident' slice.
+    """
+    total = len(full_list)
+    quotient = int(total / divisor)
+    remainder = total % divisor
+    # add 1 to the first dividents, up until all the added 1s
+    # are consumed (they add up to a value equal to remainder)
+    count = quotient + (1 if remainder >= divident else 0)
+    # starting index, from 0, with remainder gradually added,
+    # capped by max remainder value
+    start = (divident-1)*quotient + min(remainder, (divident-1))
+    # end = start of current slice + amount
+    # (as last valid index + 1, for python slice end)
+    end = start + count
+    # return a slice of the original list rather than copying it
+    return full_list[start:end]
+
+
+def between_strings(full_text, before, after):
+    """
+    Cut off a middle section of a 'full_text' string between the
+    'before' and 'after' substrings.
+    """
+    start = full_text.find(before)
+    if start == -1:
+        start = 0
+    end = full_text[start+len(before):].find(after)
+    if end == -1:
+        return full_text[start:]
+    else:
+        return full_text[start:start+len(before)+end]
+
+
+def report_test_with_log(status, note, log_dir, rule_name, test_name):
+    # Automatus groups test outputs by rule (one file per rule),
+    # and it uses ##### denoted sections for individual tests outputs
+    # within each file
+    log_file = log_dir / (rule_name + '.prescripts.log')
+    log = log_file.read_text()
+    log_part = between_strings(
+        log,
+        f'##### {rule_name} / {test_name}',
+        f'##### {rule_name} / '
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        log_part_file = Path(tmpdir) / 'out.txt'
+        log_part_file.write_text(log_part)
+        results.report(status, f'{rule_name}/{test_name}', note, logs=[log_part_file])
+
+
+virt.Host.setup()
+
+with get_content() as content_dir:
+    test_basename = util.get_test_name().rsplit('/', 1)[1]
+    if test_basename == 'from-env':
+        our_rules = os.environ.get('RULE')
+        if our_rules:
+            our_rules = our_rules.split()  # space-separated
+        else:
+            raise RuntimeError("RULE env variable not defined or empty")
+    else:
+        our_rules = slice_list(
+            oscap.get_all_profiles_rules(),
+            int(os.environ['SLICE']),
+            int(os.environ['TOTAL_SLICES'])
+        )
+
+    our_rules_textblock = textwrap.indent(('\n'.join(our_rules)), '    ')
+    util.log(f"testing rules:\n{our_rules_textblock}")
+
+    g = virt.Guest()
+
+    # install a qcow2-backed VM, so automatus.py can snapshot it
+    # - use hardening-style partitions, automatus tests need them
+    ks = virt.Kickstart(partitions=partitions.partitions)
+    g.install(kickstart=ks, disk_format='qcow2')
+
+    with g.booted():
+        env = os.environ.copy()
+        env['SSH_ADDITIONAL_OPTIONS'] = f'-o IdentityFile={g.ssh_keyfile_path}'
+        cmd = [
+            './automatus.py', 'rule',
+            '--libvirt', 'qemu:///system', virt.GUEST_NAME,
+            '--product', f'rhel{versions.rhel.major}',
+            *our_rules,
+        ]
+        _, lines = util.subprocess_stream(
+            cmd, check=True, stderr=subprocess.STDOUT,
+            env=env, cwd=(content_dir / 'tests'),
+        )
+
+        log_file = rule_name = None
+        for line in lines:
+            # copy the exact output to console
+            sys.stdout.write(f'{line}\n')
+            sys.stdout.flush()
+
+            # cut off log level
+            line = re.sub('^[A-Z]+ - ', '', line, count=1, flags=re.M)
+
+            # rule without remediation
+            match = re.fullmatch(r'''No remediation is available for rule 'xccdf_org\.ssgproject\.content_rule_(.+)'\.''', line)  # noqa
+            if match:
+                rule_name = match.group(1)
+                results.report('info', rule_name, 'no remediation')
+                continue
+
+            # remember the log file for log parsing/upload
+            #   INFO - Logging into /tmp/.../logs/rule-custom-2024-02-17-1859/test_suite.log
+            match = re.fullmatch('Logging into (.+)', line)
+            if match:
+                log_dir = Path(match.group(1)).parent
+                util.log(f"using automatus log dir: {log_dir}")
+                continue
+
+            # running tests for a new rule
+            #   INFO - xccdf_org.ssgproject.content_rule_timer_dnf-automatic_enabled
+            match = re.fullmatch(r'xccdf_org\.ssgproject\.content_rule_(.+)', line)
+            if match:
+                rule_name = match.group(1)
+                util.log(f"running for rule: {rule_name}")
+                continue
+
+            # result for one test - report it under the current rule:
+            #   INFO - Script line_missing.fail.sh using profile (all) OK
+            #   WARNING - Script correct_option.pass.sh using profile (all) notapplicable
+            #   ERROR - Script correct.pass.sh using profile (all) found issue:
+            match = re.fullmatch(r'Script (.+).sh using profile ([^ ]+) (.+)', line)
+            if match:
+                test_name, profile, status = match.groups()
+                # TODO: python 3.9+
+                #profile = profile.removeprefix('xccdf_org.ssgproject.content_profile_')
+                profile = re.sub('^xccdf_org.ssgproject.content_profile_', '', profile, count=1)
+
+                if status == 'OK':
+                    status = 'pass'
+                    note = f'profile:{profile}' if profile != '(all)' else None
+                elif status == 'notapplicable':
+                    status = 'info'
+                    note = 'not applicable'
+                elif status == 'found issue:':
+                    status = 'fail'
+                    note = f'profile:{profile}' if profile != '(all)' else None
+                else:
+                    status = 'error'
+                    note = "unknown Script status"
+
+                report_test_with_log(status, note, log_dir, rule_name, test_name)
+                continue
+
+            # this is separate, because Automatus prints 4 ERROR lines for this,
+            # using a non-standard format (unlike the above):
+            #   ERROR - Rule evaluation resulted in error, instead of expected fixed during remediation stage        # noqa
+            #   ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_tftpd_uses_secure_mode'.  # noqa
+            #   ERROR - Rule 'tftpd_uses_secure_mode' test setup script 'wrong.fail.sh' failed with exit code 1      # noqa
+            #   ERROR - Environment failed to prepare, skipping test
+            # so we parse just the one important line and ignore the rest
+            match = re.fullmatch(r'''Rule '[^']+' test setup script '(.+).sh' failed with exit code [0-9]+''', line)  # noqa
+            if match:
+                test_name = match.group(1)
+                report_test_with_log('fail', None, log_dir, rule_name, test_name)
+                continue
+
+results.report_and_exit()

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -3,24 +3,7 @@
 import re
 from pathlib import Path
 
-from lib import util, results, versions
-
-
-def download_source(package):
-    """
-    Download src rpm and return Path of the file.
-
-    'package' is name of package to download.
-    """
-    # TODO: drop yum-utils and dnf-utils deps after RHEL-7,
-    #       switch to 'dnf download --source'
-    util.subprocess_run(['yumdownloader', '--source', package], check=True)
-    package_glob = package + '*.src.rpm'
-    try:
-        src_path = next(Path.cwd().glob(package_glob))
-    except StopIteration:
-        raise FileNotFoundError(f".src.rpm not found for {package}")
-    return src_path
+from lib import util, results, versions, dnf
 
 
 def build_source(src_rpm, path=None):
@@ -45,8 +28,8 @@ def build_source(src_rpm, path=None):
 
 
 # Get src rpm and build from it
-src_rpm = download_source('scap-security-guide')
-rpm_build = build_source(src_rpm)
+with dnf.download_rpm('scap-security-guide', source=True) as src_rpm:
+    rpm_build = build_source(src_rpm)
 ssg_build = next((rpm_build / 'BUILD').glob('*/build'))
 
 # ctest


### PR DESCRIPTION
The rsync functionality was originally added for a custom Automatus runner implementation, and is currently unused, but I don't want to throw it away since it will be useful once CaC/content implements building templated/jinja2'd tests.