### PR TITLE
Add `/static-checks/diff` tests, for datastream diffing

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -12,19 +12,23 @@ if user_content:
     user_content = Path(user_content)
 
 
+def find_datastream_in(root):
+    base_dir = root / Path('usr/share/xml/scap/ssg/content')
+    if rhel.is_true_rhel():
+        return base_dir / f'ssg-rhel{rhel.major}-ds.xml'
+    elif rhel.is_centos():
+        if rhel <= 8:
+            return base_dir / f'ssg-centos{rhel.major}-ds.xml'
+        else:
+            return base_dir / f'ssg-cs{rhel.major}-ds.xml'
+
+
 def get_datastream():
     if user_content:
         build_content(user_content)
         datastream = user_content / 'build' / f'ssg-rhel{rhel.major}-ds.xml'
     else:
-        base_dir = Path('/usr/share/xml/scap/ssg/content')
-        if rhel.is_true_rhel():
-            datastream = base_dir / f'ssg-rhel{rhel.major}-ds.xml'
-        elif rhel.is_centos():
-            if rhel <= 8:
-                datastream = base_dir / f'ssg-centos{rhel.major}-ds.xml'
-            else:
-                datastream = base_dir / f'ssg-cs{rhel.major}-ds.xml'
+        datastream = find_datastream_in('/')
     if not datastream.exists():
         raise RuntimeError(f"could not find datastream as {datastream}")
     return datastream

--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -81,13 +81,17 @@ def build_content(path):
 
 
 @contextlib.contextmanager
-def get_content():
+def get_content(build=True):
     """
     Acquire and return a path to a fully built content source,
     from either a user-provided directory or a SRPM.
+
+    Optionally, specify build=False to save some time if you're accessing
+    plain files or executing utils and need just the content source.
     """
     if user_content:
-        build_content(user_content)
+        if build:
+            build_content(user_content)
         yield user_content
     else:
         # fall back to SRPM
@@ -112,8 +116,7 @@ def get_content():
                 if not extracted.exists():
                     raise FileNotFoundError(f"{extracted} not in extracted/patched SRPM")
                 # build content
-                # TODO: temporary, see https://github.com/ComplianceAsCode/content/pull/11606
-                (extracted / 'build').mkdir(exist_ok=True)
-                cmd = ['./build_product', f'rhel{rhel.major}']
-                util.subprocess_run(cmd, check=True, cwd=extracted)
+                if build:
+                    cmd = ['./build_product', f'rhel{rhel.major}']
+                    util.subprocess_run(cmd, check=True, cwd=extracted)
                 yield extracted

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -76,7 +76,7 @@ if test_basename == 'from-env':
         raise RuntimeError("RULE env variable not defined or empty")
 else:
     our_rules = slice_list(
-        oscap.get_all_profiles_rules(),
+        sorted(oscap.global_ds().get_all_profiles_rules()),
         int(os.environ['SLICE']),
         int(os.environ['TOTAL_SLICES'])
     )

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -28,7 +28,7 @@ srv.add_file('remediation-ds.xml')
 with srv:
     g.install(kickstart=ks)
 
-with g.booted(), util.get_content() as content_dir:
+with g.booted(), util.get_content(build=False) as content_dir:
     g.copy_to(util.get_datastream(), 'ssg-ds.xml')
     shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
     g.copy_from('ssg-report.html')

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -37,7 +37,7 @@ with g.snapshotted():
         raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()
 
-    with util.get_content() as content_dir:
+    with util.get_content(build=False) as content_dir:
         g.copy_to(util.get_datastream(), 'ssg-ds.xml')
         shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
         g.copy_from('ssg-report.html')

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -29,7 +29,7 @@ with g.snapshotted():
             raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
         g.soft_reboot()
 
-    with util.get_content() as content_dir:
+    with util.get_content(build=False) as content_dir:
         g.copy_to(util.get_datastream(), 'ssg-ds.xml')
         shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
         g.copy_from('ssg-report.html')

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -1,0 +1,30 @@
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 10m
+tag:
+  - NoProductization
+adjust:
+  - when: distro == rhel-7
+    enabled: false
+    because: the code is not compatible with RHEL-7
+
+/profiles:
+    summary: Diff datastreams, output added/removed profiles
+    test: python3 -m lib.runtest ./profiles.py
+
+/profile-titles:
+    summary: Diff datastreams, output profile title differences
+    test: python3 -m lib.runtest ./profile-titles.py
+
+/profile-rules:
+    summary: Diff datastreams, output profile rule/variable differences
+    test: python3 -m lib.runtest ./profile-rules.py
+
+/profile-variables:
+    summary: Diff datastreams, output profile variable refine differences
+    test: python3 -m lib.runtest ./profile-variables.py
+
+/removed-rules:
+    summary: Diff datastreams, check that no rule has been removed
+    test: python3 -m lib.runtest ./removed-rules.py

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -2,8 +2,6 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 10m
-tag:
-  - NoProductization
 adjust:
   - when: distro == rhel-7
     enabled: false
@@ -12,18 +10,22 @@ adjust:
 /profiles:
     summary: Diff datastreams, output added/removed profiles
     test: python3 -m lib.runtest ./profiles.py
+    tag: [NoProductization]
 
 /profile-titles:
     summary: Diff datastreams, output profile title differences
     test: python3 -m lib.runtest ./profile-titles.py
+    tag: [NoProductization]
 
 /profile-rules:
     summary: Diff datastreams, output profile rule/variable differences
     test: python3 -m lib.runtest ./profile-rules.py
+    tag: [NoProductization]
 
 /profile-variables:
     summary: Diff datastreams, output profile variable refine differences
     test: python3 -m lib.runtest ./profile-variables.py
+    tag: [NoProductization]
 
 /removed-rules:
     summary: Diff datastreams, check that no rule has been removed

--- a/static-checks/diff/profile-rules.py
+++ b/static-checks/diff/profile-rules.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+
+import shared
+from lib import results, oscap
+
+new = oscap.global_ds()
+
+with shared.get_old_datastream() as old_xml:
+    old = oscap.Datastream(old_xml)
+
+    common_profiles = set(new.profiles).intersection(old.profiles)
+
+    for profile in sorted(common_profiles):
+        old_rules = set(old.profiles[profile].rules)
+        new_rules = set(new.profiles[profile].rules)
+        for rule in sorted(old_rules - new_rules):
+            results.report('fail', f'{profile}/-{rule}')
+        for rule in sorted(new_rules - old_rules):
+            results.report('fail', f'{profile}/+{rule}')
+
+results.report_and_exit()

--- a/static-checks/diff/profile-titles.py
+++ b/static-checks/diff/profile-titles.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import shared
+from lib import results, oscap
+
+new = oscap.global_ds()
+
+with shared.get_old_datastream() as old_xml:
+    old = oscap.Datastream(old_xml)
+
+    common_profiles = set(new.profiles).intersection(old.profiles)
+
+    for profile in sorted(common_profiles):
+        old_title = old.profiles[profile].title
+        new_title = new.profiles[profile].title
+        if old_title != new_title:
+            results.report('fail', f'{profile}/-{old_title}')
+            results.report('fail', f'{profile}/+{new_title}')
+
+results.report_and_exit()

--- a/static-checks/diff/profile-variables.py
+++ b/static-checks/diff/profile-variables.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import shared
+from lib import results, oscap
+
+new = oscap.global_ds()
+
+with shared.get_old_datastream() as old_xml:
+    old = oscap.Datastream(old_xml)
+
+    common_profiles = set(new.profiles).intersection(old.profiles)
+
+    for profile in sorted(common_profiles):
+        # [ ('+', 'some_var', 'value') , ('-', 'another_var', 'value') , ... ]
+        added_removed = []
+
+        old_vars = old.profiles[profile].values
+        new_vars = new.profiles[profile].values
+        for var in old_vars - new_vars:
+            name, value = var
+            added_removed.append(('-', name, value))
+        for var in new_vars - old_vars:
+            name, value = var
+            added_removed.append(('+', name, value))
+
+        for sign, name, value in sorted(added_removed, key=lambda x: x[1]):
+            results.report('fail', f'{profile}/{sign}{name}={value}')
+
+results.report_and_exit()

--- a/static-checks/diff/profiles.py
+++ b/static-checks/diff/profiles.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python3
+
+import shared
+from lib import results, oscap
+
+new = oscap.global_ds()
+
+with shared.get_old_datastream() as old_xml:
+    old = oscap.Datastream(old_xml)
+    old_profiles = set(old.profiles)
+    new_profiles = set(new.profiles)
+
+    for profile in sorted(old_profiles - new_profiles):
+        results.report('fail', f'-{profile}')
+    for profile in sorted(new_profiles - old_profiles):
+        results.report('fail', f'+{profile}')
+
+results.report_and_exit()

--- a/static-checks/diff/removed-rules.py
+++ b/static-checks/diff/removed-rules.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+import shared
+from lib import results, oscap
+
+new = oscap.global_ds()
+
+with shared.get_old_datastream() as old_xml:
+    old = oscap.Datastream(old_xml)
+
+    for rule in sorted(set(old.rules) - set(new.rules)):
+        results.report('fail', rule)
+
+results.report_and_exit()

--- a/static-checks/diff/shared.py
+++ b/static-checks/diff/shared.py
@@ -1,0 +1,79 @@
+import subprocess
+import functools
+import contextlib
+import rpm
+
+from lib import util, dnf
+
+
+@contextlib.contextmanager
+def _downloaded_extracted_ds(version):
+    with dnf.download_rpm(f'scap-security-guide-{version}') as rpm:
+        with dnf.extract_rpm(rpm) as extracted:
+            datastream = util.find_datastream_in(extracted)
+            if not datastream.exists():
+                raise RuntimeError(f"could not find datastream as {datastream}")
+            yield datastream
+
+
+def _installed_ssg_version():
+    cmd = ['rpm', '-q', '--qf', '%{VERSION}-%{RELEASE}', 'scap-security-guide']
+    ret = util.subprocess_run(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+    if ret.returncode != 0:
+        util.log(f"rpm: {ret.stdout}")
+        ret.check_returncode()
+    return ret.stdout
+
+
+def _available_ssg_versions():
+    cmd = [
+        'dnf', '-q', 'repoquery', '--available', '--arch', 'noarch',
+        '--qf', '%{VERSION}-%{RELEASE}', 'scap-security-guide',
+    ]
+    ret = util.subprocess_run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
+    versions = ret.stdout.rstrip('\n').split('\n')
+    # sort from newest to oldest
+    versions.sort(key=functools.cmp_to_key(rpm.labelCompare), reverse=True)
+    return versions
+
+
+@contextlib.contextmanager
+def get_old_datastream():
+    # installed SSG with datastream in /usr/share/xml
+    installed = _installed_ssg_version()
+    root_datastream = util.find_datastream_in('/')
+    if not root_datastream.exists():
+        raise RuntimeError("DS not found on {root_datastream}, no clue what to diff")
+
+    # "new" content is CONTEST_CONTENT,
+    # "old" is the installed scap-security-guide RPM
+    if util.user_content:
+        yield root_datastream
+#        # if scap-security-guide RPM is installed and datastream exists
+#        if root_datastream.exists():
+#            util.log("using new from CONTEST_CONTENT, old from installed SSG RPM")
+#            yield root_datastream
+#        else:
+#            with _downloaded_extracted_ds() as ds:
+#                util.log("using new from CONTEST_CONTENT, old from downloaded+compiled SSG RPM")
+#                yield ds
+
+    # "new" is the installed scap-security-guide RPM,
+    # "old" is an older version available in YUM/DNF repositories
+    else:
+        available = _available_ssg_versions()
+        if not available:
+            raise RuntimeError("found no available SSG RPM versions in YUM/DNF repositories")
+        if installed != available[0]:
+            raise RuntimeError(
+                f"installed SSG {installed} is not the latest available ({available[0]})"
+            )
+        if len(available) < 2:
+            raise RuntimeError(
+                f"repoquery returned only 1 (currently installed) SSG version ({available[0]}), "
+                "no clue what to use as 'old'"
+            )
+        old = available[1]
+        with _downloaded_extracted_ds(old) as ds:
+            util.log("using new from installed SSG RPM, old from previous SSG RPM")
+            yield ds


### PR DESCRIPTION
(Go commit-by-commit, there are two somewhat unrelated commits at the start.)

These tests always select old/new datastreams to compare:
* if `CONTEST_CONTENT*` was provided (when using Contest via tmt)
  * use `CONTEST_CONTENT` as new
  * use installed SSG RPM as old
* else (when using Contest via `wow` and `--brew-task`)
  * use installed SSG RPM as new
  * find + download + extract and older SSG RPM version from dnf repositories, use it as old

They always report differences as `fail` results, to show up for human review.

The idea is to run them once, in stabilization, and have a human go through the list of `fail`s in some system that allows commenting on them (TCMS / ReportPortal / etc.). This allows the human to "waive" the failures for that specific stabilization test run, without using static copies of content (a.k.a. "normatives").

As such, these tests should not be run anywhere else, as they would likely always fail and need human intervention. Thus the `NoProductization`.

(The exception is `removed-rules`, which should never fail.)

...
Note that the variable (`refine-value`) diffing groups the results by variable name, as it seemed more natural to have the old/new value for a variable next to each other.  
OTOH rule names are diffed as big `-` / `+` blocks, because it seemed more natural to see what was removed and what was added, rather than interleaving `-` / `+` and sorting it by rule name.