### PR TITLE
Perform double remediation for `oscap` hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See also TODOs in [STYLE.md](STYLE.md), this is a temporary limitation.
 
 ### Virtual machines and logging in
 
-The VM-using `/hardening` tests do two hacks to allow login after hardening:
+The tests perform some hacks to allow login after hardening:
 
 - `-oPermitRootLogin=yes` in `OPTIONS` of `/etc/sysconfig/sshd`
   - This is to bypass ssh-denied root login. Doing this seems easier than trying
@@ -94,28 +94,6 @@ The VM-using `/hardening` tests do two hacks to allow login after hardening:
     in `/etc/sudoers` and impose other limitations.
   - Fortunately, current content doesn't check `/etc/sysconfig/sshd`, so no
     rules are failing as a result of this. :)
-- `chage -d 99999 root`
-  - This resets the password-changed time for root, allowing us to log in again
-    without actually changing the password (and going through pwquality checks).
-
-The `chage` specifically needs a bit more context - the binary itself has some
-advanced SELinux checking for `/sys/fs/selinux/access` and throws
-`Permission denied` even when it actually could do the change. This is why we
-
-- set `virt_qemu_ga_t` as a permissive domain (during OS install), allowing
-  the qemu-guest-agent (ga) to run any commands without SELinux denials
-- execute `setenforce 0` prior to `chage` via the guest agent, fooling `chage`
-  into thinking SELinux is disabled
-
-As a TODO, consider using `sed` to edit `/etc/shadow`, instead of `chage`,
-to avoid this complex situation.
-
-Note that we need qemu-guest-agent to execute the `chage` for us - we cannot do
-it via SSH, as we get locked out the second a remediation finishes. This is fine
-for `oscap`, as we can simply do `oscap xccdf eval ... ; chage ...` in the same
-shell, but Ansible remediation cannot do this.  
-So we need a simple side-channel that can run `chage` **after** ansible-playbook
-finishes.
 
 ### Using upstream/shipped content kickstarts
 

--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -30,9 +30,9 @@ def excludes():
             ]
 
     # Host hardenings
-    if re.fullmatch('/hardening/host-os/.*', test_name):
+    if versions.rhel == 7 and re.fullmatch('/hardening/host-os/.*', test_name):
         rules += [
-            # required by TMT
+            # required by TMT, see waivers
             'package_rsync_removed',
         ]
 

--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -12,8 +12,14 @@ from lib import versions, util
 
 
 def excludes():
-    rules = []
     test_name = util.get_test_name()
+
+    rules = [
+        # avoid this globally, so we don't have to change passwords
+        # or call 'chage' in every type of remediation
+        'accounts_password_set_max_life_existing',
+        'accounts_password_set_max_life_root',
+    ]
 
     # Hardenings via Ansible
     if re.fullmatch('/hardening.*/ansible/.*', test_name):

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -1,3 +1,8 @@
+# remediation for this is globally disabled in Contest,
+# see conf/remediation.py
+/hardening/.*/accounts_password_set_max_life_existing
+    True
+
 # requires running firewalld (firewall-cmd) and NetworkManager,
 # which are not available in their final form in the Anaconda environment
 # - see https://github.com/ComplianceAsCode/content/issues/9746

--- a/conf/waivers-released
+++ b/conf/waivers-released
@@ -16,40 +16,14 @@
 /hardening/image-builder(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
     rhel >= 8
 
-# https://github.com/OpenSCAP/openscap/issues/1880
-# needs to be remediated more than once due to rule ordering issues
-/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_exec_tmux
-/hardening/oscap(/with-gui)?/[^/]+/no_tmux_in_shells
-/hardening/oscap(/with-gui)?/[^/]+/configure_usbguard_auditbackend
-    rhel >= 8
-/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
-/hardening/oscap(/with-gui)?/stig(_gui)?/postfix_prevent_unrestricted_relay
-    rhel == 8
-
-# same issue, but host-os seems to be a lot more random in this
-/hardening/host-os/oscap/[^/]+/configure_bashrc_exec_tmux
-/hardening/host-os/oscap/[^/]+/no_tmux_in_shells
-/hardening/host-os/oscap/[^/]+/configure_usbguard_auditbackend
-    Match(rhel >= 8, sometimes=True)
-/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
-/hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
-    Match(rhel == 8, sometimes=True)
-
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
 # and a later enable_authselect remediation breaks it
 # - see https://github.com/OpenSCAP/openscap/issues/1880
-/hardening/(anaconda|oscap)/.+/accounts_password_pam_retry
+/hardening/anaconda/.+/accounts_password_pam_retry
     rhel >= 8
-/hardening/host-os/oscap/[^/]+/accounts_password_pam_retry
-    Match(rhel >= 8, sometimes=True)
-
-# another rule ordering issue - on s390x,
-# https://github.com/ComplianceAsCode/content/issues/10654
-/hardening/host-os/oscap/[^/]+/zipl_bootmap_is_up_to_date
-    Match(True, sometimes=True)
 
 # bz1828871, won't be fixed on rhel7
-# needs to be remediated more than once due to rule ordering issues
+# - likely NOT related to rule ordering, double remediation doesn't help
 /hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
 # https://github.com/ComplianceAsCode/content/issues/10938
 /hardening/host-os/oscap/[^/]+/postfix_network_listening_disabled
@@ -165,6 +139,11 @@
 # maybe hardware-specific and our Beaker systems don't have the hardware?
 /hardening/host-os/oscap/.+/sssd_enable_smartcards
     Match(rhel == 8, sometimes=True)
+
+# visible on double reboot (double remediation)
+# /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
+/hardening/oscap/with-gui/e8/file_ownership_binary_dirs
+    rhel == 7
 
 # TODO: completely unknown, investigate and sort
 #

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -2,6 +2,11 @@
 # see conf/remediation.py
 /hardening/.*/accounts_password_set_max_life_(existing|root)
     True
+# RHEL-7 only, because RHEL-8+ check for rsync-daemon,
+# while TMT only needs the 'rsync' command executed via ssh,
+# so remove the remediation exception + waiver on RHEL-8+
+/hardening/host-os/oscap/[^/]+/package_rsync_removed
+    rhel == 7
 
 # requires running firewalld (firewall-cmd) and NetworkManager,
 # which are not available in their final form in the Anaconda environment

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -1,3 +1,8 @@
+# remediation for this is globally disabled in Contest,
+# see conf/remediation.py
+/hardening/.*/accounts_password_set_max_life_(existing|root)
+    True
+
 # requires running firewalld (firewall-cmd) and NetworkManager,
 # which are not available in their final form in the Anaconda environment
 # - see https://github.com/ComplianceAsCode/content/issues/9746

--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -16,46 +16,14 @@
 /hardening/image-builder(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
     rhel >= 8
 
-# https://github.com/OpenSCAP/openscap/issues/1880
-# needs to be remediated more than once due to rule ordering issues
-/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_exec_tmux
-/hardening/oscap(/with-gui)?/[^/]+/configure_bashrc_tmux
-/hardening/oscap(/with-gui)?/[^/]+/no_tmux_in_shells
-/hardening/oscap(/with-gui)?/[^/]+/configure_usbguard_auditbackend
-/hardening/oscap(/with-gui)?/[^/]+/configure_tmux_lock_after_time
-/hardening/oscap(/with-gui)?/[^/]+/configure_tmux_lock_command
-/hardening/oscap(/with-gui)?/[^/]+/configure_tmux_lock_keybinding
-/hardening/host-os/oscap/[^/]+/configure_tmux_lock_after_time
-/hardening/host-os/oscap/[^/]+/configure_tmux_lock_command
-/hardening/host-os/oscap/[^/]+/configure_tmux_lock_keybinding
-    rhel >= 8
-/hardening/oscap(/with-gui)?/stig(_gui)?/postfix_prevent_unrestricted_relay
-    rhel == 8
-
-# same issue, but host-os seems to be a lot more random in this
-/hardening/host-os/oscap/[^/]+/configure_bashrc_exec_tmux
-/hardening/host-os/oscap/[^/]+/configure_bashrc_tmux
-/hardening/host-os/oscap/[^/]+/no_tmux_in_shells
-/hardening/host-os/oscap/[^/]+/configure_usbguard_auditbackend
-    Match(rhel >= 8, sometimes=True)
-/hardening/host-os/oscap/stig/postfix_prevent_unrestricted_relay
-    Match(rhel == 8, sometimes=True)
-
 # rule ordering issue - accounts_password_pam_retry is checked first and passes,
 # and a later enable_authselect remediation breaks it
 # - see https://github.com/OpenSCAP/openscap/issues/1880
-/hardening/(anaconda|oscap)/.+/accounts_password_pam_retry
+/hardening/anaconda/.+/accounts_password_pam_retry
     rhel >= 8
-/hardening/host-os/oscap/[^/]+/accounts_password_pam_retry
-    Match(rhel >= 8, sometimes=True)
-
-# another rule ordering issue - on s390x,
-# https://github.com/ComplianceAsCode/content/issues/10654
-/hardening/host-os/oscap/[^/]+/zipl_bootmap_is_up_to_date
-    Match(True, sometimes=True)
 
 # bz1828871, won't be fixed on rhel7
-# needs to be remediated more than once due to rule ordering issues
+# - likely NOT related to rule ordering, double remediation doesn't help
 /hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
 # https://github.com/ComplianceAsCode/content/issues/10938
 /hardening/host-os/oscap/[^/]+/postfix_network_listening_disabled
@@ -181,6 +149,11 @@
 # https://github.com/ComplianceAsCode/content/issues/11609
 /hardening/host-os/oscap/stig/chronyd_or_ntpd_set_maxpoll
     rhel >= 8
+
+# visible on double reboot (double remediation)
+# /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
+/hardening/oscap/with-gui/e8/file_ownership_binary_dirs
+    rhel == 7
 
 # TODO: completely unknown, investigate and sort
 #

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -16,8 +16,6 @@ ks = virt.translate_ssg_kickstart(profile)
 
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
-ks.add_post('chage -d 99999 root')
-
 if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.add_package_group('Server with GUI')
 

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -52,9 +52,11 @@ with g.snapshotted():
     oval_results = '' if versions.oscap >= 1.3 else '--results results.xml --oval-results'
 
     # scan the remediated system
-    g.copy_to(util.get_datastream(), 'contest-ds.xml')
-    proc, lines = g.ssh_stream(f'oscap xccdf eval {verbose} --profile {profile_full} --progress '
-                               f'--report report.html {oval_results} contest-ds.xml {redir}')
+    g.copy_to(util.get_datastream(), 'scan-ds.xml')
+    proc, lines = g.ssh_stream(
+        f'oscap xccdf eval {verbose} --profile {profile_full} --progress'
+        f' --report report.html {oval_results} scan-ds.xml {redir}'
+    )
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:
         raise RuntimeError("post-reboot oscap failed unexpectedly")

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -30,7 +30,6 @@ if util.get_reboot_count() == 0:
     util.subprocess_run(cmd, check=True)
 
     # restore basic login functionality
-    util.subprocess_run(['chage', '-d', '99999', 'root'], check=True)
     with open('/etc/sysconfig/sshd', 'a') as f:
         f.write('\nOPTIONS=-oPermitRootLogin=yes\n')
 

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -39,7 +39,6 @@ if util.get_reboot_count() == 0:
         raise RuntimeError("remediation oscap failed unexpectedly")
 
     # restore basic login functionality
-    util.subprocess_run(['chage', '-d', '99999', 'root'], check=True)
     with open('/etc/sysconfig/sshd', 'a') as f:
         f.write('\nOPTIONS=-oPermitRootLogin=yes\n')
 

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -13,13 +13,11 @@ from conf import remediation
 profile = os.environ['PROFILE']
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
-ds = util.get_datastream()
-
 unique_name = util.get_test_name().lstrip('/').replace('/', '-')
 
 # persistent across reboots
 tmpdir = Path(f'/var/tmp/contest-{unique_name}')
-new_ds = tmpdir / 'modified_datastream.xml'
+remediation_ds = tmpdir / 'remediation-ds.xml'
 
 if util.get_reboot_count() == 0:
     util.log("first boot, doing remediation")
@@ -28,7 +26,7 @@ if util.get_reboot_count() == 0:
         shutil.rmtree(tmpdir)
     tmpdir.mkdir()
 
-    oscap.unselect_rules(ds, new_ds, remediation.excludes())
+    oscap.unselect_rules(util.get_datastream(), remediation_ds, remediation.excludes())
 
     # remediate twice due to some rules being 'notapplicable'
     # on the first pass
@@ -36,7 +34,7 @@ if util.get_reboot_count() == 0:
         cmd = [
             'oscap', 'xccdf', 'eval', '--profile', profile,
             '--progress', '--report', tmpdir / html_report,
-            '--remediate', new_ds,
+            '--remediate', remediation_ds,
         ]
         proc = util.subprocess_run(cmd)
         if proc.returncode not in [0,2]:
@@ -58,10 +56,11 @@ else:
     oval_results = [] if versions.oscap >= 1.3 else ['--results', 'results.xml', '--oval-results']
 
     # scan the remediated system
+    # - use the original unmodified datastream
     cmd = [
         'oscap', 'xccdf', 'eval', *verbose, '--profile', profile,
         '--progress', '--report', 'report.html', *oval_results,
-        new_ds,
+        util.get_datastream(),
     ]
     proc, lines = util.subprocess_stream(cmd, **redir)
     oscap.report_from_verbose(lines)

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -3,7 +3,7 @@
 import os
 
 from lib import util, results, virt, oscap, versions
-from conf import partitions
+from conf import remediation, partitions
 
 
 virt.Host.setup()
@@ -27,7 +27,8 @@ if not g.can_be_snapshotted():
 
 with g.snapshotted():
     # copy our datastream to the guest
-    g.copy_to(util.get_datastream(), 'contest-ds.xml')
+    oscap.unselect_rules(util.get_datastream(), 'modified_ds.xml', remediation.excludes())
+    g.copy_to('modified_ds.xml', 'contest-ds.xml')
 
     # remediate, reboot
     g.ssh(f'oscap xccdf eval --profile {profile} --progress '

--- a/lib/util/httpsrv.py
+++ b/lib/util/httpsrv.py
@@ -72,7 +72,7 @@ class BackgroundHTTPServer(HTTPServer):
         self.firewalld_zones = []
         super().__init__(self.listen_addr_port, _BackgroundHTTPServerHandler)
 
-    def add_file(self, fs_path, url_path):
+    def add_file(self, fs_path, url_path=None):
         """
         Map a filesystem path to a file to virtual location on the HTTP server,
         so that requests to the virtual location get the contents of the real
@@ -86,11 +86,13 @@ class BackgroundHTTPServer(HTTPServer):
             .add_file('/etc/passwd', 'users')
             # GET /some/file will get contents of tmpfile (relative to CWD)
             .add_file('tmpfile', 'some/file')
+            # GET /testfile will get the contents of testfile (in CWD)
+            .add_file('testfile')
         """
-        url_path = Path(url_path.lstrip('/'))
+        url_path = Path(fs_path) if url_path is None else Path(url_path.lstrip('/'))
         self.file_mapping[url_path] = Path(fs_path)
 
-    def add_dir(self, fs_path, url_path):
+    def add_dir(self, fs_path, url_path=None):
         """
         Map a filesystem directory to a virtual location on the HTTP server,
         see add_file() for details.
@@ -100,8 +102,10 @@ class BackgroundHTTPServer(HTTPServer):
             .add_dir('/etc', 'config')
             # GET /repo/repodata/repomd.xml gets /tmp/tmp.12345/repodata/repomd.xml
             .add_dir('/tmp/tmp.12345', 'repo')
+            # GET /testdir/123 will get the contents of testdir/123 (in CWD)
+            .add_dir('testdir')
         """
-        url_path = Path(url_path.lstrip('/'))
+        url_path = Path(fs_path) if url_path is None else Path(url_path.lstrip('/'))
         self.dir_mapping[url_path] = Path(fs_path)
 
     def __enter__(self):


### PR DESCRIPTION
While making the feature, I needed to have working unselects, hence this PR being not very straightforward and having multiple somewhat-but-not-really related commits, sorry.

The goal of double `oscap` remediation is to get rid of many waivers which are a result of rule dependencies (`notapplicable` during first remediation, other applicable rules causing the condition to flip and the rule becoming applicable and failing during a scan -- second remediation run should catch and fix it).

Not a great solution, but likely the least bad.

[make /hardening/host-os/oscap reboot between two remediations](https://github.com/RHSecurityCompliance/contest/pull/109/commits/69dbb826721dc7e004c7c786af29cdfe14f3dd01) is not part of [run oscap-based remediation twice](https://github.com/RHSecurityCompliance/contest/pull/109/commits/8bdbe11baffb94a5f273c3165426ae636c3a0a06) because of the commit between them conflicting, and I didn't want to spend another hour re-doing all the commits just so I could squash the two. Hopefully it's not a big deal.