### PR TITLE
Add the ospp version of the existing waviers for IB on mount_option_mount_option_nodev_nonroot_local_partitions

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -173,6 +173,7 @@
 # TODO: file issues ?
 /hardening/image-builder/stig/mount_option_nodev_nonroot_local_partitions
 /hardening/image-builder/anssi_bp28_high/mount_option_nodev_nonroot_local_partitions
+/hardening/image-builder/ospp/mount_option_nodev_nonroot_local_partitions
 /hardening/image-builder/anssi_bp28_high/mount_option_tmp_noexec
 /hardening/image-builder/anssi_bp28_high/sebool_polyinstantiation_enabled
     True


### PR DESCRIPTION
This matches the waivers in this section. 

Caused by #181 