### PR TITLE
Unify `CONTEST_*` content env vars under `CONTEST_CONTENT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,15 @@ on Red Hat Enterprise Linux.
     - Because the VM was left running after the first context manager block.
     - Fortunately, no such test currently exists (the use case is rare).
 
-- `CONTEST_DATASTREAM`
-  - Specify a filesystem path to a datastream XML to use for testing.
-
-- `CONTEST_PLAYBOOK`
-  - Specify a filesystem path to an Ansible YAML file to use as a playbook
-    for testing.  
-    A magical string of '{PROFILE}' expands to a profile name being tested.
-
-- `CONTEST_KICKSTART`
-  - Specify a filesystem path to an configuration file to use as an Anaconda
-    kickstart for testing.  
-    A magical string of '{PROFILE}' expands to a profile name being tested.
+- `CONTEST_CONTENT`
+  - Specify a path to a content source directory (as cloned from
+    [CaC/content](https://github.com/ComplianceAsCode/content/)) to be used
+    for testing.
+  - The content should be already built (at least for the product under test).
+    If it is not, an attempt will be made to build it in-place (rather than
+    in a temporary directory) so that any future tests benefit from the built
+    content.
+    - Note that this may fail if the content is located on a read-only path.
 
 ## Waiving failed results
 

--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -1,51 +1,119 @@
 import os
+import subprocess
+import contextlib
+import tempfile
 from pathlib import Path
 
+from lib import util, dnf
 from lib.versions import rhel
+
+user_content = os.environ.get('CONTEST_CONTENT')
+if user_content:
+    user_content = Path(user_content)
 
 
 def get_datastream():
-    override = os.environ.get('CONTEST_DATASTREAM')
-    if override:
-        return Path(override)
-
-    base_dir = Path('/usr/share/xml/scap/ssg/content')
-    if rhel.is_true_rhel():
-        return base_dir / f'ssg-rhel{rhel.major}-ds.xml'
-    elif rhel.is_centos():
-        if rhel <= 8:
-            return base_dir / f'ssg-centos{rhel.major}-ds.xml'
-        else:
-            return base_dir / f'ssg-cs{rhel.major}-ds.xml'
+    if user_content:
+        build_content(user_content)
+        datastream = user_content / 'build' / f'ssg-rhel{rhel.major}-ds.xml'
     else:
-        raise RuntimeError("cannot find datastream for testing")
+        base_dir = Path('/usr/share/xml/scap/ssg/content')
+        if rhel.is_true_rhel():
+            datastream = base_dir / f'ssg-rhel{rhel.major}-ds.xml'
+        elif rhel.is_centos():
+            if rhel <= 8:
+                datastream = base_dir / f'ssg-centos{rhel.major}-ds.xml'
+            else:
+                datastream = base_dir / f'ssg-cs{rhel.major}-ds.xml'
+    if not datastream.exists():
+        raise RuntimeError(f"could not find datastream as {datastream}")
+    return datastream
 
 
 def get_playbook(profile):
-    override = os.environ.get('CONTEST_PLAYBOOK')
-    if override:
-        return Path(override.format(PROFILE=profile))
-
-    base_dir = Path('/usr/share/scap-security-guide/ansible')
-    if rhel.is_true_rhel():
-        return base_dir / f'rhel{rhel.major}-playbook-{profile}.yml'
-    elif rhel.is_centos():
-        if rhel <= 8:
-            return base_dir / f'centos{rhel.major}-playbook-{profile}.yml'
-        else:
-            return base_dir / f'cs{rhel.major}-playbook-{profile}.yml'
+    if user_content:
+        build_content(user_content)
+        playbook = user_content / 'build' / 'ansible' / f'rhel{rhel.major}-playbook-{profile}.yml'
     else:
-        raise RuntimeError("cannot find playbook for testing")
+        base_dir = Path('/usr/share/scap-security-guide/ansible')
+        if rhel.is_true_rhel():
+            playbook = base_dir / f'rhel{rhel.major}-playbook-{profile}.yml'
+        elif rhel.is_centos():
+            if rhel <= 8:
+                playbook = base_dir / f'centos{rhel.major}-playbook-{profile}.yml'
+            else:
+                playbook = base_dir / f'cs{rhel.major}-playbook-{profile}.yml'
+    if not playbook.exists():
+        raise RuntimeError(f"cound not find playbook as {playbook}")
+    return playbook
 
 
 def get_kickstart(profile):
-    override = os.environ.get('CONTEST_KICKSTART')
-    if override:
-        return Path(override.format(PROFILE=profile))
-
-    base_dir = Path('/usr/share/scap-security-guide/kickstart')
-    # RHEL and CentOS Stream both use 'ssg-rhel*' files
-    if rhel:
-        return base_dir / f'ssg-rhel{rhel.major}-{profile}-ks.cfg'
+    if user_content:
+        build_content(user_content)
+        kickstart = (
+            user_content / 'products' / f'rhel{rhel.major}' / 'kickstart'
+            / f'ssg-rhel{rhel.major}-{profile}-ks.cfg'
+        )
     else:
-        raise RuntimeError("cannot find kickstart for testing")
+        base_dir = Path('/usr/share/scap-security-guide/kickstart')
+        # RHEL and CentOS Stream both use 'ssg-rhel*' files
+        kickstart = base_dir / f'ssg-rhel{rhel.major}-{profile}-ks.cfg'
+    if not kickstart.exists():
+        raise RuntimeError(f"cound not find kickstart as {kickstart}")
+    return kickstart
+
+
+def content_is_built(path):
+    return (Path(path) / 'build' / 'Makefile').exists()
+
+
+def build_content(path):
+    if content_is_built(path):
+        return
+    util.log(f"building content from source in {path}")
+    # install dependencies
+    cmd = ['dnf', '-y', 'builddep', '--spec', 'scap-security-guide.spec']
+    util.subprocess_run(cmd, check=True, cwd=path)
+    # build content
+    cmd = ['./build_product', f'rhel{rhel.major}']
+    util.subprocess_run(cmd, check=True, cwd=path)
+
+
+@contextlib.contextmanager
+def get_content():
+    """
+    Acquire and return a path to a fully built content source,
+    from either a user-provided directory or a SRPM.
+    """
+    if user_content:
+        build_content(user_content)
+        yield user_content
+    else:
+        # fall back to SRPM
+        with dnf.download_rpm('scap-security-guide', source=True) as src_rpm:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # install dependencies
+                cmd = ['dnf', '-y', 'builddep', '--srpm', src_rpm]
+                util.subprocess_run(cmd, check=True, cwd=tmpdir)
+                # extract + patch SRPM
+                cmd = ['rpmbuild', '-rp', '--define', f'_topdir {tmpdir}', src_rpm]
+                util.subprocess_run(cmd, check=True)
+                # get path to the extracted content
+                # - parse name+version from the SRPM instead of glob(BUILD/*)
+                #   because of '-rhel6' content on RHEL-8
+                ret = util.subprocess_run(
+                    ['rpm', '-q', '--qf', '%{NAME}-%{VERSION}', '-p', src_rpm],
+                    check=True, stdout=subprocess.PIPE, universal_newlines=True, cwd=tmpdir,
+                )
+                name_version = ret.stdout.strip()
+                extracted = Path(tmpdir) / 'BUILD' / name_version
+                util.log(f"using {extracted} as content source")
+                if not extracted.exists():
+                    raise FileNotFoundError(f"{extracted} not in extracted/patched SRPM")
+                # build content
+                # TODO: temporary, see https://github.com/ComplianceAsCode/content/pull/11606
+                (extracted / 'build').mkdir(exist_ok=True)
+                cmd = ['./build_product', f'rhel{rhel.major}']
+                util.subprocess_run(cmd, check=True, cwd=extracted)
+                yield extracted

--- a/main.fmf
+++ b/main.fmf
@@ -9,6 +9,11 @@ recommend:
   - python36-requests
   - python3-rpm
   - python36-rpm
+  # these are needed for CONTEST_CONTENT or get_content():
+  # - builddep on scap-security-guide.spec
+  - python-srpm-macros
+  # - preparing/patching downloaded SRPM
+  - rpm-build
 component:
   - scap-security-guide
 

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -25,8 +25,6 @@ require+:
   - virt-install
   - rpm-build
   - createrepo
-  # for builddep on scap-security-guide.spec
-  - python-srpm-macros
   # automatus dependencies (oscap-ssh, etc.)
   - openscap-utils
 extra-hardware: |


### PR DESCRIPTION
With `/per-rule` now being a thing, it doesn't make sense to split user-provided (copied to SUT) content to be referenced as

* `CONTEST_DATASTREAM`
* `CONTEST_PLAYBOOK` (with custom `.format()`)
* `CONTEST_KICKSTART` (with custom `.format()`)

Instead, unify the above with `/per-rule`'s `CONTENT_SOURCE` under one variable - the CaC/content directory location (either cloned via git, or `rsync`ed to the target system) and let `util.get_datastream()` and other getters find the appropriate files inside it, building the content if necessary.