### PR TITLE
Unify timer_dnf-automatic_enabled waiver

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -5,11 +5,6 @@
 # their root cause, filing isseus/bugs or fixing tests as appropriate,
 # eventually either removing the waivers or moving them to other files
 
-# https://github.com/ComplianceAsCode/content/issues/12119
-/hardening/host-os/ansible/cui/timer_dnf-automatic_enabled
-/hardening/host-os/ansible/ospp/timer_dnf-automatic_enabled
-    rhel == 8
-
 # https://github.com/ComplianceAsCode/content/issues/12096
 /hardening/.*/cis[^/]*/sshd_use_approved_ciphers
     rhel == 9

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -28,6 +28,10 @@
 /hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
     True
 
+# https://github.com/ComplianceAsCode/content/issues/12119
+/hardening/host-os/.*/(ospp|cui)/timer_dnf-automatic_enabled
+    rhel == 8
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1797653 WONTFIX
 /scanning/oscap-eval/ERROR
     rhel == 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'


### PR DESCRIPTION
According to last daily productization, the rule is only used (and waived) in OSPP and CUI RHEL8 profiles. Other profiles/versions don't use it.

The reason of waiving it and having it in 30-permanent is described in https://github.com/ComplianceAsCode/content/issues/12119