### PR TITLE
Extend rpmbuild-ctest duration

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -3,7 +3,7 @@ test: python3 -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
-duration: 1h
+duration: 2h
 require+:
   - rpm-build
   - cmake


### PR DESCRIPTION
On Fedora, Content builds and tests all available products which takes significantly longer than just RHEL build+test.

https://artifacts.dev.testing-farm.io/d4598026-0aff-4b6c-be09-04495974be57/ - 40min spend just on build. 
2h should do it. However, not tested on public TF ranch (2h is my assumption as it got killed on `232/372` ctest). My previous testing in Beaker, on VM, and on TF (not public though) took <1h.