### PR TITLE
Remove error IB waiver.

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -91,11 +91,6 @@
 
 # Image Builder
 #
-# ignore errors for now, until 'openscap generate fix' syntax stabilizes
-# and blocker bugs are resolved
-/hardening/image-builder/.+
-    Match(rhel == 8 and status == 'error', sometimes=True)
-
 # https://issues.redhat.com/browse/RHEL-24246
 # qcow2 images have broken network with Server-like package sets
 /hardening/image-builder/with-gui/.+

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -94,7 +94,7 @@
 # https://issues.redhat.com/browse/RHEL-24246
 # qcow2 images have broken network with Server-like package sets
 /hardening/image-builder/with-gui/.+
-    rhel == 9 and status == 'error'
+    status == 'error'
 
 # https://github.com/ComplianceAsCode/content/issues/11565
 /hardening/image-builder/.*/audit_rules_privileged_commands


### PR DESCRIPTION
Our tests should use latest available openscap build where blueprint is properly generated with openscap section.