### PR TITLE
DNF5 support, `python3-setuptools` in rpmbuild-ctest, and `pandas` removal from rpmbuild-ctest

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -133,7 +133,7 @@ def get_content(build=True):
         with dnf.download_rpm('scap-security-guide', source=True) as src_rpm:
             with tempfile.TemporaryDirectory() as tmpdir:
                 # install dependencies
-                cmd = ['dnf', '-y', 'builddep', '--srpm', src_rpm]
+                cmd = ['dnf', '-y', 'builddep', src_rpm]
                 util.subprocess_run(cmd, check=True, cwd=tmpdir)
                 # extract + patch SRPM
                 cmd = ['rpmbuild', '-rp', '--define', f'_topdir {tmpdir}', src_rpm]

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -10,6 +10,7 @@ require+:
   - python3-jinja2
   - python3-devel
   - python3-pip
+  - python3-setuptools
   - gcc-c++
 recommend+:
   - dnf-utils

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -31,7 +31,7 @@ else:
 
 ansible.install_deps()
 # Extra modules to enable more unit tests
-python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'pandas', 'cmakelint']
+python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'cmakelint']
 util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])
 
 with util.get_content(build=False) as content_dir:


### PR DESCRIPTION
`--srpm` is not supported by dnf5 and dnf4 doesn't require it, thus to make it compatible with both, remove it.

On Fedora Rawhide, I've hit there was missing `python3-setuptools` required for Content build. Add it.

Remove `pandas` from `pip3` in rpmbuild test. On Fedora it now requires python 3.10+. Previously, there were some compilation errors... Thus, rather remove it as it brings more problems than it solves - it added unit tests for SRG related util scripts which I don't consider that important.