### PR TITLE
Use dynamic ports for BackgroundHTTPServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,6 @@ automatically waive failures.
 
 (TODO: Find a better place for this?)
 
-If you need to use `lib.util.httpsrv` from a test, use a port between
-8080 and 8089. Libraries (`lib`) should use a port between 8090 and 8099.
-See also TODOs in [STYLE.md](docs/STYLE.md), this is a temporary limitation.
-
 ### Virtual machines and logging in
 
 The tests perform some hacks to allow login after hardening:

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -281,7 +281,3 @@ Misc:
   - pseudotty and other executables
   - ...
   - adjust `libdir` in `util` appropriately ?
-
-ThreadingHTTPServer in Python 3.7+ to replace the multiprocessing logic, and
-automatically pre-bind to port 0 (automatic), so we don't have to have reserved
-port ranges in README and tests/libs can just read the allocated port number.

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -21,11 +21,12 @@ if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.add_package_group('Server with GUI')
 
 # host a HTTP server with a datastream and let the guest download it
-srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 0)
-oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
-srv.add_file('remediation-ds.xml')
-with srv:
-    host, port = srv.server.server_address
+with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
+    oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
+    srv.add_file('remediation-ds.xml')
+
+    host, port = srv.start()
+
     oscap_conf = {
         'content-type': 'datastream',
         'content-url': f'http://{host}:{port}/remediation-ds.xml',

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -20,19 +20,19 @@ profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.add_package_group('Server with GUI')
 
-oscap_conf = {
-    'content-type': 'datastream',
-    'content-url': f'http://{virt.NETWORK_HOST}:8088/remediation-ds.xml',
-    'profile': profile,
-}
-ks.add_oscap(oscap_conf)
-
-oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
-
 # host a HTTP server with a datastream and let the guest download it
-srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 8088)
+srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 0)
+oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
 srv.add_file('remediation-ds.xml')
 with srv:
+    host, port = srv.server.server_address
+    oscap_conf = {
+        'content-type': 'datastream',
+        'content-url': f'http://{host}:{port}/remediation-ds.xml',
+        'profile': profile,
+    }
+    ks.add_oscap(oscap_conf)
+
     g.install(kickstart=ks)
 
 with g.booted():

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -335,14 +335,13 @@ class Guest(virt.Guest):
 
             # osbuild-composer doesn't support file:// repos, so host
             # the custom RPM on a HTTP server
-            srv = util.BackgroundHTTPServer('127.0.0.1', 0)
+            srv = stack.enter_context(util.BackgroundHTTPServer('127.0.0.1', 0))
             srv.add_dir(repo, 'repo')
-            stack.enter_context(srv)
+            http_host, http_port = srv.start()
 
             # overwrite default Red Hat CDN host repos via a custom HTTP server
             repos = ComposerRepos()
             repos.add_host_repos()
-            http_host, http_port = srv.server.server_address
             repos.repos.append({
                 'name': 'contest-rpmpack',
                 'baseurl': f'http://{http_host}:{http_port}/repo',

--- a/lib/util/httpsrv.py
+++ b/lib/util/httpsrv.py
@@ -11,9 +11,13 @@ Ie.
 
 Any HTTP GET requests for '/visible.txt' will receive the contents of
 '/on/disk/file.txt' (or 404).
-
 Any HTTP GET requests for '/somedir/aa/bb' will receive the contents of
 '/on/disk/dir/aa/bb' (or 404).
+
+You can call 'srv.add_*' functions inside the context manager, however
+be aware that this creates a potential race condition with the request-
+handling code, so make sure nothing queries the server while new entries
+are being added.
 
 Port can also be specified as 0 (just like for Python's socketserver)
 which will cause a random unused port to be allocated by the OS kernel.

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -424,13 +424,12 @@ class Guest:
 
             # host the custom RPM on a HTTP server, as Anaconda needs a YUM repo
             # to pull packages from
-            srv = util.BackgroundHTTPServer(NETWORK_HOST, 0)
+            srv = stack.enter_context(util.BackgroundHTTPServer(NETWORK_HOST, 0))
             srv.add_dir(repo, 'repo')
-            stack.enter_context(srv)
+            http_host, http_port = srv.start()
 
             # now that we know the address/port of the HTTP server, add it to
             # the kickstart as well
-            http_host, http_port = srv.server.server_address
             kickstart.add_install_only_repo(
                 'contest-rpmpack',
                 f'http://{http_host}:{http_port}/repo',

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -14,11 +14,12 @@ g = virt.Guest()
 ks = virt.translate_ssg_kickstart(shared.profile)
 
 # host a HTTP server with a datastream and let the guest download it
-srv = util.BackgroundHTTPServer(virt.NETWORK_HOST, 0)
-oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
-srv.add_file('remediation-ds.xml')
-with srv:
-    host, port = srv.server.server_address
+with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
+    oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
+    srv.add_file('remediation-ds.xml')
+
+    host, port = srv.start()
+
     oscap_conf = {
         'content-type': 'datastream',
         'content-url': f'http://{host}:{port}/remediation-ds.xml',


### PR DESCRIPTION
This is a follow-up to https://github.com/RHSecurityCompliance/contest/pull/210/commits/3277a788bb19f9b6b4f1e62665413936d705f255 from https://github.com/RHSecurityCompliance/contest/pull/210.

I've tested
```
/hardening/anaconda/stig$
/hardening/image-builder/stig$
/scanning/disa-alignment/anaconda$
```
(the main/only tests impacted by this) and they all seem to pass/warn just fine, so I presume it works.

I also ran some multi-profile runs of `anaconda` / `image-builder` to make sure there isn't anything persistent that would break 2 or more tests running sequentially on a single system.