### PR TITLE
Waive sshd_use_approved_ciphers

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -128,7 +128,7 @@
 /per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value.pass
 /per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value_full.pass
 /per-rule/.+/oscap/sshd_use_approved_ciphers/correct_variable.pass
-
+    rhel == 9
 # likely something caused by restraint / Beaker test env
 # TODO: investigate
 /hardening/host-os/.+/file_permissions_unauthorized_world_writable

--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -122,6 +122,12 @@
 /per-rule/.+/package_ypserv_removed/package-installed.fail
 /per-rule/.+/service_telnet_disabled/service_disabled.pass
     rhel == 9
+# https://github.com/ComplianceAsCode/content/issues/12096
+/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_reduced_list.pass
+/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_scrambled.pass
+/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value.pass
+/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value_full.pass
+/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_variable.pass
 
 # likely something caused by restraint / Beaker test env
 # TODO: investigate


### PR DESCRIPTION
With the new productization model, these items also started to appear for a "Per Rule" test /per-rule/13/oscap/sshd_use_approved_ciphers/ which runs Automatus test.

See https://github.com/ComplianceAsCode/content/issues/12096