### PR TITLE
pass all 3 arguments to rpm.labelCompare in `/static-checks/diff`

### DIFF
--- a/static-checks/diff/shared.py
+++ b/static-checks/diff/shared.py
@@ -32,9 +32,12 @@ def _available_ssg_versions():
     ]
     ret = util.subprocess_run(cmd, check=True, stdout=subprocess.PIPE, universal_newlines=True)
     versions = ret.stdout.rstrip('\n').split('\n')
+    # transform a list of NVRs to (name, version, release) tuples,
+    # older rpm.labelCompare requires it
+    versions = ((None, x, None) for x in versions)
     # sort from newest to oldest
-    versions.sort(key=functools.cmp_to_key(rpm.labelCompare), reverse=True)
-    return versions
+    ordered = sorted(versions, key=functools.cmp_to_key(rpm.labelCompare), reverse=True)
+    return [version for _, version, _ in ordered]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Tested on RHEL-8 and RHEL-9:
```
>>> _available_ssg_versions()
['0.1.72-2.el8_9']
```
```
>>> _available_ssg_versions()
['0.1.72-1.el9_3']
```