### PR TITLE
Extend scanning/oscap-eval duration

### DIFF
--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -3,6 +3,6 @@ test: python3 -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
-duration: 15m
+duration: 30m
 require+:
   - openscap-scanner


### PR DESCRIPTION
When content is build as part of the test, chances are quite high that test won't make it in 15min.