### PR TITLE
make sometimes=True the default for waivers

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -9,7 +9,7 @@
 #  - seems to not happen on latest 8.9 nightlies ??
 #  - on latest 7.9, but upstream 2023/05 content
 /hardening/oscap/[^/]+/package_rear_installed
-    Match(rhel <= 8, sometimes=True)
+    rhel <= 8
 
 # ssh either doesn't start up, or gets blocked, possibly related
 # to new firewalld rules being added?
@@ -31,7 +31,7 @@
 /hardening/oscap/with-gui/.+/aide_scan_notification
 /hardening/oscap/with-gui/.+/aide_verify_acls
 /hardening/oscap/with-gui/.+/aide_verify_ext_attributes
-    Match(True, sometimes=True)
+    True
 
 # seems RHEL-8 specific, unknown, TODO investigate
 # remediation script says:
@@ -42,7 +42,7 @@
 #   Unable to enable feature [22]: Invalid argument
 # maybe hardware-specific and our Beaker systems don't have the hardware?
 /hardening/host-os/oscap/.+/sssd_enable_smartcards
-    Match(rhel == 8, sometimes=True)
+    rhel == 8
 
 # Ansible TODO: completely unknown, investigate and sort
 #
@@ -68,24 +68,24 @@
     rhel == 7
 # unknown as well, but happens only rarely
 /hardening/ansible/.+/configure_bashrc_exec_tmux
-    Match(True, sometimes=True)
+    True
 # only pci-dss, passes everywhere else
 /hardening/ansible(/with-gui)?/pci-dss/audit_rules_login_events
     rhel == 8 or rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/11752
 /hardening(/host-os)?/ansible/.+/audit_rules_privileged_commands
-    Match(rhel == 8 or rhel == 9, sometimes=True)
+    rhel == 8 or rhel == 9
 
 # home_nosuid failures are just really random across RHEL versions and nightlies
 /hardening/ansible/.+/mount_option_home_nosuid
-    Match(True, sometimes=True)
+    True
 
 # https://github.com/ComplianceAsCode/content/issues/10901
 # not sure what enables the service, but second remediation fixes the problem
 # TODO: we do run double remediation, but this still sometimes fails,
 #       investigate why
 /hardening/anaconda/with-gui/[^/]+/service_rpcbind_disabled
-    Match(rhel == 8, sometimes=True)
+    rhel == 8
 
 # /per-rule (Automatus rule mode) waivers
 #
@@ -134,7 +134,7 @@
 # TODO: unknown, probably worth investigating
 /hardening/host-os/oscap/.+/sysctl_net_ipv6_conf_(all|default)_accept_ra
 /hardening/host-os/oscap/.+/sysctl_net_ipv4_conf_default_log_martians
-    Match(True, sometimes=True)
+    True
 
 # DISA Alignment waivers
 #

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -30,14 +30,14 @@
 /hardening/anaconda(/with-gui)?/[^/]+/postfix_network_listening_disabled
 # https://github.com/ComplianceAsCode/content/issues/10938
 /hardening/host-os/oscap/[^/]+/postfix_network_listening_disabled
-    Match(rhel == 7, sometimes=True)
+    rhel == 7
 
 # caused by one of:
 # - bz1778661 (abrt)
 # - bz2209266 (RHEL-9 gdm)
 # - bz2209294 (RHEL-7 gdm, different issue)
 /hardening/.+/rpm_verify_(ownership|permissions)
-    Match(True, sometimes=True)
+    True
 
 # bz1825810 or maybe bz1929805
 # can be reproduced mostly reliably (95%) both via anaconda and oscap CLI,
@@ -48,20 +48,20 @@
 # and afterwards on other profiles (anssi_bp28_high), but still
 # only on GUI
 /hardening/[^/]+/with-gui/[^/]+/sysctl_net_ipv4_ip_forward
-    Match(rhel <= 8, sometimes=True)
+    rhel <= 8
 
 # https://github.com/ComplianceAsCode/content/issues/10424
 # happens on host-os hardening too, probably because Beaker doesn't have
 # firewall enabled or even installed
 /hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
 /hardening/host-os/oscap/[^/]+/service_nftables_disabled
-    Match(True, sometimes=True)
+    True
 
 # caused by us not caring whether the VM has it installed,
 # - remediation should fix it, but doesn't -- possibly caused by
 #   https://github.com/RHSecurityCompliance/contest/issues/15
 /hardening/oscap(/with-gui)?/[^/]+/package_scap-security-guide_installed
-    Match(True, sometimes=True)
+    True
 
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
@@ -82,7 +82,7 @@
 # https://issues.redhat.com/browse/OPENSCAP-3321
 # seems to be happening much more reliably with GUI
 /hardening/anaconda/with-gui/cis_workstation_l[12]
-    Match(status == 'error', sometimes=True)
+    status == 'error'
 
 # visible on double reboot (double remediation)
 # /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
@@ -132,7 +132,7 @@
     rhel == 9.0
 # https://github.com/ComplianceAsCode/content/issues/11778 (issue on DISA side)
 /scanning/disa-alignment/.*/file_permission_user_init_files_root
-    Match(rhel == 9, sometimes=True)
+    rhel == 9
 # the feature used by the rule logind_session_timeout is not available in RHEL 9.0 or <= 8.6
 /scanning/disa-alignment/.*/CCE-90784-0
     rhel == 9.0 or rhel <= 8.6

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -5,13 +5,13 @@
 # remediation for this is globally disabled in Contest,
 # see conf/remediation.py
 /hardening/.*/accounts_password_set_max_life_(existing|root)
-    Match(True, sometimes=True)
+    True
 
 # the service_sssd_enabled will be failing even if the service is enabled
 # because it requires manual configuration which cannot be attained with our rules
 # note that there are cases when sssd can be started
 /hardening/.+/service_sssd_enabled
-    Match(True, sometimes=True)
+    True
 
 # Beaker-specific:
 # all Beaker repositories have gpgcheck=0 and they get copied to nested VMs too
@@ -19,14 +19,14 @@
 # we don't control partitions on the host OS
 /hardening/host-os/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit|tmp)_(noexec|nosuid|nodev|usrquota|grpquota)
 /hardening/host-os/.+/mount_option_boot_efi_nosuid
-    Match(True, sometimes=True)
+    True
 
 # Beaker-specific, possibly;
 # same for dnf-automatic and rsyslog (??), is this fully random?
 /hardening/host-os/oscap/[^/]+/package_dnf-automatic_installed
 /hardening/host-os/oscap/[^/]+/timer_dnf-automatic_enabled
 /hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
-    Match(rhel >= 8, sometimes=True)
+    rhel >= 8
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1797653 WONTFIX
 /scanning/oscap-eval/ERROR
@@ -38,7 +38,7 @@
 # harmless (expiration is not MITM) while being the biggest contributor
 # to false positives, so just ignore them, avoiding frequent random fails
 /static-checks/html-links/.+
-    Match("failed: certificate has expired" in note, sometimes=True)
+    "failed: certificate has expired" in note
 # Inaccessible until form is filled:
 /static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
     True
@@ -48,7 +48,7 @@
 # DISA benchmark allows only released OS versions. Our content is fine with unreleased versions.
 # https://github.com/ComplianceAsCode/content/issues/11649
 /scanning/disa-alignment/.*/installed_OS_is_vendor_supported
-    Match(True, sometimes=True)
+    True
 
 # CentOS-specific waivers
 #
@@ -64,7 +64,7 @@
 /hardening/.+/ensure_gpgcheck_never_disabled
 /hardening/.+/ensure_gpgcheck_repo_metadata
 /hardening/.+/ensure_redhat_gpgkey_installed
-    Match(rhel.is_centos(), sometimes=True)
+    rhel.is_centos()
 # Presumably not valid for CentOS
 /hardening/.+/ospp/enable_fips_mode
 /hardening/.*/ospp/configure_crypto_policy

--- a/docs/WAIVERS.md
+++ b/docs/WAIVERS.md
@@ -140,13 +140,14 @@ returning `False` if the RPM is not installed.
 ### Expecting both `pass` and `fail`/`error`
 
 Sometimes, failures or errors are not reliable and happen only occassionally.
-This means a waive section might be throwing a lot of "unexpected pass" failures
-and be rendered useless.
+This is why waivers are "permissive" by default - they only waive
+`fail`/`error`, but allow `pass` to pass through, only noting `waived pass`
+in the result note.
 
-To fix this, pass `sometimes=True` to `Match()`, which tells the waiving code
-to do nothing if there's a match for a `pass` status.
+To override this, pass `strict=True` to `Match()`, which tells the waiving code
+to trigger a waive failure when the waiver matches `pass`.
 
 ```python
 /some/result/name
-    Match(rhel >= 8, sometimes=True)
+    Match(rhel >= 8, strict=True)
 ```

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -159,10 +159,12 @@ class Match:
     """
     A True/False result with additional metadata, returned from
     custom waiving format and its python code blocks.
+
+    Use 'strict=True' to fail when the waiver matches on 'pass'.
     """
-    def __init__(self, matches, *, sometimes=False):
+    def __init__(self, matches, *, strict=False):
         self.matches = matches
-        self.sometimes = sometimes
+        self.strict = strict
 
     def __bool__(self):
         return self.matches
@@ -230,10 +232,10 @@ def rewrite_result(status, name, note, new_status='warn'):
         return f'({text}) {note}' if note else text
 
     if status == 'pass':
-        if matched.sometimes:
-            return (status, name, add_note(f"waived {status}"))
+        if matched.strict:
+            return ('fail', name, add_note("waive: expected fail/error, got pass"))
         else:
-            return ('error', name, add_note("waive: expected fail/error, got pass"))
+            return (status, name, add_note("waived pass"))
 
     # fail or error
     return (new_status, name, add_note(f"waived {status}"))


### PR DESCRIPTION
This should make testing in CaC/content PRs much easier, as it avoids the complex dependency chain of
* fix bug, file PR, have tests fail on "passed, expected fail"
* remove waiver in Contest, file PR, have it merged
* break all other CaC/content PRs by them now failing on the missing waiver
* quickly try to merge the CaC/content fix, so other PRs can depend on it

With everything permissive by default, this doesn't happen.

I also switched back `error` to `fail` in the case of `strict=True`, as it actually relates to the tested functionality (so `fail` is probably appropriate), and it avoids unnecessary re-runs.