### PR TITLE
Add `/hardening/kickstart` tests for oscap-generated kickstarts

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -9,6 +9,8 @@
 # which are not available in their final form in the Anaconda environment
 # - see https://github.com/ComplianceAsCode/content/issues/9746
 /hardening/anaconda(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
+# - possibly unrelated https://github.com/ComplianceAsCode/content/issues/12276
+/hardening/kickstart(/with-gui)?/[^/]+/firewalld_sshd_port_enabled
 # https://github.com/ComplianceAsCode/content/issues/11625
 /hardening/image-builder/[^/]+/firewalld_sshd_port_enabled
     True
@@ -17,6 +19,9 @@
 # and a later enable_authselect remediation breaks it
 # - see https://github.com/OpenSCAP/openscap/issues/1880
 /hardening/anaconda/.+/accounts_password_pam_retry
+# - happens for kickstarts too, even when those should not fail on ordering,
+#   https://github.com/ComplianceAsCode/content/issues/12277
+/hardening/kickstart/.+/accounts_password_pam_retry
     True
 
 # caused by one of:
@@ -39,7 +44,6 @@
 # https://github.com/ComplianceAsCode/content/issues/10424
 # happens on host-os hardening too, probably because Beaker doesn't have
 # firewall enabled or even installed
-/hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
 /hardening/host-os/oscap/[^/]+/service_nftables_disabled
     True
 
@@ -54,10 +58,19 @@
 # https://issues.redhat.com/browse/RHEL-45706
 /hardening/anaconda/with-gui/[^/]+/service_avahi-daemon_disabled
 /hardening/anaconda(/with-gui)?/cis[^/]*/socket_systemd-journal-remote_disabled
-    True
-
 # https://github.com/ComplianceAsCode/content/issues/11498
 /hardening/anaconda/with-gui/[^/]+/service_bluetooth_disabled
+# related to, but probably not caused by:
+# https://github.com/ComplianceAsCode/content/issues/10424
+/hardening/anaconda(/with-gui)?/[^/]+/service_nftables_disabled
+    True
+
+# https://github.com/ComplianceAsCode/content/issues/12282
+/hardening/kickstart/.+/service_avahi-daemon_disabled
+/hardening/kickstart/.+/socket_systemd-journal-remote_disabled
+/hardening/kickstart/.+/service_bluetooth_disabled
+/hardening/kickstart/.+/service_nftables_disabled
+/hardening/kickstart/.+/systemd_tmp_mount_enabled
     True
 
 # RHEL-9 is not FIPS certified yet

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -30,7 +30,7 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
         'content-url': f'http://{host}:{port}/remediation-ds.xml',
         'profile': profile,
     }
-    ks.add_oscap(oscap_conf)
+    ks.add_oscap_addon(oscap_conf)
 
     g.install(kickstart=ks)
 

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -13,7 +13,8 @@ g = virt.Guest()
 profile = util.get_test_name().rpartition('/')[2]
 
 # use kickstart from content, not ours
-ks = virt.translate_ssg_kickstart(profile)
+ks_file = util.get_kickstart(profile)
+ks = virt.translate_ssg_kickstart(ks_file)
 
 if os.environ.get('USE_SERVER_WITH_GUI'):
     ks.packages.append('@Server with GUI')

--- a/hardening/image-builder/test.py
+++ b/hardening/image-builder/test.py
@@ -9,13 +9,28 @@ g = osbuild.Guest()
 
 profile = util.get_test_name().rpartition('/')[2]
 
-g.create(profile=profile)
+ds = util.get_datastream()
+
+# provide our modified DS via RpmPack to the VM as /root/contest-ds.xml,
+# tell the 'oscap xccdf eval --remediate' called by osbuild-composer to use it
+rpmpack = util.RpmPack()
+rpmpack.add_file(ds, '/root/contest-ds.xml')
+
+cmd = [
+    'oscap', 'xccdf', 'generate', '--profile', profile,
+    'fix', '--fix-type', 'blueprint',
+    ds,
+]
+_, lines = util.subprocess_stream(cmd, check=True)
+blueprint = osbuild.translate_oscap_blueprint(lines, profile, '/root/contest-ds.xml')
+
+g.create(blueprint=blueprint, rpmpack=rpmpack)
 
 with g.booted():
     # scan the remediated system
     proc, lines = g.ssh_stream(
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
-        f' --results-arf results-arf.xml {g.DATASTREAM}'
+        f' --results-arf results-arf.xml /root/contest-ds.xml'
     )
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:

--- a/hardening/image-builder/test.py
+++ b/hardening/image-builder/test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 from lib import results, oscap, osbuild, util
+from conf import remediation
 
 
 osbuild.Host.setup()
@@ -9,28 +10,30 @@ g = osbuild.Guest()
 
 profile = util.get_test_name().rpartition('/')[2]
 
-ds = util.get_datastream()
+oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
 
-# provide our modified DS via RpmPack to the VM as /root/contest-ds.xml,
+# provide our modified DS via RpmPack to the VM as /root/remediation-ds.xml,
 # tell the 'oscap xccdf eval --remediate' called by osbuild-composer to use it
 rpmpack = util.RpmPack()
-rpmpack.add_file(ds, '/root/contest-ds.xml')
+rpmpack.add_file('remediation-ds.xml', '/root/remediation-ds.xml')
 
 cmd = [
     'oscap', 'xccdf', 'generate', '--profile', profile,
     'fix', '--fix-type', 'blueprint',
-    ds,
+    'remediation-ds.xml',
 ]
 _, lines = util.subprocess_stream(cmd, check=True)
-blueprint = osbuild.translate_oscap_blueprint(lines, profile, '/root/contest-ds.xml')
+blueprint = osbuild.translate_oscap_blueprint(lines, '/root/remediation-ds.xml')
 
 g.create(blueprint=blueprint, rpmpack=rpmpack)
 
 with g.booted():
+    # copy the original DS to the guest
+    g.copy_to(util.get_datastream(), 'scan-ds.xml')
     # scan the remediated system
     proc, lines = g.ssh_stream(
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
-        f' --results-arf results-arf.xml /root/contest-ds.xml'
+        f' --results-arf results-arf.xml scan-ds.xml'
     )
     oscap.report_from_verbose(lines)
     if proc.returncode not in [0,2]:

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -1,0 +1,103 @@
+summary: Remediates VM via oscap-generated kickstart, scans via oscap
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 1h
+require+:
+  # virt library dependencies
+  - libvirt-daemon
+  - libvirt-daemon-driver-qemu
+  - libvirt-daemon-driver-storage-core
+  - libvirt-daemon-driver-network
+  - firewalld
+  - qemu-kvm
+  - libvirt-client
+  - virt-install
+  - rpm-build
+  - createrepo
+  # oscap is used to generate a kickstart fix
+  - openscap-scanner
+extra-hardware: |
+    keyvalue = HVM=1
+    hostrequire = memory>=3720
+adjust:
+  - when: arch != x86_64
+    enabled: false
+    because: we want to run virtualization on x86_64 only
+  - when: distro < rhel-10
+    enabled: false
+    because: >
+        too late in the RHEL-8 lifecycle for this,
+        TODO enable this on RHEL-9 once OpenSCAP v1.4 is there
+
+/anssi_bp28_high:
+
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
+/cis:
+
+/cis_server_l1:
+    tag+:
+      - subset-profile
+
+/cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
+
+/cui:
+    adjust+:
+      - when: distro >= rhel-10
+        enabled: false
+        because: there is no CUI profile on RHEL-10+
+
+/e8:
+
+/hipaa:
+
+/ism_o:
+
+/ospp:
+
+/pci-dss:
+
+/stig:
+
+/stig_gui:
+    adjust+:
+      - enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_advanced:
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/kickstart/test.py
+++ b/hardening/kickstart/test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+import os
+
+from lib import util, results, virt, oscap
+from conf import remediation
+
+
+virt.Host.setup()
+
+g = virt.Guest()
+
+profile = util.get_test_name().rpartition('/')[2]
+
+oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
+
+# provide our modified DS via RpmPack to the VM as /root/remediation-ds.xml,
+# tell the 'oscap xccdf eval --remediate' in %post to use it
+rpmpack = util.RpmPack()
+rpmpack.add_file('remediation-ds.xml', '/root/remediation-ds.xml')
+
+cmd = [
+    'oscap', 'xccdf', 'generate', '--profile', profile,
+    'fix', '--fix-type', 'kickstart',
+    'remediation-ds.xml',
+]
+_, lines = util.subprocess_stream(cmd, check=True)
+ks = virt.translate_oscap_kickstart(lines, '/root/remediation-ds.xml')
+
+if os.environ.get('USE_SERVER_WITH_GUI'):
+    ks.packages.append('@Server with GUI')
+
+g.install(kickstart=ks, rpmpack=rpmpack)
+
+with g.booted():
+    # copy the original DS to the guest
+    g.copy_to(util.get_datastream(), 'scan-ds.xml')
+    # scan the remediated system
+    proc, lines = g.ssh_stream(
+        f'oscap xccdf eval --profile {profile} --progress --report report.html'
+        f' --results-arf results-arf.xml scan-ds.xml'
+    )
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0,2]:
+        raise RuntimeError("post-reboot oscap failed unexpectedly")
+
+    g.copy_from('report.html')
+    g.copy_from('results-arf.xml')
+
+util.subprocess_run(['gzip', '-9', 'results-arf.xml'], check=True)
+
+results.report_and_exit(logs=['report.html', 'results-arf.xml.gz'])

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -1,0 +1,98 @@
+environment+:
+    USE_SERVER_WITH_GUI: 1
+duration: 2h
+
+/anssi_bp28_high:
+
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
+/cis:
+    adjust+:
+      - enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+
+/cis_server_l1:
+    tag+:
+      - subset-profile
+    adjust+:
+      - enabled: false
+        because: >
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+
+/cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
+
+/cui:
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+      - when: distro >= rhel-10
+        enabled: false
+        because: there is no CUI profile on RHEL-10+
+
+/e8:
+
+/hipaa:
+
+/ism_o:
+
+/ospp:
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: >
+            not supported on RHEL-8 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+
+/pci-dss:
+
+/stig:
+    adjust+:
+      - enabled: false
+        because: >
+            not supported with GUI, use stig_gui instead;
+            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
+            the "Profiles not compatible with Server with GUI" table
+
+/stig_gui:
+
+/ccn_advanced:
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -38,7 +38,6 @@ import collections
 from pathlib import Path
 
 from lib import util, dnf, virt
-from conf import remediation
 
 
 class Host:
@@ -214,17 +213,6 @@ class Blueprint:
             post,
         ])
 
-    def add_openscap_tailoring(self, *, selected=None, unselected=None):
-        if '[customizations.openscap.tailoring]' in self.assembled:
-            raise SyntaxError("openscap.taioring section already exists")
-        if not selected and not unselected:
-            return
-        self.assembled += '[customizations.openscap.tailoring]\n'
-        for name, vals in [('selected', selected), ('unselected', unselected)]:
-            if vals:
-                strings = ','.join(f'"{x}"' for x in vals)
-                self.assembled += f'{name} = [ {strings} ]\n'
-
     @contextlib.contextmanager
     def to_tmpfile(self):
         bp = self.assembled
@@ -387,7 +375,7 @@ def composer_cli_out(*args, **kwargs):
     return out.stdout.rstrip('\n')
 
 
-def translate_oscap_blueprint(lines, profile, datastream):
+def translate_oscap_blueprint(lines, datastream):
     """
     Parse (and tweak) a blueprint generated via 'oscap xccdf generate fix'.
     """
@@ -406,6 +394,5 @@ def translate_oscap_blueprint(lines, profile, datastream):
 
     # add openscap hardening, honor global excludes
     blueprint.set_openscap_datastream(datastream)
-    blueprint.add_openscap_tailoring(unselected=remediation.excludes())
 
     return blueprint

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -308,7 +308,7 @@ class Kickstart:
                 '\nEOF')
         self.add_post('\n'.join(installed_repos))
 
-    def add_oscap(self, keyvals):
+    def add_oscap_addon(self, keyvals):
         """Append an OSCAP addon section, with key=value pairs from 'keyvals'."""
         lines = '\n'.join(f'  {k} = {v}' for k, v in keyvals.items())
         section = 'org_fedora_oscap' if versions.rhel < 9 else 'com_redhat_oscap'

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -804,15 +804,12 @@ def virsh(*virsh_args, **run_args):
     return subprocess.run(cmd, **run_args)
 
 
-def translate_ssg_kickstart(profile):
+def translate_ssg_kickstart(ks_file):
     """
     Parse (and tweak) a kickstart shipped with the upstream content
     into class Kickstart instance.
     """
     ks_text = ''
-    ks_file = util.get_kickstart(profile)
-    util.log(f"using orig file: {ks_file}")
-
     with open(ks_file) as f:
         for line in f:
             line = line.rstrip('\n')

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -236,12 +236,7 @@ class Host:
 
 class Kickstart:
     TEMPLATE = util.dedent(fr'''
-        lang en_US.UTF-8
-        keyboard --vckeymap us
-        network --onboot yes --bootproto dhcp
         rootpw {GUEST_LOGIN_PASS}
-        firstboot --disable
-        selinux --enforcing
         timezone --utc Europe/Prague
         bootloader --append="console=ttyS0,115200 mitigations=off"
         reboot

--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -11,12 +11,14 @@ discover:
       # without GUI/UEFI/etc. variants
       - /hardening/oscap/[^/]+$
       - /hardening/anaconda/[^/]+$
+      - /hardening/kickstart/[^/]+$
       - /hardening/ansible/[^/]+$
       - /hardening/image-builder/[^/]+$
       # add stig_gui as an exception here, since it needs to be tested somehow
       # but the only way to do it is via GUI
       - /hardening/oscap/with-gui/stig_gui
       - /hardening/anaconda/with-gui/stig_gui
+      - /hardening/kickstart/with-gui/stig_gui
       - /hardening/ansible/with-gui/stig_gui
       - /hardening/image-builder/with-gui/stig_gui
       # run host-os as well - not because it would be very useful compared to

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -11,7 +11,8 @@ virt.Host.setup()
 
 g = virt.Guest()
 
-ks = virt.translate_ssg_kickstart(shared.profile)
+ks_file = util.get_kickstart(shared.profile)
+ks = virt.translate_ssg_kickstart(ks_file)
 
 # host a HTTP server with a datastream and let the guest download it
 with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -25,7 +25,7 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
         'content-url': f'http://{host}:{port}/remediation-ds.xml',
         'profile': shared.profile,
     }
-    ks.add_oscap(oscap_conf)
+    ks.add_oscap_addon(oscap_conf)
 
     g.install(kickstart=ks)
 


### PR DESCRIPTION
(Probably best to go commit-by-commit - the early ones are about cleanup.)

The image-builder (osbuild) rework is mainly to unify the API with `/hardening/kickstart`. I would have done the same for `/hardening/anaconda`, but (IIRC) openscap `%addon` cannot read `file://` URLs or point to local files on the installed OS, it can only reliably use remote HTTP URLs.