### PR TITLE
add /plans/upstream for using latest upstream CaC/content

### DIFF
--- a/plans/upstream.fmf
+++ b/plans/upstream.fmf
@@ -1,0 +1,22 @@
+summary: Test against a fresh build of upstream content
+
+discover:
+    how: fmf
+execute:
+    how: tmt
+
+adjust+:
+  - prepare+:
+      - how: install
+        package:
+          - git-core
+      - how: shell
+        name: Download and build latest content
+        script: |
+            if [ ! -e /root/content ]; then
+                git clone --depth=1 https://github.com/ComplianceAsCode/content.git /root/content
+            fi
+
+  - environment+:
+        CONTEST_CONTENT: /root/content
+        CONTEST_WAIVERS: upstream


### PR DESCRIPTION
Use via TMT as
```
tmt -c ... run -avv ... plans -n /plans/upstream ...
```
It will be built by any `util.get_*()` from `lib/util/content.py` automatically.