### PR TITLE
Revert waving of sshd_use_approved_ciphers for RHEL 9

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -123,13 +123,6 @@
 /per-rule/.+/package_ypserv_removed/package-installed.fail
 /per-rule/.+/service_telnet_disabled/service_disabled.pass
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/12096
-/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_reduced_list.pass
-/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_scrambled.pass
-/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value.pass
-/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_value_full.pass
-/per-rule/.+/oscap/sshd_use_approved_ciphers/correct_variable.pass
-    rhel == 9
 # likely something caused by restraint / Beaker test env
 # TODO: investigate
 /hardening/host-os/.+/file_permissions_unauthorized_world_writable


### PR DESCRIPTION
This rule has been removed from the profile for the time being.