### PR TITLE
Move socket_systemd-journal-remote_disabled to long-term waivers.

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -84,10 +84,6 @@
 /hardening/anaconda/with-gui/[^/]+/service_rpcbind_disabled
     rhel == 8
 
-# https://github.com/ComplianceAsCode/content/issues/12097
-/hardening/anaconda(/with-gui)?/cis[^/]*/socket_systemd-journal-remote_disabled
-    rhel == 9
-
 # /per-rule (Automatus rule mode) waivers
 #
 # TODO: all of these are unknown and need investigation

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -51,7 +51,9 @@
 
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
+# https://issues.redhat.com/browse/RHEL-45706
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
+/hardening/anaconda(/with-gui)?/cis[^/]*/socket_systemd-journal-remote_disabled
     True
 
 # https://github.com/ComplianceAsCode/content/issues/11498


### PR DESCRIPTION
As it has been discovered it's old known OAA issue.

Make it applicable also on other RHEL versions as it's expected to fail everywhere.