### PR TITLE
Add TMT plans for all our notable use cases

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -68,3 +68,47 @@ they don't install virtual machines.
 
 These are things like `grep`-ing for specific strings (not) present in the built
 content, syntax-checking Ansible playbooks, or verifying HTTP URLs.
+
+# Test tags
+
+These are some of the commonly-used tags amongst tests.
+
+Note that we use tags to indicate properties of tests, not to categorize them
+(think: "needs virtualization", not: "runs during release testing").
+
+## `needs-param`
+
+This indicates a test that is used as a "tool" in automation-assisted use
+cases. It should not run automatically in regular "all tests" runs, as it
+requires the user to give it input via environment variables (parameters).
+
+## `always-fails`
+
+This is a test that uses the `fail` status to indicate some unwanted findings,
+expecting the user to review the list manually. These `fail`s should not be
+waived automatically as they are specific to the configuration the user
+requested.
+
+A test like this is another form of a "tool" and should not be run regularly
+in use cases that expect `pass` to be the norm and `fail` to be a regression.
+
+## `broken`
+
+This is a perfectly valid working test, but the functionality it tests is
+either completely broken, or under very active development, creating interface
+incompatibilities, such as config directive changes, and frequently breaking
+the test.
+
+Despite this, we don't want to disable the test outright, as it is useful for
+debugging and stabilizing the tested functionality via manual use.
+
+However a test like this should not be run by automation, it is not useful
+for preventing regressions.
+
+## `destructive`
+
+A destructive tests modifies the OS it runs on to the point where it is
+unusable for further testing, typically by hardening it.
+
+A test that just installs extra RPMs from the package manager, or enables
+extra services, is not considered destructive.

--- a/hardening/image-builder/with-gui.fmf
+++ b/hardening/image-builder/with-gui.fmf
@@ -5,6 +5,7 @@ duration: 2h
 tag:
   - NoProductization
   - NoStabilization
+  - broken
 
 /anssi_bp28_high:
     environment+:

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -49,6 +49,7 @@ tag:
     tag:
       - NoProductization
       - NoStabilization
+      - needs-param
     /oscap:
         extra-summary: /CoreOS/scap-security-guide/per-rule/from-env/oscap
         extra-nitrate: TC#0617199

--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -1,0 +1,31 @@
+summary: Regular daily "productization" testing
+discover:
+    how: fmf
+    filter:
+      - tag:-needs-param
+      - tag:-always-fails
+      - tag:-broken
+    test:
+      # every remediation method, but only the basic reference environment,
+      # without GUI/UEFI/etc. variants
+      - /hardening/oscap/[^/]+$
+      - /hardening/anaconda/[^/]+$
+      - /hardening/ansible/[^/]+$
+      - /hardening/image-builder/[^/]+$
+      # add stig_gui as an exception here, since it needs to be tested somehow
+      # but the only way to do it is via GUI
+      - /hardening/oscap/with-gui/stig_gui
+      - /hardening/anaconda/with-gui/stig_gui
+      - /hardening/ansible/with-gui/stig_gui
+      - /hardening/image-builder/with-gui/stig_gui
+      # run host-os as well - not because it would be very useful compared to
+      # the above, but because we use it for CaC/content TestingFarm and want to
+      # detect impact of waivers on RHEL early after an upstream-related change
+      - /hardening/host-os
+      # run /per-rule as oscap only - this almost halves the runtime (for now)
+      - /per-rule/[^/]+/oscap$
+      # the rest is cheap to run
+      - /scanning
+      - /static-checks
+
+# vim: syntax=yaml

--- a/plans/default.fmf
+++ b/plans/default.fmf
@@ -1,1 +1,5 @@
-summary: Default plan (simple for now)
+summary: Default plan discovering all tests for ad-hoc use
+discover:
+    how: fmf
+
+# vim: syntax=yaml

--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -1,0 +1,16 @@
+summary: Testing builds added to errata
+discover:
+    how: fmf
+    filter:
+      - tag:-needs-param
+      - tag:-always-fails
+      - tag:-broken
+    test:
+      # just some basic smoke testing that should never fail
+      - /scanning/oscap-eval
+      - /static-checks
+    exclude:
+      # often fails on temporary retrieval issues
+      - /static-checks/html-links
+
+# vim: syntax=yaml

--- a/plans/gating-ci.fmf
+++ b/plans/gating-ci.fmf
@@ -1,0 +1,1 @@
+errata.fmf

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,9 +2,6 @@
 /:
     inherit: false
 
-discover:
-    how: fmf
-
 execute:
     how: tmt
 
@@ -101,3 +98,5 @@ adjust:
                 rm -f "$repofile"
             fi
     when: distro > rhel-7
+
+# vim: syntax=yaml

--- a/plans/stabilization.fmf
+++ b/plans/stabilization.fmf
@@ -1,0 +1,9 @@
+summary: Pre-release "stabilization" testing
+discover:
+    how: fmf
+    # all tests are included by default, except these
+    filter:
+      - tag:-needs-param
+      - tag:-broken
+
+# vim: syntax=yaml

--- a/plans/weekly.fmf
+++ b/plans/weekly.fmf
@@ -1,0 +1,10 @@
+summary: Regular weekly "productization" testing
+discover:
+    how: fmf
+    # all tests are included by default, except these
+    filter:
+      - tag:-needs-param
+      - tag:-always-fails
+      - tag:-broken
+
+# vim: syntax=yaml

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -10,7 +10,9 @@ adjust:
 /profiles:
     summary: Diff datastreams, output added/removed profiles
     test: python3 -m lib.runtest ./profiles.py
-    tag: [NoProductization]
+    tag:
+      - NoProductization
+      - always-fails
     extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profiles
     extra-nitrate: TC#0617452
     id: 5f0d1df1-f2b5-4212-84e7-2c25ec5566c1
@@ -18,7 +20,9 @@ adjust:
 /profile-titles:
     summary: Diff datastreams, output profile title differences
     test: python3 -m lib.runtest ./profile-titles.py
-    tag: [NoProductization]
+    tag:
+      - NoProductization
+      - always-fails
     extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-titles
     extra-nitrate: TC#0617450
     id: 9e43b634-eaab-4e4f-81c2-bbab571f7db1
@@ -26,7 +30,9 @@ adjust:
 /profile-rules:
     summary: Diff datastreams, output profile rule/variable differences
     test: python3 -m lib.runtest ./profile-rules.py
-    tag: [NoProductization]
+    tag:
+      - NoProductization
+      - always-fails
     extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-rules
     extra-nitrate: TC#0617449
     id: d17358be-d702-4786-a9df-6716036c8428
@@ -34,7 +40,9 @@ adjust:
 /profile-variables:
     summary: Diff datastreams, output profile variable refine differences
     test: python3 -m lib.runtest ./profile-variables.py
-    tag: [NoProductization]
+    tag:
+      - NoProductization
+      - always-fails
     extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-variables
     extra-nitrate: TC#0617451
     id: dd504436-0d67-4f1c-96f4-faeff18a2c0c


### PR DESCRIPTION
I split these according to what seemed reasonable. Milan mentioned we should probably use auto-ptp via Beaker directly, so I didn't include a plan for it.

Feel free to add suggestions what to change - I'm not sure if having automated errata runs is even useful if we test everything before that. And we got rid of manual tests since (replaced them with JIRA).

I left the original tags (`NoProductization`, `daily`, etc.) in place, due to TCMS, but I expect we remove them after we switch away - https://github.com/RHSecurityCompliance/contest/issues/151 .