### PR TITLE
remove /static-checks/html-links from the daily/weekly plans

### DIFF
--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -27,5 +27,8 @@ discover:
       # the rest is cheap to run
       - /scanning
       - /static-checks
+    exclude:
+      # frequently fails on transient issues, run it only in stabilization
+      - /static-checks/html-links
 
 # vim: syntax=yaml

--- a/plans/weekly.fmf
+++ b/plans/weekly.fmf
@@ -6,5 +6,8 @@ discover:
       - tag:-needs-param
       - tag:-always-fails
       - tag:-broken
+    exclude:
+      # frequently fails on transient issues, run it only in stabilization
+      - /static-checks/html-links
 
 # vim: syntax=yaml


### PR DESCRIPTION
The test frequently fails on issues that are typically resolved within a few days.

While a better solution would be able to detect long-term changes to links rather than just closing our eyes for daily/weekly runs, the exclude is a lot easier to implement and doesn't require a dedicated process.
