### PR TITLE
report any `ansible-playbook` fatal errors

### DIFF
--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -42,7 +42,10 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-    util.subprocess_run(ansible_cmd, check=True)
+    proc, lines = util.subprocess_stream(ansible_cmd)
+    failed = ansible.report_from_output(lines)
+    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
+        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()
 
     # RHEL-7 HTML report doesn't contain OVAL findings by default

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -26,7 +26,10 @@ if util.get_reboot_count() == 0:
         *skip_tags_arg,
         playbook,
     ]
-    util.subprocess_run(cmd, check=True)
+    proc, lines = util.subprocess_stream(cmd)
+    failed = ansible.report_from_output(lines)
+    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
+        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
 
     # restore basic login functionality
     with open('/etc/sysconfig/sshd', 'a') as f:

--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -1,6 +1,8 @@
 import os
+import sys
+import re
 
-from lib import util, versions
+from lib import util, versions, results
 
 
 def install_deps():
@@ -28,3 +30,43 @@ def install_deps():
             util.subprocess_run(
                 ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
                 check=True)
+
+
+def report_from_output(lines):
+    """
+    Process 'ansible-playbook' output, hide useless info, and report important
+    info.
+
+    Return True whether there was at least one 'failed' module check.
+    This can be used by the caller to differentiate between ansible-playbook
+    exit code 2 due to failed checks vs the same exit code due to bad args, etc.
+    (False && exit code 2 means a task-unrelated problem.)
+    """
+    failed = False
+    task = '<unknown task>'
+
+    for line in lines:
+        # shorten facts
+        m = re.match(r'(ok: \[.+\] =>) {"ansible_facts": ', line)
+        if m:
+            line = f'{m.group(1)} (Redacted by Contest)'
+
+        sys.stdout.write(f'{line}\n')
+        sys.stdout.flush()
+
+        # match and parse task name
+        m = re.fullmatch(r'TASK \[(.+)\] \*+', line, flags=re.M)
+        if m:
+            task = m.group(1)
+            continue
+
+        # match and parse a module status line
+        m = re.fullmatch(r'([\w]+): \[.+\](: [^ ]+)? => (.+)', line)
+        if m:
+            status, _, data = m.groups()
+            if status == 'fatal':
+                results.report('error', f'playbook: {task}', data)
+                failed = True
+            continue
+
+    return failed

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -31,7 +31,10 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-    util.subprocess_run(ansible_cmd, check=True)
+    proc, lines = util.subprocess_stream(ansible_cmd)
+    failed = ansible.report_from_output(lines)
+    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
+        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()
 
     with util.get_content() as content_dir:


### PR DESCRIPTION
This was inspired by
```
TASK [Set 'dns' to 'none' in the [main] section of '/etc/NetworkManager/NetworkManager.conf'] ***
fatal: [192.168.121.90]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ini_file) module: ignore_spaces. Supported parameters include: allow_no_value, attributes, backup, create, exclusive, group, mode, no_extra_spaces, option, owner, path, section, selevel, serole, setype, seuser, state, unsafe_writes, value, values (attr, dest)."}

PLAY RECAP *********************************************************************
192.168.121.90             : ok=2552 changed=419  unreachable=0    failed=1    skipped=983  rescued=0    ignored=1   
```
where the overall reported result was just
```
subprocess.CalledProcessError: Command '['ansible-playbook', '-v', '-i', '192.168.121.90,', '--private-key', '/var/lib/libvirt/images/contest.sshkey', '--skip-tags', 'accounts_password_set_max_life_existing,accounts_password_set_max_life_root', PosixPath('/usr/share/scap-security-guide/ansible/rhel9-playbook-stig.yml')]' returned non-zero exit status 2.
```
which is somewhat confusing (with the `--skip-tags` and all).

With this change, the fatal error gets reported and the overall `ansible-playbook` exit code 2 is ignored, allowing us to waive the one reported error instead of waiving both the `fatal:` error + `CalledProcessError` caused error.

```
errr /hardening/ansible/stig/playbook: Enable FIPS Mode - Check to See the Current Status of FIPS Mode (on default-0) ({"changed": false, "cmd": ["/usr/bin/fips-mode-setup", "--check"], "delta": "0:00:00.367348", "end": "2024-04-02 18:57:21.135536", "msg": "non-zero return code", "rc": 1, "start": "2024-04-02 18:57:20.768188", "stderr": "", "stderr_lines": [], "stdout": "FIPS mode is disabled. Inconsistent state detected.", "stdout_lines": ["FIPS mode is disabled.", "Inconsistent state detected."]}) [1/1]
```

The waiver actually won't be necessary if we wait with this PR until https://github.com/ComplianceAsCode/content/pull/11782  is merged.