### PR TITLE
ignore SSL certificate expirations in /static-checks/html-links

### DIFF
--- a/conf/waivers-upstream
+++ b/conf/waivers-upstream
@@ -269,6 +269,11 @@
 
 # HTML links from datastreams waivers
 #
+# ignore SSL certificate expirations in html-links - these are generally
+# harmless (expiration is not MITM) while being the biggest contributor
+# to false positives, so just ignore them, avoiding frequent random fails
+/static-checks/html-links/.+
+    Match("failed: certificate has expired" in note, sometimes=True)
 # Inaccessible until form is filled:
 /static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
     True


### PR DESCRIPTION
Not 100% sure about this, as we then wouldn't detect links with expirations going on for a long time (effectively rendering the link broken), as opposed to occasional random fails caused by the admin forgetting and fixing it in 1-7 days.

But I think I would rather /not/ see a long-broken link caused by expiration, than observe false positives pop up much more frequently.

Plus, we still do see `warn` results in HTML reports, so chances are that a long-term failing link would be recognized as "hey I've seen that `warn` before", triggering an investigation.