### PR TITLE
Add flake8 and tmt to Github Actions

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -23,3 +23,12 @@ jobs:
               print(str(e))
               sys.exit(1)
             EOF
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install flake8
+        run: python3 -m pip install flake8
+      - name: Run flake8
+        run: flake8 -v

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -32,3 +32,14 @@ jobs:
         run: python3 -m pip install flake8
       - name: Run flake8
         run: flake8 -v
+  tmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tmt
+        run: python3 -m pip install tmt
+      - name: Run tmt lint
+        run: tmt lint --failed-only
+      - name: Run basic tmt run discover
+        run: tmt run -v plans -n /plans/default discover -h fmf

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,11 @@
 ;     https://www.flake8rules.com/rules/W503.html
 ;   freely admits, new code should use Knuth's notation, see also
 ;     https://peps.python.org/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
-extend-ignore = E265,E226,E231,W503
+; E306 empty line between nested function declaration and its parent
+; - this seems like a bad idea, all other code is fine to be written directly
+;   after the (parent) function declaration, so why not another 'def'?
+; - allowing this arguably helps readability, as it allows condensed code
+;   to appear where it makes sense (tightly integrated nested 1-line functions)
+;   rather than having to 'foo = lambda x: something(x)' and breaking debug
+extend-ignore = E265,E226,E231,W503,E306
 max-line-length = 99


### PR DESCRIPTION
The flake8 `-v` / `--verbose` is there to show how many files were checked, as a debugging help when flake8 doesn't find anything despite obvious issues (ie. when checkout fails and it's running in an empty directory).

However, the pip version of flake8 doesn't seem to have what my Fedora version has:
```
flake8.checker            MainProcess     52 INFO     Checking 37 files
```
either way, non-verbose / verbose probably doesn't matter.

Fixes https://github.com/RHSecurityCompliance/contest/issues/5