### PR TITLE
extend audit-sample-rules/audit_ospp_general waiver to older RHELs

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -10,7 +10,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Contest deps
-        run: sudo apt-get install -y python3-rpm python3-dnf
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y python3-rpm python3-dnf
       - name: Collect waivers
         run: |
             python3 <<'EOF'

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -123,8 +123,14 @@
 
 # /static-checks
 #
+# new arch= on RHEL-9.5
 # https://github.com/ComplianceAsCode/content/issues/12321
 /static-checks/audit-sample-rules/audit_ospp_general.*
-    rhel == 9
+    rhel == 9.5
+# older issues with pkexec and grub2-set-bootflag, they seem to appear
+# only with older audit-3.0.x
+# https://github.com/ComplianceAsCode/content/issues/12321
+/static-checks/audit-sample-rules/audit_ospp_general.*
+    (rhel == 9 and rhel <= 9.3) or rhel == 8.8
 
 # vim: syntax=python


### PR DESCRIPTION
Details are in the linked issue - it's a different problem, but same upstream issue.