### PR TITLE
Fix "missing tar command" error in /per-rule tests

### DIFF
--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -16,7 +16,7 @@ profile = util.get_test_name().rpartition('/')[2]
 ks = virt.translate_ssg_kickstart(profile)
 
 if os.environ.get('USE_SERVER_WITH_GUI'):
-    ks.add_package_group('Server with GUI')
+    ks.packages.append('@Server with GUI')
 
 # host a HTTP server with a datastream and let the guest download it
 with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -21,7 +21,7 @@ else:
 if not g.can_be_snapshotted():
     ks = virt.Kickstart(partitions=partitions.partitions)
     if use_gui:
-        ks.add_package_group('Server with GUI')
+        ks.packages.append('@Server with GUI')
     g.install(kickstart=ks)
     g.prepare_for_snapshot()
 

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -20,7 +20,7 @@ else:
 if not g.can_be_snapshotted():
     ks = virt.Kickstart(partitions=partitions.partitions)
     if use_gui:
-        ks.add_package_group('Server with GUI')
+        ks.packages.append('@Server with GUI')
     g.install(kickstart=ks)
     g.prepare_for_snapshot()
 

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -294,12 +294,6 @@ class Kickstart:
                'set -xe; exec >/dev/tty 2>&1\n' + content + '\n%end')
         self.append(new)
 
-    def add_packages(self, pkgs):
-        self.packages += pkgs
-
-    def add_package_group(self, group):
-        self.packages.append(f'@{group}')
-
     def add_install_only_repo(self, name, baseurl):
         self.appends.append(f'repo --name={name} --baseurl={baseurl}')
 
@@ -435,7 +429,7 @@ class Guest:
                 'contest-rpmpack',
                 f'http://{http_host}:{http_port}/repo',
             )
-            kickstart.add_packages([util.RpmPack.NAME])
+            kickstart.packages.append(util.RpmPack.NAME)
 
             ksfile = stack.enter_context(kickstart.to_tmpfile())
 

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -77,6 +77,7 @@ if not g.is_installed():
     # install a qcow2-backed VM, so automatus.py can snapshot it
     # - use hardening-style partitions, automatus tests need them
     ks = virt.Kickstart(partitions=partitions.partitions)
+    ks.packages.append('tar')
     g.install(kickstart=ks, disk_format='qcow2')
 
 with util.get_content() as content_dir, g.booted():


### PR DESCRIPTION
`/per-rule` tests were not executed as they were terminated at the beginning because of
```
ERROR - Terminating due to error: Unable to upload test scripts: Cannot extract data tarball /root/ssgts/tmppt219c40.tar.gz.
```
After checking logs, it was caused by missing `tar` package which is not installed on minimal RHEL9 by default.