### PR TITLE
Update ANSSI waivers, mainly for upstream CI

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -59,6 +59,8 @@
 /hardening(/host-os)?/ansible/.+/no_tmux_in_shells
 /hardening(/host-os)?/ansible/.+/configure_usbguard_auditbackend
 /hardening(/host-os)?/ansible/.+/audit_rules_unsuccessful_file_modification
+# https://github.com/ComplianceAsCode/content/issues/11752
+/hardening(/host-os)?/ansible/.+/audit_rules_privileged_commands
     rhel == 8 or rhel == 9
 # RHEL-8
 /hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -16,8 +16,8 @@
 # all Beaker repositories have gpgcheck=0 and they get copied to nested VMs too
 /(hardening|scanning)/.+/ensure_gpgcheck_never_disabled
 # we don't control partitions on the host OS
-/hardening/host-os/oscap/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit|tmp)_(noexec|nosuid|nodev|usrquota|grpquota)
-/hardening/host-os/oscap/.+/mount_option_boot_efi_nosuid
+/hardening/host-os/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit|tmp)_(noexec|nosuid|nodev|usrquota|grpquota)
+/hardening/host-os/.+/mount_option_boot_efi_nosuid
     Match(True, sometimes=True)
 
 # Beaker-specific, possibly;


### PR DESCRIPTION
During `audit_rules_privileged_commands` fix, it has been found ANSSI profile is not tested in upstream CI - https://github.com/ComplianceAsCode/content/pull/11791 - and the fix revealed there are some ANSSI-specific issues.
This PR waives the issues so the ANSSI can be introduced to upstream CI as passing test.