### PR TITLE
Verbosely print datastream XML paths from `/static-checks/diff`

### DIFF
--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -13,7 +13,7 @@ from lib import util, results
 class Datastream:
     FixType = enum.Flag('FixType', ['bash', 'ansible'])
 
-    def __init__(self, xml_file=None):
+    def __init__(self, xml_file):
         # extracted datastream metadata
         #   self.profiles = {
         #     'ospp': namespace(
@@ -30,16 +30,17 @@ class Datastream:
         #       .fixes = FixType.bash,
         #     ),
         #   }
+        #   self.path = Path(file_the_datastream_was_parsed_from)
         def make_profile():
             return types.SimpleNamespace(title=None, rules=set(), values=set())
         self.profiles = collections.defaultdict(make_profile)
         def make_rule():
             return types.SimpleNamespace(fixes=self.FixType(0))
         self.rules = collections.defaultdict(make_rule)
-        if xml_file:
-            self.parse_xml(xml_file)
+        self._parse_xml(xml_file)
+        self.path = Path(xml_file)
 
-    def parse_xml(self, xml_file):
+    def _parse_xml(self, xml_file):
         # parse input XML datastream in 10KB binary chunks (arbitrary
         # reasonable value), pass them to the ElementTree parser, which
         # returns element start/end events

--- a/static-checks/diff/profile-rules.py
+++ b/static-checks/diff/profile-rules.py
@@ -5,6 +5,7 @@ from lib import util, results, oscap
 new = oscap.global_ds()
 
 with util.get_old_datastream() as old_xml:
+    util.log(f"comparing OLD: {old_xml} to NEW: {new.path}")
     old = oscap.Datastream(old_xml)
 
     common_profiles = set(new.profiles).intersection(old.profiles)

--- a/static-checks/diff/profile-titles.py
+++ b/static-checks/diff/profile-titles.py
@@ -5,6 +5,7 @@ from lib import util, results, oscap
 new = oscap.global_ds()
 
 with util.get_old_datastream() as old_xml:
+    util.log(f"comparing OLD: {old_xml} to NEW: {new.path}")
     old = oscap.Datastream(old_xml)
 
     common_profiles = set(new.profiles).intersection(old.profiles)

--- a/static-checks/diff/profile-variables.py
+++ b/static-checks/diff/profile-variables.py
@@ -5,6 +5,7 @@ from lib import util, results, oscap
 new = oscap.global_ds()
 
 with util.get_old_datastream() as old_xml:
+    util.log(f"comparing OLD: {old_xml} to NEW: {new.path}")
     old = oscap.Datastream(old_xml)
 
     common_profiles = set(new.profiles).intersection(old.profiles)

--- a/static-checks/diff/profiles.py
+++ b/static-checks/diff/profiles.py
@@ -5,6 +5,7 @@ from lib import util, results, oscap
 new = oscap.global_ds()
 
 with util.get_old_datastream() as old_xml:
+    util.log(f"comparing OLD: {old_xml} to NEW: {new.path}")
     old = oscap.Datastream(old_xml)
     old_profiles = set(old.profiles)
     new_profiles = set(new.profiles)


### PR DESCRIPTION
This should help somewhat with debugging.