### PR TITLE
Clean up FMF definitions - TCMS, tags, variables

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -28,67 +28,39 @@ adjust:
     because: content doesn't have pre-made kickstarts for RHEL-10+
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -26,9 +26,6 @@ adjust:
   - when: distro >= rhel-10
     enabled: false
     because: content doesn't have pre-made kickstarts for RHEL-10+
-tag:
-  - max1
-  - daily
 
 /anssi_bp28_high:
     environment+:
@@ -73,8 +70,6 @@ tag:
 /ospp:
     environment+:
         PROFILE: ospp
-    tag+:
-      - Errata
 
 /pci-dss:
     environment+:

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -33,37 +33,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/anssi_bp28_high
-    extra-nitrate: TC#0615157
-    id: fa9bafe4-ec23-4f9e-8f20-277b32c3bcb3
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cis
-    extra-nitrate: TC#0615164
-    id: 82c25703-4912-4303-993b-50a6dddf6b6b
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cis_server_l1
-    extra-nitrate: TC#0615165
-    id: b3d1f448-0d79-4ae5-bbf3-5156fb68f8ee
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cis_workstation_l1
-    extra-nitrate: TC#0615166
-    id: 53392955-75bd-4858-ab18-ce131b72aee4
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cis_workstation_l2
-    extra-nitrate: TC#0615167
-    id: 2b1bb08e-baca-40a7-8ba5-7a8710d9fe2e
 
 /cui:
     environment+:
@@ -72,53 +57,32 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/cui
-    extra-nitrate: TC#0615169
-    id: dcc000cc-f65a-47fd-bce2-d3ed4a1d5f4f
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/e8
-    extra-nitrate: TC#0615170
-    id: 7a3f46a1-0208-4c06-bc5e-55f98c87d7b2
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/hipaa
-    extra-nitrate: TC#0615171
-    id: 4f739cba-f337-4530-99f5-2afcde678dd2
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ism_o
-    extra-nitrate: TC#0615172
-    id: 0d9c11fb-da88-4a94-8a35-3247287b4fc5
 
 /ospp:
     environment+:
         PROFILE: ospp
     tag+:
       - Errata
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ospp
-    extra-nitrate: TC#0615174
-    id: 2a02056b-9fd1-4de1-9f23-bc493f41b6c8
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/pci-dss
-    extra-nitrate: TC#0615175
-    id: f0f0151a-888c-4efa-aef8-90d0a94499c1
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig
-    extra-nitrate: TC#0615180
-    id: 156ae132-5eac-4063-8189-7bd2fdd32e21
 
 /stig_gui:
     environment+:
@@ -126,9 +90,6 @@ tag:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/stig_gui
-    extra-nitrate: TC#0615403
-    id: 9f841ee0-a08c-4b3b-b4bb-4676e41d7f19
 
 /ccn_advanced:
     environment+:
@@ -137,6 +98,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/ccn_advanced
-    extra-nitrate: TC#0615550
-    id: de88ef36-6433-4e03-83c5-cb234683cc88

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -15,8 +15,6 @@ profile = util.get_test_name().rpartition('/')[2]
 # use kickstart from content, not ours
 ks = virt.translate_ssg_kickstart(profile)
 
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
-
 if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.add_package_group('Server with GUI')
 

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -10,7 +10,7 @@ virt.Host.setup()
 
 g = virt.Guest()
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 
 # use kickstart from content, not ours
 ks = virt.translate_ssg_kickstart(profile)

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -2,10 +2,6 @@ environment+:
     USE_SERVER_WITH_GUI: 1
 duration: 2h
 
-# do not run GUI tests in CI unless explicitly mentioned below
-tag-:
-  - Kickstarts
-
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
@@ -35,8 +31,6 @@ tag-:
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    tag+:
-      - Kickstarts
 
 /cui:
     environment+:
@@ -90,8 +84,6 @@ tag-:
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    tag+:
-      - Kickstarts
 
 /ccn_advanced:
     environment+:

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -9,9 +9,6 @@ tag-:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/anssi_bp28_high
-    extra-nitrate: TC#0615404
-    id: 2325cf2f-0fb8-4250-858a-03c62d495011
 
 /cis:
     environment+:
@@ -21,9 +18,6 @@ tag-:
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis
-    extra-nitrate: TC#0615406
-    id: e5ecac50-c56a-420d-b815-e8a18a5d6414
 
 /cis_server_l1:
     environment+:
@@ -33,25 +27,16 @@ tag-:
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_server_l1
-    extra-nitrate: TC#0615407
-    id: 58631255-d82f-4475-856c-9cba991ee86e
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l1
-    extra-nitrate: TC#0615408
-    id: 15a29c70-4d83-49ae-8e1c-06201cb6498a
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
     tag+:
       - Kickstarts
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cis_workstation_l2
-    extra-nitrate: TC#0615409
-    id: 93c3eba2-b612-4c9f-a755-b440d66b1c90
 
 /cui:
     environment+:
@@ -65,30 +50,18 @@ tag-:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/cui
-    extra-nitrate: TC#0615410
-    id: 571513d7-7160-4b73-8eec-9f087a1ddddf
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/e8
-    extra-nitrate: TC#0615411
-    id: 96f2e4ce-92a2-4c41-8bc7-61b06be35d23
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/hipaa
-    extra-nitrate: TC#0615412
-    id: 3cd0f065-b874-4342-b0d7-7d1af70189da
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ism_o
-    extra-nitrate: TC#0615413
-    id: 4577aecc-3186-47d7-9425-b894939ae034
 
 /ospp:
     environment+:
@@ -99,16 +72,10 @@ tag-:
         because: >
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ospp
-    extra-nitrate: TC#0615414
-    id: 916f98e8-4c0d-45e7-85da-f5f6e5150c2c
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/pci-dss
-    extra-nitrate: TC#0615415
-    id: ff3ae0c7-fb56-4272-b7c0-c24bb5b1eab2
 
 /stig:
     environment+:
@@ -119,18 +86,12 @@ tag-:
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig
-    extra-nitrate: TC#0615416
-    id: 87e79307-059d-4c20-a66e-b6ca83d4a1f1
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
     tag+:
       - Kickstarts
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/stig_gui
-    extra-nitrate: TC#0615417
-    id: 3289b917-ca54-469c-8bce-f1db3c705239
 
 /ccn_advanced:
     environment+:
@@ -139,6 +100,3 @@ tag-:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/anaconda/with-gui/ccn_advanced
-    extra-nitrate: TC#0615551
-    id: 15392a8c-5e38-4d48-8622-bca57c0056af

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -3,12 +3,8 @@ environment+:
 duration: 2h
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
     adjust+:
       - enabled: false
         because: >
@@ -16,8 +12,6 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
     adjust+:
       - enabled: false
         because: >
@@ -25,16 +19,10 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -46,20 +34,12 @@ duration: 2h
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -68,12 +48,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
     adjust+:
       - enabled: false
         because: >
@@ -82,12 +58,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -34,37 +34,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/anssi_bp28_high
-    extra-nitrate: TC#0615418
-    id: 7d851e6c-3e2f-45ba-8e6c-d65c026533e0
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis
-    extra-nitrate: TC#0615420
-    id: c450feb4-8a84-458b-8076-c4fc34c6d420
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_server_l1
-    extra-nitrate: TC#0615421
-    id: d8aac2ce-03f8-49cc-af32-7a762892b15b
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l1
-    extra-nitrate: TC#0615422
-    id: f66247b6-ad88-499f-999f-cee18b20736e
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cis_workstation_l2
-    extra-nitrate: TC#0615423
-    id: 33ef4c07-f316-4fef-8319-bc92e674e9fc
 
 /cui:
     environment+:
@@ -73,53 +58,32 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/cui
-    extra-nitrate: TC#0615424
-    id: ecd81d95-db3c-4ce0-8bc2-0634a6d10891
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/e8
-    extra-nitrate: TC#0615425
-    id: 57fa0d26-5c60-4f1d-abeb-1fb01c2eea2a
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/hipaa
-    extra-nitrate: TC#0615426
-    id: a630571c-06e9-4d9f-b241-fceac07db427
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ism_o
-    extra-nitrate: TC#0615427
-    id: fdf874e0-b9c3-48aa-b72c-8744eb9e82c2
 
 /ospp:
     environment+:
         PROFILE: ospp
     tag+:
       - Errata
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ospp
-    extra-nitrate: TC#0615428
-    id: 67fa598d-8e48-429c-9462-42b1314bc208
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/pci-dss
-    extra-nitrate: TC#0615429
-    id: b110b2ec-1155-4b9c-a72c-d2430c376544
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig
-    extra-nitrate: TC#0615430
-    id: 557bc116-2952-469f-87a6-a1515df8baa8
 
 /stig_gui:
     environment+:
@@ -127,9 +91,6 @@ tag:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/stig_gui
-    extra-nitrate: TC#0615431
-    id: 9a90982b-ce7f-471e-8ff2-217e7ab5c658
 
 /ccn_advanced:
     environment+:
@@ -138,6 +99,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/ccn_advanced
-    extra-nitrate: TC#0615552
-    id: b9c5b67c-73a9-4aad-a4e1-aaadc0c6a18b

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -29,67 +29,39 @@ adjust:
     because: we want to run virtualization on x86_64 only
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -27,9 +27,6 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-tag:
-  - max1
-  - daily
 
 /anssi_bp28_high:
     environment+:
@@ -74,8 +71,6 @@ tag:
 /ospp:
     environment+:
         PROFILE: ospp
-    tag+:
-      - Errata
 
 /pci-dss:
     environment+:

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -10,7 +10,6 @@ ansible.install_deps()
 virt.Host.setup()
 
 profile = util.get_test_name().rpartition('/')[2]
-profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 use_gui = os.environ.get('USE_SERVER_WITH_GUI')
 
@@ -51,7 +50,7 @@ with g.snapshotted():
     # scan the remediated system
     g.copy_to(util.get_datastream(), 'scan-ds.xml')
     proc, lines = g.ssh_stream(
-        f'oscap xccdf eval --profile {profile_full} --progress --report report.html'
+        f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf results-arf.xml scan-ds.xml'
     )
     oscap.report_from_verbose(lines)

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -9,7 +9,7 @@ from conf import remediation, partitions
 ansible.install_deps()
 virt.Host.setup()
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 use_gui = os.environ.get('USE_SERVER_WITH_GUI')

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -5,9 +5,6 @@ duration: 2h
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/anssi_bp28_high
-    extra-nitrate: TC#0615432
-    id: 70600369-4127-4489-bc67-bad0c41847b9
 
 /cis:
     environment+:
@@ -17,9 +14,6 @@ duration: 2h
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis
-    extra-nitrate: TC#0615434
-    id: 21ada412-9be2-4e32-8c45-1873c3ff5306
 
 /cis_server_l1:
     environment+:
@@ -29,23 +23,14 @@ duration: 2h
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_server_l1
-    extra-nitrate: TC#0615435
-    id: 78c09474-e64f-4174-b60b-cf6ea439b590
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l1
-    extra-nitrate: TC#0615436
-    id: 05fb0cea-604f-463c-a48e-2d6c774a0cc5
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cis_workstation_l2
-    extra-nitrate: TC#0615437
-    id: e683e50e-8579-4323-99bb-9d14822e069a
 
 /cui:
     environment+:
@@ -59,30 +44,18 @@ duration: 2h
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/cui
-    extra-nitrate: TC#0615438
-    id: c2089407-3b4d-46f7-8172-5e6d2d4c9919
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/e8
-    extra-nitrate: TC#0615439
-    id: 898c7b70-4711-420b-80c5-e79a7a3e8adc
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/hipaa
-    extra-nitrate: TC#0615440
-    id: b493b8b5-41b4-4b77-84b7-962001bf2970
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ism_o
-    extra-nitrate: TC#0615441
-    id: 3cc4f0ee-6dfd-485d-9dd2-f0d841e2eb87
 
 /ospp:
     environment+:
@@ -93,16 +66,10 @@ duration: 2h
         because: >
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ospp
-    extra-nitrate: TC#0615442
-    id: 28e32d25-2386-4fd7-bfb6-b889b5d5df90
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/pci-dss
-    extra-nitrate: TC#0615443
-    id: c1ed3b2a-8ab8-4575-b3b0-19c3f7735ca5
 
 /stig:
     environment+:
@@ -113,16 +80,10 @@ duration: 2h
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig
-    extra-nitrate: TC#0615444
-    id: 97abbf39-45a8-45e4-bc03-3e3955d131d2
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/stig_gui
-    extra-nitrate: TC#0615445
-    id: 2e5aae97-9ded-4055-bef1-38e98cbf9dc8
 
 /ccn_advanced:
     environment+:
@@ -131,6 +92,3 @@ duration: 2h
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/ansible/with-gui/ccn_advanced
-    extra-nitrate: TC#0615553
-    id: 585d1dbd-63c8-4d53-a217-eaf935f4a7ce

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -3,12 +3,8 @@ environment+:
 duration: 2h
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
     adjust+:
       - enabled: false
         because: >
@@ -16,8 +12,6 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
     adjust+:
       - enabled: false
         because: >
@@ -25,16 +19,10 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -46,20 +34,12 @@ duration: 2h
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -68,12 +48,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
     adjust+:
       - enabled: false
         because: >
@@ -82,12 +58,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -20,37 +20,22 @@ adjust:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/anssi_bp28_high
-    extra-nitrate: TC#0615446
-    id: 3bc79691-409a-47a2-ab09-552b66befd65
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis
-    extra-nitrate: TC#0615448
-    id: 91051ca5-3f8a-41a3-a6cf-7b03b561f3d3
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_server_l1
-    extra-nitrate: TC#0615449
-    id: d3e24927-f05d-41b7-a75d-cff02d060163
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l1
-    extra-nitrate: TC#0615450
-    id: b5dc6c8b-2d66-45c7-acfd-b13eb74b21f6
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cis_workstation_l2
-    extra-nitrate: TC#0615451
-    id: da6f9fad-ecf6-4c9a-af42-d5d8e21f080b
 
 /cui:
     environment+:
@@ -59,51 +44,30 @@ adjust:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/cui
-    extra-nitrate: TC#0615452
-    id: b5e079b6-91b0-4815-8f83-e0fc64e90f70
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/e8
-    extra-nitrate: TC#0615453
-    id: 30fbaaba-6989-4b15-b60c-d6523599049b
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/hipaa
-    extra-nitrate: TC#0615454
-    id: bafd98c6-473b-4279-873e-c11165c1cf4b
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ism_o
-    extra-nitrate: TC#0615455
-    id: 866ac5c0-8f56-464d-a995-36313c77347a
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ospp
-    extra-nitrate: TC#0615456
-    id: f735909d-920c-4e80-84c0-11e723e5f5ea
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/pci-dss
-    extra-nitrate: TC#0615457
-    id: 5ffdce69-c34c-43ee-a6e5-ada888565f59
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig
-    extra-nitrate: TC#0615458
-    id: 72fd6d33-edf3-4b77-8bba-6f6a2882ea8d
 
 /stig_gui:
     environment+:
@@ -111,9 +75,6 @@ adjust:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/stig_gui
-    extra-nitrate: TC#0615459
-    id: cfb0fe65-acf3-4239-8ff6-a4f74aefb591
 
 /ccn_advanced:
     environment+:
@@ -122,6 +83,3 @@ adjust:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/ansible/ccn_advanced
-    extra-nitrate: TC#0615554
-    id: 1b9e4188-f07f-4a57-a3df-471d1d05ca91

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -18,67 +18,39 @@ adjust:
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -6,7 +6,7 @@ from lib import util, results, oscap, ansible
 from conf import remediation
 
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 # the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -7,7 +7,6 @@ from conf import remediation
 
 
 profile = util.get_test_name().rpartition('/')[2]
-profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 # the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks
 # on trying to accept its ssh key - tell it to ignore this
@@ -42,7 +41,7 @@ else:
 
     # scan the remediated system
     cmd = [
-        'oscap', 'xccdf', 'eval', '--profile', profile_full, '--progress',
+        'oscap', 'xccdf', 'eval', '--profile', profile, '--progress',
         '--report', 'report.html', '--results-arf', 'results-arf.xml',
         util.get_datastream(),
     ]

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -13,37 +13,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/anssi_bp28_high
-    extra-nitrate: TC#0615460
-    id: 6de66fee-9a46-4652-a421-771e61d3576d
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis
-    extra-nitrate: TC#0615462
-    id: 3a9226db-8c9d-4958-bea2-15bc836886be
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_server_l1
-    extra-nitrate: TC#0615463
-    id: 4fb3e747-63a8-43c0-9bad-ebd13190480b
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l1
-    extra-nitrate: TC#0615464
-    id: 1e05f676-a224-45de-87ac-9cfc3e19577f
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cis_workstation_l2
-    extra-nitrate: TC#0615465
-    id: 86864467-a125-464a-bd30-638cfc535dc0
 
 /cui:
     environment+:
@@ -52,51 +37,30 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/cui
-    extra-nitrate: TC#0615466
-    id: bf0a09f8-0809-43e6-bb85-a46566ae99e7
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/e8
-    extra-nitrate: TC#0615467
-    id: 54df232a-ac9a-40d5-bc60-ccf056c53cf7
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/hipaa
-    extra-nitrate: TC#0615468
-    id: 28ce0a42-a450-47a6-b4e2-f88f5cb47c93
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ism_o
-    extra-nitrate: TC#0615469
-    id: 128a3122-a0f8-45b8-8734-575ad25bf97a
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ospp
-    extra-nitrate: TC#0615470
-    id: f6f4b2b8-2965-41b6-b1f0-aec59ebc1140
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/pci-dss
-    extra-nitrate: TC#0615471
-    id: 6de810a8-a2fe-4e12-ac72-e19c5d307aac
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig
-    extra-nitrate: TC#0615472
-    id: 5720054d-bbc3-4fe6-b765-56277973f533
 
 /stig_gui:
     environment+:
@@ -104,9 +68,6 @@ tag:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/stig_gui
-    extra-nitrate: TC#0615473
-    id: af89d34d-5454-4313-a5b3-6ce0bdf09cfc
 
 /ccn_advanced:
     environment+:
@@ -115,6 +76,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/host-os/oscap/ccn_advanced
-    extra-nitrate: TC#0615555
-    id: d156c98b-30de-4af2-a4b7-5224079681da

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -8,7 +8,6 @@ require+:
   - openscap-scanner
 tag:
   - destructive
-  - daily
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -10,67 +10,39 @@ tag:
   - destructive
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -9,7 +9,6 @@ from conf import remediation
 
 
 profile = util.get_test_name().rpartition('/')[2]
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 unique_name = util.get_test_name().lstrip('/').replace('/', '-')
 

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 
-import os
 import shutil
 
 from pathlib import Path
@@ -9,7 +8,7 @@ from lib import util, results, oscap
 from conf import remediation
 
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 unique_name = util.get_test_name().lstrip('/').replace('/', '-')

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -37,37 +37,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/anssi_bp28_high
-    extra-nitrate: TC#0617135
-    id: 49378e15-8946-456f-a385-e1f46ce215ed
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/cis
-    extra-nitrate: TC#0617138
-    id: 9271436d-0174-4ce1-8095-336fbc88ecd8
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/cis_server_l1
-    extra-nitrate: TC#0617139
-    id: 14b1138a-1518-42ef-a7f5-ddc166569c84
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/cis_workstation_l1
-    extra-nitrate: TC#0617140
-    id: acbe7c1c-f4c2-4fa4-82ee-82d6466d53e9
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/cis_workstation_l2
-    extra-nitrate: TC#0617141
-    id: fa04eabf-bb44-4e83-b0da-0d01a855593f
 
 /cui:
     environment+:
@@ -76,51 +61,30 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/cui
-    extra-nitrate: TC#0617142
-    id: b51902b5-372b-4bac-abde-7b4ed55883a9
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/e8
-    extra-nitrate: TC#0617143
-    id: b1ed4be5-8d13-49c3-81da-c5237e99a3cf
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/hipaa
-    extra-nitrate: TC#0617144
-    id: ade802a8-0f34-44bb-b6d2-d79c42100763
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/ism_o
-    extra-nitrate: TC#0617145
-    id: 86e541fb-6ea0-4e9f-b945-08085700d16e
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/ospp
-    extra-nitrate: TC#0617146
-    id: ceca6b61-a274-4bf6-99ec-e0c1ccdb954c
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/pci-dss
-    extra-nitrate: TC#0617147
-    id: 4e045305-52af-4157-a692-553025d2e3ce
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/stig
-    extra-nitrate: TC#0617148
-    id: 509cf2e8-60b1-4133-8770-f9cd1a2b4385
 
 /stig_gui:
     environment+:
@@ -128,7 +92,6 @@ tag:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/stig_gui
 
 /ccn_advanced:
     environment+:
@@ -137,6 +100,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/image-builder/ccn_advanced
-    extra-nitrate: TC#0617137
-    id: 4852122f-0667-4f88-a6e5-d8146e36d244

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -30,9 +30,6 @@ adjust:
   - when: distro ~< rhel-8.10 or distro ~< rhel-9.4
     enabled: false
     because: there is no OSBuild or Image Builder on old RHEL8/9 contain old OSBuild
-tag:
-  - max1
-  - daily
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -32,67 +32,39 @@ adjust:
     because: there is no OSBuild or Image Builder on old RHEL8/9 contain old OSBuild
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/image-builder/test.py
+++ b/hardening/image-builder/test.py
@@ -11,8 +11,6 @@ profile = util.get_test_name().rpartition('/')[2]
 
 g.create(profile=profile)
 
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
-
 with g.booted():
     # scan the remediated system
     proc, lines = g.ssh_stream(

--- a/hardening/image-builder/test.py
+++ b/hardening/image-builder/test.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-import os
-
 from lib import results, oscap, osbuild, util
 
 
@@ -9,7 +7,7 @@ osbuild.Host.setup()
 
 g = osbuild.Guest()
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 
 g.create(profile=profile)
 

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -25,67 +25,39 @@ adjust:
     because: we want to run virtualization on x86_64 only
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -23,9 +23,6 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-tag:
-  - max1
-  - daily
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -30,37 +30,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/anssi_bp28_high
-    extra-nitrate: TC#0615184
-    id: f505892f-12ab-49de-bfa0-59e3fe9fe5c4
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis
-    extra-nitrate: TC#0615191
-    id: 161d1843-4d37-4d23-96ee-cbcf1d2e9dac
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_server_l1
-    extra-nitrate: TC#0615192
-    id: 8741b321-348b-4aa8-be48-abcbf8fcff20
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l1
-    extra-nitrate: TC#0615193
-    id: aa7ffa68-66ff-43d6-b674-72bb4d4ef94d
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cis_workstation_l2
-    extra-nitrate: TC#0615194
-    id: a984cb43-71a8-4aea-b965-5c29a6c4018a
 
 /cui:
     environment+:
@@ -69,51 +54,30 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/cui
-    extra-nitrate: TC#0615196
-    id: 0acaf295-d069-47fa-844b-c1e2ac652032
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/e8
-    extra-nitrate: TC#0615197
-    id: 3e7a9455-05f4-4e76-87d3-88e42fc5c1a9
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/hipaa
-    extra-nitrate: TC#0615198
-    id: eafe8f99-1948-44b6-a3a1-cee260a8dc7d
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ism_o
-    extra-nitrate: TC#0615199
-    id: 71ec5f37-5061-490a-a845-7eea86ad0c16
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ospp
-    extra-nitrate: TC#0615201
-    id: cba8f70e-15d2-4adb-851b-b77c8b95de49
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/pci-dss
-    extra-nitrate: TC#0615202
-    id: 339cb66e-0b63-4266-802a-3972b6cf36ff
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig
-    extra-nitrate: TC#0615207
-    id: 90d8c69c-4dea-404f-9158-2b2923e929c3
 
 /stig_gui:
     environment+:
@@ -121,9 +85,6 @@ tag:
     adjust+:
       - enabled: false
         because: not supported without GUI, use stig instead
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/stig_gui
-    extra-nitrate: TC#0615474
-    id: f65796bd-64eb-4c8a-b88b-3cf3b597d073
 
 /ccn_advanced:
     environment+:
@@ -132,6 +93,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/ccn_advanced
-    extra-nitrate: TC#0615556
-    id: 2aea8f2f-de4c-49c0-a012-86175698e18e

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -16,37 +16,22 @@ tag:
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/anssi_bp28_high
-    extra-nitrate: TC#0617510
-    id: 3973f4f3-792d-49bb-bd7b-21468dc136c1
 
 /cis:
     environment+:
         PROFILE: cis
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/cis
-    extra-nitrate: TC#0617512
-    id: 9b70c421-f252-4b22-9d1e-f0e8248ed276
 
 /cis_server_l1:
     environment+:
         PROFILE: cis_server_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/cis_server_l1
-    extra-nitrate: TC#0617513
-    id: b07098d2-8191-41d1-b1f0-d19e52e9999f
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/cis_workstation_l1
-    extra-nitrate: TC#0617514
-    id: 1910db2c-c679-4378-9b4f-df18c9b71018
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/cis_workstation_l2
-    extra-nitrate: TC#0617515
-    id: 6bb4fa20-8e0d-46b7-9d2b-90275bb70786
 
 /cui:
     environment+:
@@ -55,51 +40,30 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/cui
-    extra-nitrate: TC#0617516
-    id: 62972d55-4aca-484e-817b-ea5b751270d3
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/e8
-    extra-nitrate: TC#0617517
-    id: b5dfc321-50a7-4f3b-be20-45a4e701e003
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/hipaa
-    extra-nitrate: TC#0617518
-    id: cf85ecb1-2c70-475c-9eeb-43f938e714f8
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/ism_o
-    extra-nitrate: TC#0617519
-    id: 6372d9f5-b47b-4e13-88cb-4c9bb4664ac8
 
 /ospp:
     environment+:
         PROFILE: ospp
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/ospp
-    extra-nitrate: TC#0617520
-    id: 30620306-a6e3-4a48-a703-19aea1559299
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/pci-dss
-    extra-nitrate: TC#0617522
-    id: 9f5978e4-996c-4f2b-a14b-e6d8ea3b9d8c
 
 /stig:
     environment+:
         PROFILE: stig
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/stig
-    extra-nitrate: TC#0617523
-    id: d72ace16-e474-45dc-9c57-f8054144b840
 
 /stig_gui:
     environment+:
@@ -115,6 +79,3 @@ tag:
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/old-new/ccn_advanced
-    extra-nitrate: TC#0617511
-    id: a437d0e7-6784-4554-aaad-a295d05c87d3

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -9,9 +9,6 @@ description: |-
     successfully fixes the non-compliance, as verified by a scan.
 environment+:
     PYTHONPATH: ../../..
-tag:
-  # because old productization uses max1 and cannot run these efficiently
-  - NoProductization
 
 /anssi_bp28_high:
     environment+:

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -11,67 +11,39 @@ environment+:
     PYTHONPATH: ../../..
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
     adjust+:
       - enabled: false
         because: not worth re-installing the VM snapshot with GUI packages
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/oscap/old-new/test.py
+++ b/hardening/oscap/old-new/test.py
@@ -1,14 +1,12 @@
 #!/usr/bin/python3
 
-import os
-
 from lib import util, results, virt, oscap
 from conf import remediation, partitions
 
 
 virt.Host.setup()
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 g = virt.Guest('minimal_with_oscap')

--- a/hardening/oscap/old-new/test.py
+++ b/hardening/oscap/old-new/test.py
@@ -7,7 +7,6 @@ from conf import remediation, partitions
 virt.Host.setup()
 
 profile = util.get_test_name().rpartition('/')[2]
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 g = virt.Guest('minimal_with_oscap')
 

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -8,7 +8,7 @@ from conf import remediation, partitions
 
 virt.Host.setup()
 
-profile = os.environ['PROFILE']
+profile = util.get_test_name().rpartition('/')[2]
 profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 use_gui = os.environ.get('USE_SERVER_WITH_GUI')

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -9,7 +9,6 @@ from conf import remediation, partitions
 virt.Host.setup()
 
 profile = util.get_test_name().rpartition('/')[2]
-profile = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 use_gui = os.environ.get('USE_SERVER_WITH_GUI')
 

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -3,12 +3,8 @@ environment+:
 duration: 2h
 
 /anssi_bp28_high:
-    environment+:
-        PROFILE: anssi_bp28_high
 
 /cis:
-    environment+:
-        PROFILE: cis
     adjust+:
       - enabled: false
         because: >
@@ -16,8 +12,6 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
-    environment+:
-        PROFILE: cis_server_l1
     adjust+:
       - enabled: false
         because: >
@@ -25,16 +19,10 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_workstation_l1:
-    environment+:
-        PROFILE: cis_workstation_l1
 
 /cis_workstation_l2:
-    environment+:
-        PROFILE: cis_workstation_l2
 
 /cui:
-    environment+:
-        PROFILE: cui
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -46,20 +34,12 @@ duration: 2h
         because: there is no CUI profile on RHEL-10+
 
 /e8:
-    environment+:
-        PROFILE: e8
 
 /hipaa:
-    environment+:
-        PROFILE: hipaa
 
 /ism_o:
-    environment+:
-        PROFILE: ism_o
 
 /ospp:
-    environment+:
-        PROFILE: ospp
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -68,12 +48,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /pci-dss:
-    environment+:
-        PROFILE: pci-dss
 
 /stig:
-    environment+:
-        PROFILE: stig
     adjust+:
       - enabled: false
         because: >
@@ -82,12 +58,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
-    environment+:
-        PROFILE: stig_gui
 
 /ccn_advanced:
-    environment+:
-        PROFILE: ccn_advanced
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -5,9 +5,6 @@ duration: 2h
 /anssi_bp28_high:
     environment+:
         PROFILE: anssi_bp28_high
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/anssi_bp28_high
-    extra-nitrate: TC#0615475
-    id: 5c1f431d-990f-4379-963e-924ef8bcf9b2
 
 /cis:
     environment+:
@@ -17,9 +14,6 @@ duration: 2h
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis
-    extra-nitrate: TC#0615477
-    id: ca3b4846-1360-4c73-ad27-1a669bb2a46b
 
 /cis_server_l1:
     environment+:
@@ -29,23 +23,14 @@ duration: 2h
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_server_l1
-    extra-nitrate: TC#0615478
-    id: fb2a6fc0-fa80-468f-85ab-fce898e68af6
 
 /cis_workstation_l1:
     environment+:
         PROFILE: cis_workstation_l1
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l1
-    extra-nitrate: TC#0615479
-    id: a8bf4338-a3c0-430d-8aea-e494d20cb75a
 
 /cis_workstation_l2:
     environment+:
         PROFILE: cis_workstation_l2
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cis_workstation_l2
-    extra-nitrate: TC#0615480
-    id: 087db3e2-3014-4f3a-8f36-7a2dc63af6a1
 
 /cui:
     environment+:
@@ -59,30 +44,18 @@ duration: 2h
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/cui
-    extra-nitrate: TC#0615481
-    id: 79f376c2-e518-4d7d-b62b-44156da7dc79
 
 /e8:
     environment+:
         PROFILE: e8
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/e8
-    extra-nitrate: TC#0615482
-    id: ce009bae-f18d-45a2-ace0-7e9b80f93c42
 
 /hipaa:
     environment+:
         PROFILE: hipaa
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/hipaa
-    extra-nitrate: TC#0615483
-    id: f5c798e1-0c82-4886-a5d8-91f63929efae
 
 /ism_o:
     environment+:
         PROFILE: ism_o
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ism_o
-    extra-nitrate: TC#0615484
-    id: 86e0eb89-aca8-4f3c-9dcd-274827153d02
 
 /ospp:
     environment+:
@@ -93,16 +66,10 @@ duration: 2h
         because: >
             not supported on RHEL-8 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ospp
-    extra-nitrate: TC#0615485
-    id: bf8a040e-23c5-489e-8202-7a2d39828adc
 
 /pci-dss:
     environment+:
         PROFILE: pci-dss
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/pci-dss
-    extra-nitrate: TC#0615486
-    id: 358e4f83-4a83-442b-9f91-4480abe8b85e
 
 /stig:
     environment+:
@@ -113,16 +80,10 @@ duration: 2h
             not supported with GUI, use stig_gui instead;
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig
-    extra-nitrate: TC#0615487
-    id: 97922f22-f3a7-4e2a-9dd2-71c34d0400d4
 
 /stig_gui:
     environment+:
         PROFILE: stig_gui
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/stig_gui
-    extra-nitrate: TC#0615488
-    id: 184a8acc-4759-480d-a0b6-948f6df720db
 
 /ccn_advanced:
     environment+:
@@ -131,6 +92,3 @@ duration: 2h
       - when: distro == rhel-8
         enabled: false
         because: CNN Advanced profile is specific to RHEL 9
-    extra-summary: /CoreOS/scap-security-guide/hardening/oscap/with-gui/ccn_advanced
-    extra-nitrate: TC#0615557
-    id: f73289ae-643d-4cf0-bf01-e1b31cdefd40

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -37,15 +37,10 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-tag:
-  - max1
-  - daily
 
 # for use with the RULE environment variable
 /from-env:
     tag:
-      - NoProductization
-      - NoStabilization
       - needs-param
     /oscap:
     /ansible:

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -48,160 +48,64 @@ tag:
       - NoStabilization
       - needs-param
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env/oscap
-        extra-nitrate: TC#0617199
-        id: 237c1eaf-bf68-4eba-b097-6cc0222ca282
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/from-env/ansible
-        extra-nitrate: TC#0617448
-        id: 0ddf3a59-be7c-4511-82ac-71a6efe4544e
 
 /1:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/1/oscap
-        extra-nitrate: TC#0617184
-        id: ccef824b-20d1-4509-8bae-8553f67608db
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/1/ansible
-        extra-nitrate: TC#0617433
-        id: 62e723ca-103e-4e87-b0dd-a76af38a4132
 
 /2:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/2/oscap
-        extra-nitrate: TC#0617191
-        id: b42e38dd-3b5d-4901-867e-1715eaf9aa95
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/2/ansible
-        extra-nitrate: TC#0617440
-        id: 2e6e47eb-3567-4f0d-baee-0cb7e606a36c
 
 /3:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/3/oscap
-        extra-nitrate: TC#0617192
-        id: 94e30407-823f-4c06-a47c-2c4bf8f1d356
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/3/ansible
-        extra-nitrate: TC#0617441
-        id: e2f6b558-9cf1-4943-b6d5-3964273ea852
 
 /4:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/4/oscap
-        extra-nitrate: TC#0617193
-        id: 9c6f132b-ebbf-42cd-b914-ac3f8fa6aa90
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/4/ansible
-        extra-nitrate: TC#0617442
-        id: 6bea4901-eb10-48f4-8349-4aa801e8f78c
 
 /5:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/5/oscap
-        extra-nitrate: TC#0617194
-        id: bf193dd8-c102-4659-9935-45106f06dd0b
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/5/ansible
-        extra-nitrate: TC#0617443
-        id: 216e2550-03b6-41ec-b6fd-e31dfa5e91bf
 
 /6:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/6/oscap
-        extra-nitrate: TC#0617195
-        id: 6adea628-3166-4b33-aa04-ab910ed997b2
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/6/ansible
-        extra-nitrate: TC#0617444
-        id: 12b75ece-619c-489d-95a0-b4b0cae0de73
 
 /7:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/7/oscap
-        extra-nitrate: TC#0617196
-        id: fb780940-e9f7-4864-b4f7-6caabfdec066
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/7/ansible
-        extra-nitrate: TC#0617445
-        id: c21a5eaa-bcaa-4784-a988-c44cb240eda6
 
 /8:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/8/oscap
-        extra-nitrate: TC#0617197
-        id: 1bc5fcef-3e5a-43a8-b9de-532a87bad95b
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/8/ansible
-        extra-nitrate: TC#0617446
-        id: 76aff506-8425-4bb6-acd0-28a315651884
 
 /9:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/9/oscap
-        extra-nitrate: TC#0617198
-        id: c82b9968-e5b9-4570-b04b-f11d9565c234
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/9/ansible
-        extra-nitrate: TC#0617447
-        id: 632ad14f-8823-4f96-aee0-640de8c72b98
 
 /10:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/10/oscap
-        extra-nitrate: TC#0617185
-        id: d6b4651f-43c9-4836-9ddd-9b426f753b77
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/10/ansible
-        extra-nitrate: TC#0617434
-        id: e85ea7df-ce8b-432f-8c27-ca589ee3e7f5
 
 /11:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/11/oscap
-        extra-nitrate: TC#0617186
-        id: 3c58f725-0e34-4a53-9b47-653d47c7e49a
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/11/ansible
-        extra-nitrate: TC#0617435
-        id: e6afe2ab-64d9-4d7e-a676-71abdfa8fa79
 
 /12:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/12/oscap
-        extra-nitrate: TC#0617187
-        id: 7c90efc8-59b5-4d45-b8ed-ca381b106fcb
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/12/ansible
-        extra-nitrate: TC#0617436
-        id: 5aa4dcb3-c395-4e67-ab68-1eb8bb86a7fc
 
 /13:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/13/oscap
-        extra-nitrate: TC#0617188
-        id: 0f496d79-4fef-4338-8ca1-93fb21ed5d6f
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/13/ansible
-        extra-nitrate: TC#0617437
-        id: 96fb9dce-8db5-4aaf-9276-46bfc6378c66
 
 /14:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/14/oscap
-        extra-nitrate: TC#0617189
-        id: 330f74dc-8851-4e45-b23a-0637037ace08
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/14/ansible
-        extra-nitrate: TC#0617438
-        id: f0009f19-ed96-4da7-9951-f837fdc3d891
 
 /15:
     /oscap:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/15/oscap
-        extra-nitrate: TC#0617190
-        id: 82cdc8da-bf6c-4996-8e72-bcb83cd85050
     /ansible:
-        extra-summary: /CoreOS/scap-security-guide/per-rule/15/ansible
-        extra-nitrate: TC#0617439
-        id: a46774b5-e751-4c7b-8dfe-7f1a3232cc0f

--- a/scanning/disa-alignment/anaconda.fmf
+++ b/scanning/disa-alignment/anaconda.fmf
@@ -4,9 +4,6 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
-tag:
-  - max1
-  - daily
 adjust:
   - when: distro >= rhel-10
     enabled: false

--- a/scanning/disa-alignment/anaconda.fmf
+++ b/scanning/disa-alignment/anaconda.fmf
@@ -11,6 +11,3 @@ adjust:
   - when: distro >= rhel-10
     enabled: false
     because: content doesn't have pre-made kickstarts for RHEL-10+
-extra-summary: /CoreOS/scap-security-guide/scanning/disa-alignment/anaconda
-extra-nitrate: TC#0617227
-id: e4ad5180-63d3-4abf-9596-5ceae361875a

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -23,7 +23,7 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
     oscap_conf = {
         'content-type': 'datastream',
         'content-url': f'http://{host}:{port}/remediation-ds.xml',
-        'profile': shared.profile_full,
+        'profile': shared.profile,
     }
     ks.add_oscap(oscap_conf)
 

--- a/scanning/disa-alignment/ansible.fmf
+++ b/scanning/disa-alignment/ansible.fmf
@@ -9,6 +9,3 @@ require+:
   # needed for the ini_file ansible plugin, and more
   - rhc-worker-playbook
 duration: 1h
-tag:
-  - max1
-  - daily

--- a/scanning/disa-alignment/ansible.fmf
+++ b/scanning/disa-alignment/ansible.fmf
@@ -12,6 +12,3 @@ duration: 1h
 tag:
   - max1
   - daily
-extra-summary: /CoreOS/scap-security-guide/scanning/disa-alignment/ansible
-extra-nitrate: TC#0617228
-id: 2fc98724-cb1c-46c3-9714-3e9168a4f3c5

--- a/scanning/disa-alignment/oscap.fmf
+++ b/scanning/disa-alignment/oscap.fmf
@@ -4,6 +4,3 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
-tag:
-  - max1
-  - daily

--- a/scanning/disa-alignment/oscap.fmf
+++ b/scanning/disa-alignment/oscap.fmf
@@ -7,6 +7,3 @@ duration: 1h
 tag:
   - max1
   - daily
-extra-summary: /CoreOS/scap-security-guide/scanning/disa-alignment/oscap
-extra-nitrate: TC#0617229
-id: bb380a85-1a28-428a-af6e-623e7c921064

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -21,7 +21,7 @@ with g.snapshotted():
     g.copy_to('remediation-ds.xml')
     for _ in range(2):
         cmd = [
-            'oscap', 'xccdf', 'eval', '--profile', shared.profile_full,
+            'oscap', 'xccdf', 'eval', '--profile', shared.profile,
             '--progress', '--remediate', 'remediation-ds.xml',
         ]
         proc = g.ssh(' '. join(cmd))

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -4,7 +4,6 @@ from lib import results
 
 
 profile = 'stig'
-profile_full = f'xccdf_org.ssgproject.content_profile_{profile}'
 
 shared_cmd = ['oscap', 'xccdf', 'eval', '--progress']
 
@@ -16,7 +15,7 @@ def content_scan(host, ds, html, arf):
     """
     cmd = [
         *shared_cmd,
-        '--profile', profile_full,
+        '--profile', profile,
         '--report', html,
         '--stig-viewer', arf,
         ds,

--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -6,6 +6,3 @@ environment+:
 duration: 15m
 require+:
   - openscap-scanner
-tag:
-  - CI-Tier-1
-  - Errata

--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -9,6 +9,3 @@ require+:
 tag:
   - CI-Tier-1
   - Errata
-extra-summary: /CoreOS/scap-security-guide/scanning/oscap-eval
-extra-nitrate: TC#0615489
-id: 12ccbda9-d7e4-4331-a74d-14f9abdd9374

--- a/static-checks/ansible/allowed-modules/main.fmf
+++ b/static-checks/ansible/allowed-modules/main.fmf
@@ -21,6 +21,3 @@ adjust:
   - when: arch == aarch64
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64
-extra-summary: /CoreOS/scap-security-guide/static-checks/ansible/allowed-modules
-extra-nitrate: TC#0615492
-id: 2081f398-38e2-4404-94c4-b88f2e73ccb0

--- a/static-checks/ansible/allowed-modules/main.fmf
+++ b/static-checks/ansible/allowed-modules/main.fmf
@@ -14,9 +14,6 @@ recommend+:
   - ansible-core
   # needed for the ini_file ansible plugin, and more
   - rhc-worker-playbook
-tag:
-  - CI-Tier-1
-  - daily
 adjust:
   - when: arch == aarch64
     enabled: false

--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -22,4 +22,3 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: Ansible playbooks are same on all architectures
-extra-summary: /CoreOS/scap-security-guide/static-checks/ansible/syntax-check

--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -15,9 +15,6 @@ recommend+:
   - rhc-worker-playbook
   # individual rule playbooks
   - scap-security-guide-rule-playbooks
-tag:
-  - CI-Tier-1
-  - daily
 adjust:
   - when: arch != x86_64
     enabled: false

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -3,7 +3,6 @@ environment+:
     PYTHONPATH: ../..
 duration: 10m
 tag:
-  - NoProductization
   - always-fails
 
 /profiles:

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -9,27 +9,15 @@ tag:
 /profiles:
     summary: Diff datastreams, output added/removed profiles
     test: python3 -m lib.runtest ./profiles.py
-    extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profiles
-    extra-nitrate: TC#0617452
-    id: 5f0d1df1-f2b5-4212-84e7-2c25ec5566c1
 
 /profile-titles:
     summary: Diff datastreams, output profile title differences
     test: python3 -m lib.runtest ./profile-titles.py
-    extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-titles
-    extra-nitrate: TC#0617450
-    id: 9e43b634-eaab-4e4f-81c2-bbab571f7db1
 
 /profile-rules:
     summary: Diff datastreams, output profile rule/variable differences
     test: python3 -m lib.runtest ./profile-rules.py
-    extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-rules
-    extra-nitrate: TC#0617449
-    id: d17358be-d702-4786-a9df-6716036c8428
 
 /profile-variables:
     summary: Diff datastreams, output profile variable refine differences
     test: python3 -m lib.runtest ./profile-variables.py
-    extra-summary: /CoreOS/scap-security-guide/static-checks/diff/profile-variables
-    extra-nitrate: TC#0617451
-    id: dd504436-0d67-4f1c-96f4-faeff18a2c0c

--- a/static-checks/html-links/main.fmf
+++ b/static-checks/html-links/main.fmf
@@ -6,8 +6,6 @@ environment+:
 duration: 5m
 recommend+:
   - python3-requests
-tag:
-  - daily
 adjust:
   - enabled: false
     when: arch != x86_64

--- a/static-checks/html-links/main.fmf
+++ b/static-checks/html-links/main.fmf
@@ -12,6 +12,3 @@ adjust:
   - enabled: false
     when: arch != x86_64
     continue: false
-extra-summary: /CoreOS/scap-security-guide/static-checks/html-links
-extra-nitrate: TC#0617233
-id: 8943f18e-666d-48c1-b172-fd71f999f7c9

--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -12,6 +12,3 @@ adjust:
   - enabled: false
     when: arch != x86_64
     continue: false
-extra-summary: /CoreOS/scap-security-guide/static-checks/nist-validation
-extra-nitrate: TC#0617590
-id: 1b8e363a-5cc2-42df-8931-30a6b26a57ee

--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -6,8 +6,6 @@ environment+:
 duration: 15m
 require+:
   - java-17-openjdk
-tag:
-  - daily
 adjust:
   - enabled: false
     when: arch != x86_64

--- a/static-checks/removed-rules/main.fmf
+++ b/static-checks/removed-rules/main.fmf
@@ -4,6 +4,3 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 10m
-extra-summary: /CoreOS/scap-security-guide/static-checks/removed-rules
-extra-nitrate: TC#0617453
-id: 6dfdc617-53f7-45de-af41-feeb9ae991ea

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -21,6 +21,3 @@ tag:
   - CI-Tier-1
   - Errata
   - daily
-extra-summary: /CoreOS/scap-security-guide/static-checks/rpmbuild-ctest
-extra-nitrate: TC#0615490
-id: 87442db1-5e7a-4c3f-93fa-1e37b233721e

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -17,7 +17,3 @@ recommend+:
   - ansible-core
   - rhc-worker-playbook
   - bats
-tag:
-  - CI-Tier-1
-  - Errata
-  - daily


### PR DESCRIPTION
This removes now-useless TCMS metadata, as well as seemingly undocumented tags (not in `docs/TESTS.md`) and makes `/hardening` tests parse profile name from the test name, rather than from a separate `PROFILE` variable.

I couldn't decide whether ie.
```yaml
/anssi_bp28_high:
/cis:
/cis_server_l1:
/cis_workstation_l1:
/cis_workstation_l2:
/cui:
    adjust+:
      - when: distro >= rhel-10
        enabled: false
        because: there is no CUI profile on RHEL-10+
/e8:
/hipaa:
/ism_o:
/ospp:
/pci-dss:
/stig:
/stig_gui:
    adjust+:
      - enabled: false
        because: not supported without GUI, use stig instead
/ccn_advanced:
    adjust+:
      - when: distro == rhel-8
        enabled: false
        because: CNN Advanced profile is specific to RHEL 9
```
looked better than spacing each profile name with a newline, so I left the newlines in. If you prefer the compacted version, I can update the PR.

Tested on all `/hardening/.*/cis$` to exercise every test, and it seems to work. I'd like to do a full productization run before merging this PR, though.