### PR TITLE
Add `g++` requirement to rpmbuild-ctest

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -10,6 +10,7 @@ require+:
   - python3-jinja2
   - python3-devel
   - python3-pip
+  - gcc-c++
 recommend+:
   - dnf-utils
   - yum-utils


### PR DESCRIPTION
On ppc64le, pandas installation fails over and over ending in overall `error` test result.

Compilers are mentioned in pandas error messages. `gcc` wasn't sufficient, but with `gcc-c++` I was able to install pandas, build SSG and run unit tests.