### PR TITLE
Build, find, and test Ansible per-rule playbooks

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -47,7 +47,17 @@ def _find_playbooks(root):
         build_content(user_content)
         return user_content / 'build' / 'ansible'
     else:
-        return root / Path('/usr/share/scap-security-guide/ansible')
+        return root / Path('usr/share/scap-security-guide/ansible')
+
+
+def _find_per_rule_playbooks(root):
+    if user_content:
+        build_content(user_content)
+        return user_content / 'build' / f'rhel{rhel.major}' / 'playbooks' / 'all'
+    else:
+        return root / Path(
+            f'usr/share/scap-security-guide/ansible/rule_playbooks/rhel{rhel.major}/all'
+        )
 
 
 def get_playbook(profile, root='/'):
@@ -65,9 +75,12 @@ def get_playbook(profile, root='/'):
 
 
 def iter_playbooks(root='/'):
-    for file in _find_playbooks(root).rglob('*'):
+    for file in _find_playbooks(root).iterdir():
         if file.suffix == '.yml':
             yield file
+    per_rule_dir = _find_per_rule_playbooks(root)
+    if per_rule_dir.exists():
+        yield from per_rule_dir.iterdir()
 
 
 def get_kickstart(profile):

--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -111,7 +111,7 @@ def build_content(path):
     cmd = ['dnf', '-y', 'builddep', '--spec', 'scap-security-guide.spec']
     util.subprocess_run(cmd, check=True, cwd=path)
     # build content
-    cmd = ['./build_product', f'rhel{rhel.major}']
+    cmd = ['./build_product', '--playbook-per-rule', f'rhel{rhel.major}']
     util.subprocess_run(cmd, check=True, cwd=path)
 
 
@@ -152,6 +152,6 @@ def get_content(build=True):
                     raise FileNotFoundError(f"{extracted} not in extracted/patched SRPM")
                 # build content
                 if build:
-                    cmd = ['./build_product', f'rhel{rhel.major}']
+                    cmd = ['./build_product', '--playbook-per-rule', f'rhel{rhel.major}']
                     util.subprocess_run(cmd, check=True, cwd=extracted)
                 yield extracted

--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -9,6 +9,7 @@ discover:
       # just some basic smoke testing that should never fail
       - /scanning/oscap-eval
       - /static-checks
+      - /static-checks/ansible/syntax-check
     exclude:
       # often fails on temporary retrieval issues
       - /static-checks/html-links


### PR DESCRIPTION
Per-rule playbooks, used by console dot are in different package and located in different path than profile playbooks shipped by scap-security-guide.
For built content:
Profile playbooks
```
$ ls build/ansible
all-profile-playbooks-rhel9                 rhel9-playbook-ccn_intermediate.yml    rhel9-playbook-hipaa.yml
rhel9-playbook-anssi_bp28_enhanced.yml      rhel9-playbook-cis_server_l1.yml       rhel9-playbook-ism_o.yml
rhel9-playbook-anssi_bp28_high.yml          rhel9-playbook-cis_workstation_l1.yml  rhel9-playbook-ospp.yml
rhel9-playbook-anssi_bp28_intermediary.yml  rhel9-playbook-cis_workstation_l2.yml  rhel9-playbook-pci-dss.yml
rhel9-playbook-anssi_bp28_minimal.yml       rhel9-playbook-cis.yml                 rhel9-playbook-stig_gui.yml
rhel9-playbook-ccn_advanced.yml             rhel9-playbook-cui.yml                 rhel9-playbook-stig.yml
rhel9-playbook-ccn_basic.yml                rhel9-playbook-e8.yml
```
Rule playbooks (there are profile directories, but `all` should contain all rules from datastream):
```
$ ls build/rhel9/playbooks/all/ | tail -n5
zipl_page_alloc_shuffle_argument.yml
zipl_page_poison_argument.yml
zipl_slub_debug_argument.yml
zipl_systemd_debug-shell_argument_absent.yml
zipl_vsyscall_argument.yml
```

RPM:
scap-security-guide
```
# rpm -ql scap-security-guide | grep .yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-anssi_bp28_enhanced.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-anssi_bp28_high.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-anssi_bp28_intermediary.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-anssi_bp28_minimal.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-ccn_advanced.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-ccn_basic.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-ccn_intermediate.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-cis.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-cis_server_l1.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-cis_workstation_l1.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-cis_workstation_l2.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-cui.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-e8.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-hipaa.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-ism_o.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-ospp.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-pci-dss.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-stig.yml
/usr/share/scap-security-guide/ansible/rhel9-playbook-stig_gui.yml
```
scap-security-guide-rule-playbooks
```
# rpm -ql scap-security-guide-rule-playbooks | grep /all/ | tail -n5
/usr/share/scap-security-guide/ansible/rule_playbooks/rhel9/all/zipl_page_alloc_shuffle_argument.yml
/usr/share/scap-security-guide/ansible/rule_playbooks/rhel9/all/zipl_page_poison_argument.yml
/usr/share/scap-security-guide/ansible/rule_playbooks/rhel9/all/zipl_slub_debug_argument.yml
/usr/share/scap-security-guide/ansible/rule_playbooks/rhel9/all/zipl_systemd_debug-shell_argument_absent.yml
/usr/share/scap-security-guide/ansible/rule_playbooks/rhel9/all/zipl_vsyscall_argument.yml
```


Previous approach `_find_playbooks(root).rglob('*')` worked for RPM - it traversed all `/usr/share/scap-security-guide/ansible/` directories and searched for `.yml`. However, it was not efficient as it checked syntax for same playbook multiple times (for each profile directory where a playbook was).
It didn't work for built content thus even if we would have built it in productization, the playbooks would not be yield by `iter_playbooks`.
Newly implemented option `--playbook-per-rule` builds per-rule playbooks via `./build_product` and no need for `cmake` - https://github.com/ComplianceAsCode/content/pull/12105
