### PR TITLE
Add DISA alignment test for Bash remediation

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -281,4 +281,22 @@
 /per-rule/[^/]+/tftpd_uses_secure_mode/wrong.fail
     rhel == 9
 
+# DISA Alignment waivers
+#
+# https://github.com/ComplianceAsCode/content/issues/9307 (DISA issue)
+/scanning/disa-alignment/oscap/sysctl_kernel_yama_ptrace_scope
+# https://github.com/ComplianceAsCode/content/issues/9308 (DISA issue)
+/scanning/disa-alignment/oscap/sysctl_kernel_core_pattern
+# https://github.com/ComplianceAsCode/content/issues/10044 (DISA issue)
+/scanning/disa-alignment/oscap/accounts_password_pam_pwhistory_remember_password_auth
+# https://github.com/ComplianceAsCode/content/issues/11197 (DISA issue)
+/scanning/disa-alignment/oscap/display_login_attempts
+    rhel == 8
+# https://github.com/ComplianceAsCode/content/issues/11649 (DISA issue)
+/scanning/disa-alignment/oscap/installed_OS_is_vendor_supported
+# https://github.com/ComplianceAsCode/content/issues/11650
+/scanning/disa-alignment/oscap/kernel_module_tipc_disabled
+    rhel == 9
+
+
 # vim: syntax=python

--- a/scanning/disa-alignment/oscap/main.fmf
+++ b/scanning/disa-alignment/oscap/main.fmf
@@ -1,0 +1,31 @@
+summary: Compare SSG and DISA STIG benchmark scan results after Bash remediation
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../../..
+require+:
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
+  - rpm-build
+  - createrepo
+duration: 1h
+extra-hardware: |
+    keyvalue = HVM=1
+    hostrequire = memory>=3720
+adjust:
+  - when: arch != x86_64
+    enabled: false
+    because: run virtualization on x86_64 only
+  - when: distro == rhel-7
+    enabled: false
+    because: the code is not compatible with RHEL-7
+tag:
+  - max1
+  - daily

--- a/scanning/disa-alignment/oscap/test.py
+++ b/scanning/disa-alignment/oscap/test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+import os
+import re
+import subprocess
+
+from lib import util, results, virt, oscap, versions
+from conf import partitions, remediation
+
+
+virt.Host.setup()
+
+profile = 'xccdf_org.ssgproject.content_profile_stig'
+
+g = virt.Guest('minimal_with_oscap')
+
+if not g.can_be_snapshotted():
+    ks = virt.Kickstart(partitions=partitions.partitions)
+    g.install(kickstart=ks)
+    g.prepare_for_snapshot()
+
+with g.snapshotted():
+    oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
+    g.copy_to('remediation-ds.xml')
+
+    for _ in range(2):
+        cmd = [
+            'oscap', 'xccdf', 'eval', '--profile', profile,
+            '--progress', '--remediate', 'remediation-ds.xml',
+        ]
+        proc = g.ssh(' '. join(cmd))
+        if proc.returncode not in [0,2]:
+            raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
+        g.soft_reboot()
+
+    with util.get_content() as content_dir:
+        # There is always one (the latest) DISA benchmark in content src
+        references = content_dir / 'shared' / 'references'
+        disa_ds = next(
+            references.glob(f'disa-stig-rhel{versions.rhel.major}-*-xccdf-scap.xml')
+        )
+
+        # old RHEL-7 oscap mixes errors into --progress rule names without a newline
+        redir = '2>&1' if versions.oscap >= 1.3 else ''
+        # RHEL-7 HTML report doesn't contain OVAL findings by default
+        oval_results = '' if versions.oscap >= 1.3 else '--results results.xml --oval-results'
+
+        shared_cmd = ['oscap', 'xccdf', 'eval', '--progress', oval_results]
+        # Scan with scap-security-guide benchmark
+        g.copy_to(util.get_datastream(), 'ssg-ds.xml')
+        cmd = [
+            *shared_cmd,
+            '--profile', profile,
+            '--report', 'ssg-report.html',
+            '--stig-viewer', 'ssg-stig-viewer.xml',
+            'ssg-ds.xml', redir,
+        ]
+        proc = g.ssh(' '. join(cmd))
+        if proc.returncode not in [0,2]:
+            raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
+        g.copy_from('ssg-report.html')
+        g.copy_from('ssg-stig-viewer.xml')
+
+        # Scan with DISA benchmark
+        g.copy_to(disa_ds, 'disa-ds.xml')
+        cmd = [
+            *shared_cmd,
+            '--profile', '\'(all)\'',
+            '--report', 'disa-report.html',
+            '--results-arf', 'disa-arf.xml',
+            'disa-ds.xml', redir
+        ]
+        proc = g.ssh(' '. join(cmd))
+        if proc.returncode not in [0,2]:
+            raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
+        g.copy_from('disa-report.html')
+        g.copy_from('disa-arf.xml')
+
+        compare_script = content_dir / 'utils' / 'compare_results.py'
+        env = os.environ.copy()
+        env['PYTHONPATH'] = str(content_dir)
+        cmd = [
+            compare_script, 'ssg-stig-viewer.xml', 'disa-arf.xml',
+        ]
+        proc = util.subprocess_run(cmd, env=env, universal_newlines=True, stdout=subprocess.PIPE)
+
+        # Same result format:      CCE CCI - DISA_RULE_ID SSG_RULE_ID     RESULT
+        # Different result format: CCE CCI - DISA_RULE_ID SSG_RULE_ID     SSG_RESULT - DISA_RESULT
+        result_regex = re.compile(r'[\w-]+ [\w-]+ - [\w-]+ (\w*)\s+(\w+)(?: - *(\w+))*')
+        for match in result_regex.finditer(proc.stdout.rstrip('\n')):
+            rule_id, ssg_result, disa_result = match.groups()
+            if not rule_id:
+                rule_id = 'rule_id_not_found'
+            # Only 1 result matched - same results
+            if not disa_result:
+                results.report('pass', rule_id)
+            # SSG CPE checks can make rule notapplicable by different reason (package not
+            # installed, architecture, RHEL version). DISA bechmark doesn't have this
+            # capability, it just 'pass'. Ignore such result misalignments
+            elif ssg_result == 'notapplicable' and disa_result == 'pass':
+                result_note = 'SSG result: notapplicable, DISA result: pass'
+                results.report('pass', rule_id, result_note)
+            # Different results
+            else:
+                result_note = f'SSG result: {ssg_result}, DISA result: {disa_result}'
+                results.report('fail', rule_id, result_note)
+
+results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])


### PR DESCRIPTION
1. Harden the system using scap-security-guide Bash remediations (`oscap xccdf eval --remediate ...`)
2. Scan the system with our and DISA benchmark and get ARF results for comparing results
3. Compare results via `compare_results.py` scripts from scap-security-guide utils

The diff results reporting part (last `for`) will be same for all DISA Alignment tests (3x - Bash, Ansible, OAA). Is it worth of having it in `lib/`?