### PR TITLE
abort lib.virt installation on kernel panic

### DIFF
--- a/lib/virt.py
+++ b/lib/virt.py
@@ -112,6 +112,8 @@ INSTALL_FAILURES = [
     br"Non interactive installation failed",
     # RHEL-7 ignores inst.noninteractive
     br"Please respond ",
+    # Anaconda died due to oscap crashing (or other reasons)
+    br"Kernel panic - not syncing",
 ]
 
 PIPE = subprocess.PIPE


### PR DESCRIPTION
I ran into this when `oscap` froze, I killed it via SSH (expecting the test to abort & retry via `runcontest`), but it treated the VM as successfully installed, waiting for SSH.