### PR TITLE
Introduce `subset-profile` tag

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -164,8 +164,8 @@
 # Image Builder
 #
 # TODO: file issues ?
-/hardening/image-builder/anssi_bp28_high/mount_option_tmp_noexec
-/hardening/image-builder/anssi_bp28_high/sebool_polyinstantiation_enabled
+/hardening/image-builder/anssi_[^/]+/mount_option_tmp_noexec
+/hardening/image-builder/anssi_[^/]+/sebool_polyinstantiation_enabled
     True
 /hardening/image-builder/hipaa/sebool_selinuxuser_execmod
     rhel == 9

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -75,7 +75,7 @@
 # https://github.com/ComplianceAsCode/content/issues/11565
 /hardening/image-builder/.*/audit_rules_privileged_commands
 # https://github.com/ComplianceAsCode/content/issues/11566
-/hardening/image-builder/(hipaa|anssi_bp28_high)/sebool_selinuxuser_execstack
+/hardening/image-builder/[^/]+/sebool_selinuxuser_execstack
 # https://github.com/ComplianceAsCode/content/issues/11567
 /hardening/image-builder/.*/enable_dracut_fips_module
 /hardening/image-builder/.*/enable_fips_mode
@@ -84,7 +84,7 @@
     True
 # OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
 # https://issues.redhat.com/browse/RHEL-25574
-/hardening/image-builder/ccn_advanced
+/hardening/image-builder/ccn_[^/]+
     rhel == 9 and status == 'error'
 
 # DISA Alignment waivers

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -112,3 +112,16 @@ unusable for further testing, typically by hardening it.
 
 A test that just installs extra RPMs from the package manager, or enables
 extra services, is not considered destructive.
+
+## `subset-profile`
+
+Some compliance standards specify multiple "levels" of system hardening,
+with the more permissive levels typically being a subset of the more
+restrictive ones, ie. Minimal, Intermediary and Enhanced.
+
+This tag signifies that a test covers one of the levels (profiles), which
+are themselves a subset of another level (profile).
+
+There are other minor factors (content profile variables) that break this
+relationship, however, if you want a smaller test set at the cost of ignoring
+these factors, exclude tests with this tag.

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -29,13 +29,29 @@ adjust:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -58,10 +74,26 @@ adjust:
 /stig_gui:
     adjust+:
       - enabled: false
-        because: not supported without GUI, use stig instead
+        because: CCN profiles are not present on RHEL-8
 
 /ccn_advanced:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -4,6 +4,18 @@ duration: 2h
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
     adjust+:
       - enabled: false
@@ -12,15 +24,19 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
+    tag+:
+      - subset-profile
     adjust+:
       - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
 
-/cis_workstation_l1:
-
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -63,4 +79,20 @@ duration: 2h
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -30,13 +30,29 @@ adjust:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -65,4 +81,20 @@ adjust:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -4,6 +4,18 @@ duration: 2h
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
     adjust+:
       - enabled: false
@@ -12,15 +24,19 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
+    tag+:
+      - subset-profile
     adjust+:
       - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
 
-/cis_workstation_l1:
-
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -63,4 +79,20 @@ duration: 2h
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -19,13 +19,29 @@ adjust:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -54,4 +70,20 @@ adjust:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -11,13 +11,29 @@ tag:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -46,4 +62,20 @@ tag:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -33,13 +33,29 @@ adjust:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -68,4 +84,20 @@ adjust:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -26,13 +26,29 @@ adjust:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -61,4 +77,20 @@ adjust:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -12,13 +12,29 @@ environment+:
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
 
 /cis_server_l1:
-
-/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -47,4 +63,20 @@ environment+:
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -4,6 +4,18 @@ duration: 2h
 
 /anssi_bp28_high:
 
+/anssi_bp28_enhanced:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_intermediary:
+    tag+:
+      - subset-profile
+
+/anssi_bp28_minimal:
+    tag+:
+      - subset-profile
+
 /cis:
     adjust+:
       - enabled: false
@@ -12,15 +24,19 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /cis_server_l1:
+    tag+:
+      - subset-profile
     adjust+:
       - enabled: false
         because: >
             not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
             the "Profiles not compatible with Server with GUI" table
 
-/cis_workstation_l1:
-
 /cis_workstation_l2:
+
+/cis_workstation_l1:
+    tag+:
+      - subset-profile
 
 /cui:
     adjust+:
@@ -63,4 +79,20 @@ duration: 2h
     adjust+:
       - when: distro == rhel-8
         enabled: false
-        because: CNN Advanced profile is specific to RHEL 9
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_intermediate:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8
+
+/ccn_basic:
+    tag+:
+      - subset-profile
+    adjust+:
+      - when: distro == rhel-8
+        enabled: false
+        because: CCN profiles are not present on RHEL-8

--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -5,6 +5,7 @@ discover:
       - tag:-needs-param
       - tag:-always-fails
       - tag:-broken
+      - tag:-subset-profile
     test:
       # every remediation method, but only the basic reference environment,
       # without GUI/UEFI/etc. variants


### PR DESCRIPTION
`subset-profile` tag is for profiles that are subset of other profile. Those rulesets are covered by the other profile (superset) but variables might differ and thus it's good to test those from time to time.

In this PR, couple of "new" profiles (subset profiles) are introduced. Subset profiles are tagged and using the tag excluded from daily productization as we don't want to test all those profiles every day.

Fixes #229 