### PR TITLE
Remove waivers for firewalld_loopback_traffic rules

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -17,9 +17,6 @@
 /hardening/anaconda(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
 # https://github.com/ComplianceAsCode/content/issues/11625
 /hardening/image-builder(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
-# https://github.com/ComplianceAsCode/content/issues/10939
-# https://github.com/ComplianceAsCode/content/issues/10613
-/hardening/anaconda(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
 # https://github.com/ComplianceAsCode/content/issues/11564
 /hardening/image-builder(/with-gui)?/[^/]+/firewalld_loopback_traffic_(restricted|trusted)
     rhel >= 8


### PR DESCRIPTION
Remove the waivers for firewalld_loopback_traffic_trusted rules in Anaconda tests after the
https://github.com/ComplianceAsCode/content/pull/11868