### PR TITLE
support `self` as a Class object in `util.log`

### DIFF
--- a/lib/util/log.py
+++ b/lib/util/log.py
@@ -54,13 +54,14 @@ def log(msg, *, skip_frames=0):
     parent = stack[0]
     function = parent.function
 
-    # if the function has 'self' and it looks like a class instance,
+    # if the function has 'self' and it looks like a class (instance),
     # prepend it to the function name
     p_locals = parent.frame.f_locals
     if 'self' in p_locals:
         self = p_locals['self']
         if hasattr(self, '__class__') and inspect.isclass(self.__class__):
-            function = f'{self.__class__.__name__}.{function}'
+            name = self.__name__ if isinstance(self, type) else self.__class__.__name__
+            function = f'{name}.{function}'
 
     # don't report module name of a function if it's the same as running module
     if parent.filename != module.filename:


### PR DESCRIPTION
This makes `util.log()` correctly display class name in `@classmethod` functions, instead of `type`:
```
  test.py:15: lib.osbuild.type._wait_for_finished:148: ...
```
```
  test.py:15: lib.osbuild.Compose._wait_for_finished:148: ...
```
Fixes #88 .