### PR TITLE
Switch --destdir as --downloaddir was dropped in DNF5

### DIFF
--- a/lib/dnf.py
+++ b/lib/dnf.py
@@ -113,7 +113,7 @@ def download_rpm(nvr, source=False):
     'source' specifies whether to download a binary or a source RPM.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        cmd = ['dnf', 'download', '--downloaddir', tmpdir]
+        cmd = ['dnf', 'download', '--destdir', tmpdir]
         if source:
             cmd.append('--source')
         cmd.append(nvr)


### PR DESCRIPTION
https://dnf5.readthedocs.io/en/latest/changes.html

> --downloaddir
Dropped. Now only the --destdir is used for the download command.

Fedora Rawhide already switched to dnf5 - https://fedoraproject.org/wiki/Releases/41/ChangeSet#Switch_to_dnf5