### PR TITLE
Disable `/static-checks/nist-validation` on RHEL-10 for now

### DIFF
--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -5,7 +5,7 @@ environment+:
     PYTHONPATH: ../..
 duration: 15m
 require+:
-  - java-openjdk
+  - java-17-openjdk
 adjust:
   - enabled: false
     when: arch != x86_64

--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -5,8 +5,13 @@ environment+:
     PYTHONPATH: ../..
 duration: 15m
 require+:
+  # we use java-17 specifically here because the NIST tool needs it and does not
+  # work with any newer version
   - java-17-openjdk
 adjust:
-  - enabled: false
-    when: arch != x86_64
-    continue: false
+  - when: arch != x86_64
+    enabled: false
+    because: the test is not architecture-specific, one is enough
+  - when: distro == rhel-10
+    enabled: false
+    because: TODO - RHEL-10 doesn't have Java 17, see requires above


### PR DESCRIPTION
It seems the NIST tool cannot handle newer Java versions,
```
2024-08-20 04:56:56 test.py:30: running: ./scapval.sh -scapversion 1.3 -valreportfile ssg-firefox-ds.report.html -valresultfile ssg-firefox-ds.results.xml -file /usr/share/xml/scap/ssg/content/ssg-firefox-ds.xml
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: gov/nist/secauto/scap/validation/Application has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:473)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:621)
```
so let's disable it for now, until it starts supporting OpenJDK > 17.