### PR TITLE
waive disa misalignment test involving login_session_timeout rule

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -129,5 +129,8 @@
 # https://github.com/ComplianceAsCode/content/issues/11548 (DISA is stricter than us)
 /scanning/disa-alignment/.*/accounts_tmout
     True
+# the feature used in this stigid is not ported to 9.0
+/scanning/disa-alignment/.*/CCE-90785-7
+    rhel == 9.0
 
 # vim: syntax=python


### PR DESCRIPTION
the inapplicability of the rule on RHEL 9.0 is deliberate. The underlying feature is not present there. DISA should change their rule or the feature should be ported.