### PR TITLE
waive DISA misalignment regarding logind_session_timeout in RHEL 8

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -133,5 +133,8 @@
 # https://github.com/ComplianceAsCode/content/issues/11937
 /scanning/disa-alignment/.*/accounts_umask_etc_bashrc
     rhel == 9
+# the feature used by this rule is not available in RHEL 9.0 or <= 8.6
+/scanning/disa-alignment/.*/logind_session_timeout
+    rhel == 9.0 or rhel <= 8.6
 
 # vim: syntax=python


### PR DESCRIPTION
the feature is available since 8.7.
check the platform in the rule logind_session_timeout