### PR TITLE
Fix disa-alignment/anaconda adjust

### DIFF
--- a/scanning/disa-alignment/anaconda.fmf
+++ b/scanning/disa-alignment/anaconda.fmf
@@ -4,7 +4,7 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 1h
-adjust:
+adjust+:
   - when: distro >= rhel-10
     enabled: false
     because: content doesn't have pre-made kickstarts for RHEL-10+


### PR DESCRIPTION
`disa-alignment/main.fmf` already has:
```
adjust:
  - when: arch != x86_64
    enabled: false
    because: run virtualization on x86_64 only
```
and recently updated `anaconda.fmf` rewrites it. We still want to run it only on x86_64 and thus changing it to `adjust+` to extend `main.fmf`.