### PR TITLE
Fix virtualization-enabled tests on CentOS Stream

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -48,7 +48,7 @@ def excludes():
             'ensure_gpgcheck_repo_metadata',
         ]
         # Remove when CentOS repos use at least 3072b RSA key
-        if versions.rhel.major == 9 and re.fullmatch('/hardening/host-os/.*/ospp', test_name):
+        if versions.rhel.major == 9 and re.fullmatch('/hardening/.+/ospp', test_name):
             rules += [
                 'configure_crypto_policy',
                 'enable_fips_mode',

--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -21,14 +21,6 @@ def excludes():
         'accounts_password_set_max_life_root',
     ]
 
-    # Hardenings via Ansible
-    if re.fullmatch('/hardening.*/ansible/.*', test_name):
-        if versions.rhel.is_centos():
-            rules += [
-                # https://github.com/ComplianceAsCode/content/issues/8480
-                'ensure_redhat_gpgkey_installed',
-            ]
-
     # Host hardenings
     if versions.rhel == 7 and re.fullmatch('/hardening/host-os/.*', test_name):
         rules += [

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -62,6 +62,7 @@
 /hardening/.+/ensure_gpgcheck_local_packages
 /hardening/.+/ensure_gpgcheck_never_disabled
 /hardening/.+/ensure_gpgcheck_repo_metadata
+/hardening/.+/ensure_redhat_gpgkey_installed
     Match(rhel.is_centos(), sometimes=True)
 # Presumably not valid for CentOS
 /hardening/.+/ospp/enable_fips_mode

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -58,14 +58,14 @@
 /hardening/host-os/.+/aide_use_fips_hashes
     rhel.is_centos()
 # Remediations are unselected for CentOS, but they might pass outside Testing Farm
-/hardening/host-os/.+/ensure_gpgcheck_globally_activated
-/hardening/host-os/.+/ensure_gpgcheck_local_packages
-/hardening/host-os/.+/ensure_gpgcheck_never_disabled
-/hardening/host-os/.+/ensure_gpgcheck_repo_metadata
+/hardening/.+/ensure_gpgcheck_globally_activated
+/hardening/.+/ensure_gpgcheck_local_packages
+/hardening/.+/ensure_gpgcheck_never_disabled
+/hardening/.+/ensure_gpgcheck_repo_metadata
     Match(rhel.is_centos(), sometimes=True)
 # Presumably not valid for CentOS
-/hardening/host-os/.+/ospp/enable_fips_mode
-/hardening/host-os/.*/ospp/configure_crypto_policy
+/hardening/.+/ospp/enable_fips_mode
+/hardening/.*/ospp/configure_crypto_policy
     rhel.is_centos() and rhel == 9
 
 # vim: syntax=python

--- a/lib/dnf.py
+++ b/lib/dnf.py
@@ -66,7 +66,8 @@ def _get_repos_dnf():
         # sanity check for (in)valid URLs as Anaconda fails on broken ones
         if baseurl.startswith(('http://', 'https://')):
             try:
-                reply = requests.head(baseurl, verify=False, allow_redirects=True)
+                repomd = baseurl.rstrip('/') + '/repodata/repomd.xml'
+                reply = requests.head(repomd, verify=False, allow_redirects=True)
                 reply.raise_for_status()
             except requests.exceptions.RequestException as e:
                 util.log(f"skipping: {e}")
@@ -129,6 +130,7 @@ def installable_url():
     Return one baseurl usable for installing the currently-running system.
     """
     for _, url in repo_urls():
+        url = url.rstrip('/')
         util.log(f"considering: {url}")
         reply = requests.head(url + '/images/install.img', verify=False)
         if reply.status_code == 200:

--- a/lib/dnf.py
+++ b/lib/dnf.py
@@ -47,6 +47,12 @@ def _get_repos_yum():
 # dnf up to dnf4
 def _get_repos_dnf():
     db = dnf.Base()
+    # black magic to make the dnf python API load /etc/dnf/dnf.conf
+    # and variables from /etc/dnf/vars/*, used by CentOS Stream to
+    # define $stream, used in metalinks
+    # source: https://bugzilla.redhat.com/show_bug.cgi?id=1920735#c2
+    db.conf.read(priority=dnf.conf.PRIO_MAINCONFIG)
+    db.conf.substitutions.update_from_etc(installroot=db.conf.installroot, varsdir=db.conf.varsdir)
     db.read_all_repos()
     for name, repo in db.repos.items():
         # no disabled repos

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -26,7 +26,7 @@ be used in two ways, both using a context manager ('g' is an instance):
      - Assumes (1) was done and just boots and waits for ssh.
 
 Any host yum.repos.d repositories are given to Anaconda via kickstart 'repo'
-upon guest installation. Only baseurl is supported for now, Fedora won't work.
+upon guest installation.
 
 Step (1) can be replaced by importing a pre-existing ImageBuilder image, with
 (2) and (3), or Guest() usage, remaining unaffected / compatible.
@@ -275,9 +275,12 @@ class Kickstart:
     def add_host_repos(self):
         installed_repos = []
         for reponame, config in dnf.repo_configs():
-            # TODO: repo --metalink support, don't assume baseurl exists
-            baseurl = config['baseurl']
-            self.appends.append(f'repo --name={reponame} --baseurl={baseurl}')
+            if 'metalink' in config:
+                metalink = config['metalink']
+                self.appends.append(f'repo --name={reponame} --metalink={metalink}')
+            else:
+                baseurl = config['baseurl']
+                self.appends.append(f'repo --name={reponame} --baseurl={baseurl}')
             installed_repos.append(
                 f'cat > /etc/yum.repos.d/{reponame}.repo <<\'EOF\'\n' +
                 f'[{reponame}]\n' +


### PR DESCRIPTION
This adds a series of commits that make it possible to run VM-enabled tests on CentOS Stream, mainly metalink support.

There will probably be more changes needed, but this at least makes the tests run, see ie. https://artifacts.dev.testing-farm.io/ddebc218-17f8-4bf1-9215-1b9ace186ce9/ (the random Artemis errors are still under investigation, they don't seem to be there if only 1-2 TMT plans are running.

I've run these changes through current CaC/content CI pipeline and it passed, so it doesn't seem to cause regressions there at least.