### PR TITLE
Misc fixes - building in plan, PyYAML, datastream XML parsing

### DIFF
--- a/lib/results.py
+++ b/lib/results.py
@@ -15,6 +15,7 @@ import os
 import sys
 import shutil
 import requests
+import yaml
 from pathlib import Path
 
 from lib import util, waive
@@ -25,27 +26,6 @@ failed_count = 0
 errored_count = 0
 
 RESULTS_FILE = 'results.yaml'
-
-
-def _compose_results_yaml(keyvals):
-    """
-    Trivial hack to output simple YAML without a PyYAML depedency.
-    """
-    def printval(x):
-        if type(x) is list:
-            # python str(list) format is compatible with YAML
-            return str(x)
-        else:
-            # account for name/note having complex content
-            x = x.replace('"', '\\"')
-            return f'"{x}"'
-    it = iter(keyvals.items())
-    # prefix first item with '-'
-    key, value = next(it)
-    out = f'- "{key}": {printval(value)}\n'
-    for key, value in it:
-        out += f'  "{key}": {printval(value)}\n'
-    return out
 
 
 def have_tmt_api():
@@ -125,10 +105,8 @@ def report_tmt(status, name=None, note=None, logs=None, *, add_output=True):
     if log_entries:
         new_result['log'] = log_entries
 
-    yaml_addition = _compose_results_yaml(new_result)
-
     with open(test_data / RESULTS_FILE, 'a') as f:
-        f.write(yaml_addition)
+        yaml.dump([new_result], f)
 
 
 def report_beaker(status, name=None, note=None, logs=None):

--- a/lib/util/__init__.py
+++ b/lib/util/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 libdir = Path(inspect.getfile(inspect.currentframe())).parent.parent
 
 from .content      import *  # noqa
+from .backup       import *  # noqa
 from .dedent       import *  # noqa
 from .environment  import *  # noqa
 from .httpsrv      import *  # noqa

--- a/lib/util/backup.py
+++ b/lib/util/backup.py
@@ -1,0 +1,45 @@
+"""
+Simple recursive backup/restore of filesystem paths, preserving
+file metadata where possible.
+"""
+
+import shutil
+import contextlib
+from pathlib import Path
+
+from lib import util
+
+
+def backup(path):
+    util.log(f"backing up {path}")
+    path = Path(path)
+    path_backup = path.with_suffix('.contest-backup')
+    if path_backup.exists():
+        raise RuntimeError(f"previous backup found: {path_backup}")
+    # store the original files in the backup + copy them for our use
+    # - this is to preserve original inode numbers after restore
+    path.rename(path_backup)
+    shutil.copytree(path_backup, path, symlinks=True)
+
+
+def restore(path):
+    util.log(f"restoring {path}")
+    path = Path(path)
+    path_backup = path.with_suffix('.contest-backup')
+    if not path_backup.exists():
+        raise RuntimeError(f"no backup found: {path_backup}")
+    shutil.rmtree(path)
+    path_backup.rename(path)
+
+
+@contextlib.contextmanager
+def backed_up(path):
+    """
+    Context manager for automatic backup/restore of a given path,
+    use as:
+        with backed_up('/some/path'):
+            # do destructive stuff to it
+    """
+    backup(path)
+    yield
+    restore(path)

--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -19,7 +19,6 @@ def _find_datastreams(force_ssg):
         return ssg_path
     # if CONTEST_CONTENT was specified
     if user_content:
-        build_content(user_content)
         return user_content / 'build'
     # default to the OS-wide scap-security-guide content
     return ssg_path
@@ -53,7 +52,6 @@ def _find_playbooks(force_ssg):
         return ssg_path
     # if CONTEST_CONTENT was specified
     if user_content:
-        build_content(user_content)
         return user_content / 'build' / 'ansible'
     # default to the OS-wide scap-security-guide content
     return ssg_path
@@ -66,7 +64,6 @@ def _find_per_rule_playbooks(force_ssg):
         return ssg_path
     # if CONTEST_CONTENT was specified
     if user_content:
-        build_content(user_content)
         return user_content / 'build' / f'rhel{rhel.major}' / 'playbooks' / 'all'
     # default to the OS-wide scap-security-guide content
     return ssg_path
@@ -97,7 +94,6 @@ def iter_playbooks(force_ssg=False):
 
 def get_kickstart(profile):
     if user_content:
-        build_content(user_content)
         kickstart = (
             user_content / 'products' / f'rhel{rhel.major}' / 'kickstart'
             / f'ssg-rhel{rhel.major}-{profile}-ks.cfg'
@@ -115,18 +111,6 @@ def content_is_built(path):
     return (Path(path) / 'build' / f'ssg-rhel{rhel.major}-ds.xml').exists()
 
 
-def build_content(path):
-    if content_is_built(path):
-        return
-    util.log(f"building content from source in {path}")
-    # install dependencies
-    cmd = ['dnf', '-y', 'builddep', '--spec', 'scap-security-guide.spec']
-    util.subprocess_run(cmd, check=True, cwd=path)
-    # build content
-    cmd = ['./build_product', '--playbook-per-rule', f'rhel{rhel.major}']
-    util.subprocess_run(cmd, check=True, cwd=path)
-
-
 @contextlib.contextmanager
 def get_content(build=True):
     """
@@ -137,8 +121,7 @@ def get_content(build=True):
     plain files or executing utils and need just the content source.
     """
     if user_content:
-        if build:
-            build_content(user_content)
+        # content already built by a TMT plan prepare step
         yield user_content
     else:
         # fall back to SRPM

--- a/main.fmf
+++ b/main.fmf
@@ -11,6 +11,8 @@ recommend:
   - python36
   - python3-requests
   - python36-requests
+  - python3-pyyaml
+  - python36-pyyaml
   - python3-rpm
   - python36-rpm
   # these are needed for CONTEST_CONTENT or get_content():

--- a/main.fmf
+++ b/main.fmf
@@ -15,9 +15,6 @@ recommend:
   - python36-pyyaml
   - python3-rpm
   - python36-rpm
-  # these are needed for CONTEST_CONTENT or get_content():
-  # - builddep on scap-security-guide.spec
-  - python-srpm-macros
   # - preparing/patching downloaded SRPM
   - rpm-build
 component:

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -8,8 +8,14 @@ execute:
 adjust:
   - prepare+:
       - how: install
+        name: Install dependencies for further prepare steps
         package:
+          # for git-fetch downloading of CONTEST_CONTENT_*
           - git-core
+          # for building CONTEST_CONTENT
+          - python-srpm-macros
+
+  - prepare+:
       - how: shell
         name: Download and build latest or pull request content
         script: |
@@ -33,6 +39,18 @@ adjust:
                 git checkout FETCH_HEAD
             fi
             echo "CONTEST_CONTENT=$content_dir" >> "$TMT_PLAN_ENVIRONMENT_FILE"
+      - how: shell
+        name: Build CONTEST_CONTENT (if specified)
+        script: |
+            set -xe
+            . "$TMT_PLAN_ENVIRONMENT_FILE"  # not done automatically
+            [ -z "$CONTEST_CONTENT" ] && exit 0
+            cd "$CONTEST_CONTENT"
+            major=$(. /etc/os-release && echo "${VERSION_ID%%.*}")
+            # already built
+            [ -e "build/ssg-rhel${major}-ds.xml" ] && exit 0
+            dnf -y builddep --spec scap-security-guide.spec
+            ./build_product --playbook-per-rule "rhel${major}"
 
   - prepare+:
       - how: shell


### PR DESCRIPTION
(These were originally part of a new `audit-sample-rules` test, https://github.com/RHSecurityCompliance/contest/issues/259, but I decided to split them off for easier discussion tracking.)

Going by commits, from oldest:

### add `util/backup.py` for backup+restore of filesystem paths

This was for an earlier version of the test, which actually remediated the audit rules into `/etc/audit` - I first had a VM-using test, but realized we need to run it multi-arch, so I rewrote it without VMs, hence the backup/restore.

The current version of the test doesn't use this, but I think it would still be good to have it, rather than throw the code away. The early versions of Contest also had it: https://github.com/RHSecurityCompliance/contest/blob/bb2778816c463f9148395c8e566c7724ce60b28e/lib/backup.sh :smile: 

### start using PyYAML instead of hacking YAML syntax

From the commit message body:
```
    This was likely a RHEL-7 limitation, plus we didn't want to add
    unnecessary dependency on non-python-stdlib modules (like 'requests'
    or 'PyYAML').

    However we keep running into the need to parse YAML (ie. playbooks
    or TMT metadata), and python3*-pyyaml seems to be widely available
    in RHEL (even ie. python39-pyyaml on RHEL-8), unlike 'rpm' or 'dnf',
    so we might as well use it.

    The '/static-checks/ansible/allowed-modules' test already uses it
    without adding a RPM dependency, which hints at how widely available
    PyYAML is. Also, TMT probably depends on it too.
```

I specifically needed it in the audit test to parse ansible remediations and get `.rules` filepath / contents without having to sed/grep bash code.

### build `CONTEST_CONTENT` in a TMT plan prepare step

Per the commit:
```
    This is because building takes a long time (10+ minutes) on some
    slow systems and that easily exceeds a 5/10 minute 'duration'
    of a small test that never anticipated the extra delay.

    Moving it to a plan moves it outside the 'duration' count.

    Also, it's probably a better central place given that all tests
    always share the built content so the ./build_product options
    have to be considered globally.

    Finally, this is not a great fix given that we are still left
    with the 'build' argument to get_content(),

        def get_content(build=True):
            ...

    and its SRPM-based building code, which still runs within test
    'duration', however there is no easy solution for that (other than
    getting rid of SRPM support entirely), so this commit at least
    tries to bump things in a right direction.
```

### split off xml-parsing code from `class Datastream`

I originally wanted to redesign the whole XML parsing in `class Datastream` to have a more modular "what you want" data retrieval:
```python
class Datastream(enum.Flag):
    """
    Represent an OpenSCAP datastream XML definition and enable extracting
    selected values from it.

    This is done by the class definition having enum.Flag style variables,
    which get overwritten by a class instance to either None (if the given
    value was not chosen to be extracted) or the contents of the extracted
    data.

    Ie.
        ds = Datastream()
        ds.parse_xml('file.xml', Datastream.profiles | Datastream.rules)

        profiles = ds.profiles          # is a dict() of profile metadata
        rules = ds.rules                # is a dict() of rule metadata
        remediations = ds.remediations  # is None (was not requested)

    This is to preserve reasonable speed and low memory overhead for use
    cases that don't need all the details.

    Data structure example:

        ds.path = Path(file_the_datastream_was_parsed_from)

        ds.profiles = {
          'ospp': namespace(
            .title = 'Some text',
            .rules = set( 'audit_delete_success' , 'service_firewalld_enabled' , ...),
            .values = set( ('var_rekey_limit_size','1G') , ...),
          ),
          ... (all profiles in the datastream) ...
        }

        ds.rules = {
          'configure_crypto_policy': namespace(
            .fixes = FixType.bash | FixType.ansible,
          ),
          'account_password_selinux_faillock_dir': namespace(
            .fixes = FixType.bash,
          ),
          ... (all rules in the datastream) ...
        }

        ds.remediations = {
          'configure_crypto_policy': {
            FixType.bash: '... bash code ...',
            FixType.ansible: '... ansible playbook ...',
          },
          'account_password_selinux_faillock_dir': namespace(
            FixType.bash: '... bash code ...',
          ),
          ... (all rules with at least one type of fix available) ...
        }

        (FixType is Datastream.FixType)
    """
```
However, mid-way through implementing it, I realized that when parsing out remediation code, we probably don't want to extract all 10s of MBs of code, just a few select rules.

So I went with what's in the commit - splitting off the batched XML parser, allowing the audit test to parse the DS XML on its own, extracting remediation code only for rules in the `policy_rules` Group.

I'm not against revisiting the `class Datastream` code in the future, but (depite the big `+++` and `---`), nothing has really changed inside, aside from one minor bug fix (`elem.get` to `elements[-1].get`).