### PR TITLE
Add ansible testing to `/per-rule`

### DIFF
--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -46,111 +46,97 @@ tag:
     tag:
       - NoProductization
       - NoStabilization
-    extra-summary: /CoreOS/scap-security-guide/per-rule/from-env
-    extra-nitrate: TC#0617199
-    id: 237c1eaf-bf68-4eba-b097-6cc0222ca282
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env
+        extra-nitrate: TC#0617199
+        id: 237c1eaf-bf68-4eba-b097-6cc0222ca282
 
 /1:
-    environment+:
-        SLICE: 1
-    extra-summary: /CoreOS/scap-security-guide/per-rule/1
-    extra-nitrate: TC#0617184
-    id: ccef824b-20d1-4509-8bae-8553f67608db
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/1
+        extra-nitrate: TC#0617184
+        id: ccef824b-20d1-4509-8bae-8553f67608db
 
 /2:
-    environment+:
-        SLICE: 2
-    extra-summary: /CoreOS/scap-security-guide/per-rule/2
-    extra-nitrate: TC#0617191
-    id: b42e38dd-3b5d-4901-867e-1715eaf9aa95
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/2
+        extra-nitrate: TC#0617191
+        id: b42e38dd-3b5d-4901-867e-1715eaf9aa95
 
 /3:
-    environment+:
-        SLICE: 3
-    extra-summary: /CoreOS/scap-security-guide/per-rule/3
-    extra-nitrate: TC#0617192
-    id: 94e30407-823f-4c06-a47c-2c4bf8f1d356
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/3
+        extra-nitrate: TC#0617192
+        id: 94e30407-823f-4c06-a47c-2c4bf8f1d356
 
 /4:
-    environment+:
-        SLICE: 4
-    extra-summary: /CoreOS/scap-security-guide/per-rule/4
-    extra-nitrate: TC#0617193
-    id: 9c6f132b-ebbf-42cd-b914-ac3f8fa6aa90
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/4
+        extra-nitrate: TC#0617193
+        id: 9c6f132b-ebbf-42cd-b914-ac3f8fa6aa90
 
 /5:
-    environment+:
-        SLICE: 5
-    extra-summary: /CoreOS/scap-security-guide/per-rule/5
-    extra-nitrate: TC#0617194
-    id: bf193dd8-c102-4659-9935-45106f06dd0b
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/5
+        extra-nitrate: TC#0617194
+        id: bf193dd8-c102-4659-9935-45106f06dd0b
 
 /6:
-    environment+:
-        SLICE: 6
-    extra-summary: /CoreOS/scap-security-guide/per-rule/6
-    extra-nitrate: TC#0617195
-    id: 6adea628-3166-4b33-aa04-ab910ed997b2
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/6
+        extra-nitrate: TC#0617195
+        id: 6adea628-3166-4b33-aa04-ab910ed997b2
 
 /7:
-    environment+:
-        SLICE: 7
-    extra-summary: /CoreOS/scap-security-guide/per-rule/7
-    extra-nitrate: TC#0617196
-    id: fb780940-e9f7-4864-b4f7-6caabfdec066
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/7
+        extra-nitrate: TC#0617196
+        id: fb780940-e9f7-4864-b4f7-6caabfdec066
 
 /8:
-    environment+:
-        SLICE: 8
-    extra-summary: /CoreOS/scap-security-guide/per-rule/8
-    extra-nitrate: TC#0617197
-    id: 1bc5fcef-3e5a-43a8-b9de-532a87bad95b
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/8
+        extra-nitrate: TC#0617197
+        id: 1bc5fcef-3e5a-43a8-b9de-532a87bad95b
 
 /9:
-    environment+:
-        SLICE: 9
-    extra-summary: /CoreOS/scap-security-guide/per-rule/9
-    extra-nitrate: TC#0617198
-    id: c82b9968-e5b9-4570-b04b-f11d9565c234
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/9
+        extra-nitrate: TC#0617198
+        id: c82b9968-e5b9-4570-b04b-f11d9565c234
 
 /10:
-    environment+:
-        SLICE: 10
-    extra-summary: /CoreOS/scap-security-guide/per-rule/10
-    extra-nitrate: TC#0617185
-    id: d6b4651f-43c9-4836-9ddd-9b426f753b77
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/10
+        extra-nitrate: TC#0617185
+        id: d6b4651f-43c9-4836-9ddd-9b426f753b77
 
 /11:
-    environment+:
-        SLICE: 11
-    extra-summary: /CoreOS/scap-security-guide/per-rule/11
-    extra-nitrate: TC#0617186
-    id: 3c58f725-0e34-4a53-9b47-653d47c7e49a
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/11
+        extra-nitrate: TC#0617186
+        id: 3c58f725-0e34-4a53-9b47-653d47c7e49a
 
 /12:
-    environment+:
-        SLICE: 12
-    extra-summary: /CoreOS/scap-security-guide/per-rule/12
-    extra-nitrate: TC#0617187
-    id: 7c90efc8-59b5-4d45-b8ed-ca381b106fcb
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/12
+        extra-nitrate: TC#0617187
+        id: 7c90efc8-59b5-4d45-b8ed-ca381b106fcb
 
 /13:
-    environment+:
-        SLICE: 13
-    extra-summary: /CoreOS/scap-security-guide/per-rule/13
-    extra-nitrate: TC#0617188
-    id: 0f496d79-4fef-4338-8ca1-93fb21ed5d6f
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/13
+        extra-nitrate: TC#0617188
+        id: 0f496d79-4fef-4338-8ca1-93fb21ed5d6f
 
 /14:
-    environment+:
-        SLICE: 14
-    extra-summary: /CoreOS/scap-security-guide/per-rule/14
-    extra-nitrate: TC#0617189
-    id: 330f74dc-8851-4e45-b23a-0637037ace08
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/14
+        extra-nitrate: TC#0617189
+        id: 330f74dc-8851-4e45-b23a-0637037ace08
 
 /15:
-    environment+:
-        SLICE: 15
-    extra-summary: /CoreOS/scap-security-guide/per-rule/15
-    extra-nitrate: TC#0617190
-    id: 82cdc8da-bf6c-4996-8e72-bcb83cd85050
+    /oscap:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/15
+        extra-nitrate: TC#0617190
+        id: 82cdc8da-bf6c-4996-8e72-bcb83cd85050

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -47,96 +47,128 @@ tag:
       - NoProductization
       - NoStabilization
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env
+        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env/oscap
         extra-nitrate: TC#0617199
         id: 237c1eaf-bf68-4eba-b097-6cc0222ca282
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env/ansible
 
 /1:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/1
+        extra-summary: /CoreOS/scap-security-guide/per-rule/1/oscap
         extra-nitrate: TC#0617184
         id: ccef824b-20d1-4509-8bae-8553f67608db
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/1/ansible
 
 /2:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/2
+        extra-summary: /CoreOS/scap-security-guide/per-rule/2/oscap
         extra-nitrate: TC#0617191
         id: b42e38dd-3b5d-4901-867e-1715eaf9aa95
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/2/ansible
 
 /3:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/3
+        extra-summary: /CoreOS/scap-security-guide/per-rule/3/oscap
         extra-nitrate: TC#0617192
         id: 94e30407-823f-4c06-a47c-2c4bf8f1d356
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/3/ansible
 
 /4:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/4
+        extra-summary: /CoreOS/scap-security-guide/per-rule/4/oscap
         extra-nitrate: TC#0617193
         id: 9c6f132b-ebbf-42cd-b914-ac3f8fa6aa90
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/4/ansible
 
 /5:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/5
+        extra-summary: /CoreOS/scap-security-guide/per-rule/5/oscap
         extra-nitrate: TC#0617194
         id: bf193dd8-c102-4659-9935-45106f06dd0b
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/5/ansible
 
 /6:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/6
+        extra-summary: /CoreOS/scap-security-guide/per-rule/6/oscap
         extra-nitrate: TC#0617195
         id: 6adea628-3166-4b33-aa04-ab910ed997b2
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/6/ansible
 
 /7:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/7
+        extra-summary: /CoreOS/scap-security-guide/per-rule/7/oscap
         extra-nitrate: TC#0617196
         id: fb780940-e9f7-4864-b4f7-6caabfdec066
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/7/ansible
 
 /8:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/8
+        extra-summary: /CoreOS/scap-security-guide/per-rule/8/oscap
         extra-nitrate: TC#0617197
         id: 1bc5fcef-3e5a-43a8-b9de-532a87bad95b
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/8/ansible
 
 /9:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/9
+        extra-summary: /CoreOS/scap-security-guide/per-rule/9/oscap
         extra-nitrate: TC#0617198
         id: c82b9968-e5b9-4570-b04b-f11d9565c234
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/9/ansible
 
 /10:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/10
+        extra-summary: /CoreOS/scap-security-guide/per-rule/10/oscap
         extra-nitrate: TC#0617185
         id: d6b4651f-43c9-4836-9ddd-9b426f753b77
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/10/ansible
 
 /11:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/11
+        extra-summary: /CoreOS/scap-security-guide/per-rule/11/oscap
         extra-nitrate: TC#0617186
         id: 3c58f725-0e34-4a53-9b47-653d47c7e49a
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/11/ansible
 
 /12:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/12
+        extra-summary: /CoreOS/scap-security-guide/per-rule/12/oscap
         extra-nitrate: TC#0617187
         id: 7c90efc8-59b5-4d45-b8ed-ca381b106fcb
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/12/ansible
 
 /13:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/13
+        extra-summary: /CoreOS/scap-security-guide/per-rule/13/oscap
         extra-nitrate: TC#0617188
         id: 0f496d79-4fef-4338-8ca1-93fb21ed5d6f
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/13/ansible
 
 /14:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/14
+        extra-summary: /CoreOS/scap-security-guide/per-rule/14/oscap
         extra-nitrate: TC#0617189
         id: 330f74dc-8851-4e45-b23a-0637037ace08
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/14/ansible
 
 /15:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/15
+        extra-summary: /CoreOS/scap-security-guide/per-rule/15/oscap
         extra-nitrate: TC#0617190
         id: 82cdc8da-bf6c-4996-8e72-bcb83cd85050
+    /ansible:
+        extra-summary: /CoreOS/scap-security-guide/per-rule/15/ansible

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -67,7 +67,8 @@ def report_test_with_log(status, note, log_dir, rule_name, test_name):
 
 virt.Host.setup()
 
-test_basename = util.get_test_name().rsplit('/', 1)[1]
+# /per-rule/from-env/oscap --> test_basename=from-env, fix_type=oscap
+test_basename, fix_type = util.get_test_name().rsplit('/')[-2:]
 if test_basename == 'from-env':
     our_rules = os.environ.get('RULE')
     if our_rules:
@@ -77,7 +78,7 @@ if test_basename == 'from-env':
 else:
     our_rules = slice_list(
         sorted(oscap.global_ds().get_all_profiles_rules()),
-        int(os.environ['SLICE']),
+        int(test_basename),
         int(os.environ['TOTAL_SLICES'])
     )
 
@@ -98,6 +99,7 @@ with util.get_content() as content_dir, g.booted():
         './automatus.py', 'rule',
         '--libvirt', 'qemu:///system', virt.GUEST_NAME,
         '--product', f'rhel{versions.rhel.major}',
+        '--remediate-using', fix_type,
         *our_rules,
     ]
     _, lines = util.subprocess_stream(

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -85,12 +85,14 @@ else:
 our_rules_textblock = textwrap.indent(('\n'.join(our_rules)), '    ')
 util.log(f"testing rules:\n{our_rules_textblock}")
 
-g = virt.Guest()
+# tag named after the tool that modifies the VM/image
+g = virt.Guest('automatus')
 
-# install a qcow2-backed VM, so automatus.py can snapshot it
-# - use hardening-style partitions, automatus tests need them
-ks = virt.Kickstart(partitions=partitions.partitions)
-g.install(kickstart=ks, disk_format='qcow2')
+if not g.is_installed():
+    # install a qcow2-backed VM, so automatus.py can snapshot it
+    # - use hardening-style partitions, automatus tests need them
+    ks = virt.Kickstart(partitions=partitions.partitions)
+    g.install(kickstart=ks, disk_format='qcow2')
 
 with util.get_content() as content_dir, g.booted():
     env = os.environ.copy()


### PR DESCRIPTION
This (in several commits) splits the `/per-rule` tests into `oscap` and `ansible`, to match the `--remediate-using` argument of `automatus.py`.

The split is done on the FMF metadata level to make all these inherit `max1` and run in parallel - the thought is that Beaker jobs will spread themselves out much more evenly than when running `oscap`+`ansible` in one test, on one system.

OTOH `/per-rule/from-env` is likely intended to be run on a single system for both `oscap` and `ansible`, so I've added a re-use logic to `lib.virt` for non-snapshotted (meaning not snapshotted by Contest) logic for VMs, avoiding the second VM install, relying on `automatus.py` to use `qcow2`-internal snapshots.

Nitrate (TCMS) export to be done after PR merge.