### PR TITLE
Disable CCN profiles on RHEL-10

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -82,22 +82,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -77,22 +77,22 @@ duration: 2h
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -83,22 +83,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -80,22 +80,22 @@ duration: 2h
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -72,22 +72,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -64,22 +64,22 @@ tag:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -86,22 +86,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -86,22 +86,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -80,22 +80,22 @@ duration: 2h
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -79,22 +79,22 @@ adjust:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -65,22 +65,22 @@ environment+:
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -80,22 +80,22 @@ duration: 2h
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8
+      - when: distro == rhel-8 or distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: CCN profiles are not present on RHEL-8 and on RHEL-10


### PR DESCRIPTION
There are no CCN profiles in RHEL10, see https://github.com/ComplianceAsCode/content/tree/master/products/rhel10/profiles