### PR TITLE
Prepare Ansible for rpmbuild-ctest

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -14,6 +14,8 @@ recommend+:
   - dnf-utils
   - yum-utils
   - yum-builddep
+  - ansible-core
+  - rhc-worker-playbook
   - bats
 tag:
   - CI-Tier-1

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -2,7 +2,7 @@
 
 import re
 
-from lib import util, results, versions
+from lib import util, results, versions, ansible
 
 
 # options are taken from scap-security-guide spec file
@@ -29,6 +29,7 @@ else:
         '-DSSG_BUILD_SCAP_12_DS=OFF',
     ]
 
+ansible.install_deps()
 # Extra modules to enable more unit tests
 python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'pandas', 'cmakelint']
 util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])


### PR DESCRIPTION
If different Ansible test is run before `rpmbuild-ctest`, it installs Ansible and thus enables also Ansible syntax check ctest there.
However, the env variable is not set there. Thus, for consistency reasons, enable the Ansible ctest by default via `ansible-core`/`rhc-worker-playbook` packages and prepare it in test code.