### PR TITLE
ignore Image Builder test errors, globally

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -208,39 +208,10 @@
 
 # Image Builder errors
 #
-# https://issues.redhat.com/browse/RHEL-24246
-/hardening/image-builder/anssi_bp28_high
-    status == 'error' and 'TimeoutError' in note
-# 'composer-cli compose start' fails with:
-# OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
-# https://issues.redhat.com/browse/RHEL-25574
-/hardening/image-builder/ccn_advanced
-    status == 'error'
-# compose building fails on oscap with:
-# Fatal: can't open /dev/urandom: No such file or directory
-# https://github.com/osbuild/osbuild/pull/1590
-/hardening/image-builder/cui
-    rhel == 8 and status == 'error'
-# https://issues.redhat.com/browse/RHEL-24441 on 'squid'
-/hardening/image-builder/e8
-    rhel == 9 and status == 'error'
-# https://issues.redhat.com/browse/RHEL-24441 on 'telnet'
-/hardening/image-builder/hipaa
-    rhel == 9 and status == 'error'
-# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'snmpd'
-# RHEL-8: Fatal: can't open /dev/urandom: No such file or directory
-/hardening/image-builder/ism_o
-    status == 'error'
-# Fatal: can't open /dev/urandom: No such file or directory
-/hardening/image-builder/ospp
-    rhel == 8 and status == 'error'
-# https://github.com/ComplianceAsCode/content/issues/11568
-/hardening/image-builder/pci-dss
-    status == 'error'
-# RHEL-9: https://issues.redhat.com/browse/RHEL-24441 on 'autofs'
-# RHEL-8: Fatal: can't open /dev/urandom: No such file or directory
-/hardening/image-builder/stig
-    status == 'error'
+# ignore errors for now, until 'openscap generate fix' syntax stabilizes
+# and blocker bugs are resolved
+/hardening/image-builder/.+
+    Match(status == 'error', sometimes=True)
 
 # Image Builder failures
 #


### PR DESCRIPTION
Currently, IB is broken on openscap generating multiple `[customizations.services]` sections, which is wrong, and likely fixed in git upstream, but not in downstream RPMs.

Even if that is fixed, we'll need some `lib/osbuild.py` updates to account for `generate fix` now including a `[customization.openscap]` section by default (with profile specified, without datastream), which won't be easy given the code structure of `lib/osbuild.py` (allowing for unhardened images, optionally adding the section, `profile` arg on multiple places now being invalid since the generated Blueprint has it already, etc.).

And even when that is fixed, there are still blockers like https://issues.redhat.com/browse/RHEL-24246 .

So, at least for now, let's ignore broken `image-builder` tests, until the ecosystem stabilizes.

PS: Most of the issues linked in waivers are fixed, so it's IMHO not worth preserving that info.