### PR TITLE
Fix rpmbuild-ctest to use also upstream Content

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -6,6 +6,8 @@ environment+:
 duration: 1h
 require+:
   - rpm-build
+  - cmake
+  - python3-jinja2
 recommend+:
   - dnf-utils
   - yum-utils

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -8,10 +8,13 @@ require+:
   - rpm-build
   - cmake
   - python3-jinja2
+  - python3-devel
+  - python3-pip
 recommend+:
   - dnf-utils
   - yum-utils
   - yum-builddep
+  - bats
 tag:
   - CI-Tier-1
   - Errata

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -29,6 +29,10 @@ else:
         '-DSSG_BUILD_SCAP_12_DS=OFF',
     ]
 
+# Extra modules to enable more unit tests
+python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'pandas', 'cmakelint']
+util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])
+
 with util.get_content(build=False) as content_dir:
     build_dir = content_dir / 'build'
 

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -48,12 +48,12 @@ with util.get_content(build=False) as content_dir:
 
     with open(build_dir / 'ctest_results') as f:
         # Result format: X/Y Test  #X: test_name .................  test_result   Z sec
-        result_regex = re.compile(r'\d+\s+Test\s+#\d+:\s+([^\s]+)\s+\.+\s+(\w+)\s+')
+        result_regex = re.compile(r'\d+\s+Test\s+#\d+:\s+([^\s]+)\s+\.+')
         for line in f:
             result_match = result_regex.search(line)
             if result_match:
-                test_name, test_result = result_match.groups()
-                result = 'pass' if test_result == 'Passed' else 'fail'
+                test_name = result_match.group(1)
+                result = 'pass' if 'Passed' in line else 'fail'
                 results.report(result, test_name)
 
     results.report_and_exit(logs=[build_dir / 'Testing' / 'Temporary' / 'LastTest.log'])


### PR DESCRIPTION
Use `util.get_content` to get SSG content. If content is provided by env variable, use it, not the packaged one. Otherwise, use packaged content. In both cases, built it and test it using `cmake`.