### PR TITLE
Add new test /static-checks/html-links

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -294,5 +294,14 @@
 /scanning/disa-alignment/oscap/kernel_module_tipc_disabled
     rhel == 9
 
+# HTML links from datastreams waivers
+#
+# Inaccessible until form is filled:
+/static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+    True
+# https://github.com/ComplianceAsCode/content/issues/11678
+/static-checks/html-links/http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+    True
+
 
 # vim: syntax=python

--- a/static-checks/html-links/main.fmf
+++ b/static-checks/html-links/main.fmf
@@ -1,0 +1,15 @@
+summary: Verify that HTML links from datastream are accessible.
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 5m
+recommend+:
+  - python3-requests
+tag:
+  - daily
+adjust:
+  - enabled: false
+    when: arch != x86_64
+    continue: false
+extra-summary: /CoreOS/scap-security-guide/static-checks/html-links

--- a/static-checks/html-links/test.py
+++ b/static-checks/html-links/test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import re
+import requests
+
+from lib import util, results
+
+
+headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64;)'}
+url_regex = re.compile(r'href=[\'"]?(http[^\'" ]+)', re.IGNORECASE)
+
+with open(util.get_datastream(), 'r') as ds:
+    ds_content = ds.read()
+    urls = set(url_regex.findall(ds_content))
+
+for url in urls:
+    try:
+        r = requests.get(url, timeout=10, headers=headers)
+        r.raise_for_status()
+    except requests.exceptions.RequestException as err:
+        results.report('fail', url, err)
+    else:
+        results.report('pass', url)
+
+results.report_and_exit()


### PR DESCRIPTION
Test verifies that HTML links from datastream are accessible.

Rewrite of old `Sanity/oscap-html-links` test.

The new test also identified a broken link in datastreams, reported in https://github.com/ComplianceAsCode/content/issues/11678