### PR TITLE
Ensure build directory exists

### DIFF
--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -36,6 +36,7 @@ util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])
 
 with util.get_content(build=False) as content_dir:
     build_dir = content_dir / 'build'
+    build_dir.mkdir(exist_ok=True)
 
     util.subprocess_run(['cmake', '../', *cmake_options], cwd=build_dir, check=True)
     util.subprocess_run(['make', '-j4'], cwd=build_dir, check=True)


### PR DESCRIPTION
On older SSG versions from src rpm, there is no `build/` dir. Thus, ensure it exists.

Happens only in `rpmbuild-ctest`. In other test cases, we do `./build_product` which ensures that `build` directory exists. But in this case, we use directly `cmake ../` which should be run from already existing `build` directory.
The problem happens only on RHEL8 with srpm, RHEL9 is fine, and for upstream content, `build` directory is there by default.