### PR TITLE
Run datastream static checks only on x86_64

### DIFF
--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -4,6 +4,10 @@ environment+:
 duration: 10m
 tag:
   - always-fails
+adjust:
+  - when: arch != x86_64
+    enabled: false
+    because: datastream is same on all architectures
 
 /profiles:
     summary: Diff datastreams, output added/removed profiles

--- a/static-checks/removed-rules/main.fmf
+++ b/static-checks/removed-rules/main.fmf
@@ -4,3 +4,7 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 10m
+adjust:
+  - when: arch != x86_64
+    enabled: false
+    because: datastream is same on all architectures


### PR DESCRIPTION
scap-security-guide is noarch and thus datastream is same on all archs.