### PR TITLE
Introduce test for checking rule identifiers

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -129,20 +129,20 @@
 
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12421
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12424
+# RHEL10 - No official RHEL10 STIG benchmark yet
 /static-checks/rule-identifiers/stig/.*
-    rhel == 8 or rhel == 9
+    rhel == 8 or rhel == 9 or rhel == 10
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12425
 /static-checks/rule-identifiers/ospp/.*
     rhel == 8 or rhel == 9
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
+# https://github.com/ComplianceAsCode/content/issues/12430
 /static-checks/rule-identifiers/ism_o/.*
-    rhel == 8 or rhel == 9
+    rhel == 8 or rhel == 9 or rhel == 10
 # https://github.com/ComplianceAsCode/content/issues/12426
 /static-checks/rule-identifiers/hipaa/sshd_use_directory_configuration
     rhel == 9
-
-
 
 # vim: syntax=python

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -127,4 +127,22 @@
 /static-checks/audit-sample-rules/audit_ospp_general.*
     rhel == 9
 
+# RHEL8 https://github.com/ComplianceAsCode/content/issues/12421
+# RHEL9 https://github.com/ComplianceAsCode/content/issues/12424
+/static-checks/rule-identifiers/stig/.*
+    rhel == 8 or rhel == 9
+# RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
+# RHEL9 https://github.com/ComplianceAsCode/content/issues/12425
+/static-checks/rule-identifiers/ospp/.*
+    rhel == 8 or rhel == 9
+# RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
+# RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
+/static-checks/rule-identifiers/ism_o/.*
+    rhel == 8 or rhel == 9
+# https://github.com/ComplianceAsCode/content/issues/12426
+/static-checks/rule-identifiers/hipaa/sshd_use_directory_configuration
+    rhel == 9
+
+
+
 # vim: syntax=python

--- a/static-checks/rule-identifiers/main.fmf
+++ b/static-checks/rule-identifiers/main.fmf
@@ -1,0 +1,10 @@
+summary: Search for policy references in rules
+test: python3 -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 10m
+adjust:
+  - when: distro == rhel-10
+    enabled: false
+    because: rhel10 profiles are in draft state with missing references

--- a/static-checks/rule-identifiers/main.fmf
+++ b/static-checks/rule-identifiers/main.fmf
@@ -4,7 +4,3 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 10m
-adjust:
-  - when: distro == rhel-10
-    enabled: false
-    because: rhel10 profiles are in draft state with missing references

--- a/static-checks/rule-identifiers/test.py
+++ b/static-checks/rule-identifiers/test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+import re
+from collections import defaultdict
+
+from lib import util, results, oscap
+
+
+profile_references = {
+    # srg, disa, stigid@PRODUCT or controls file
+    'stig': [
+        'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',  # noqa:E501
+        'https://public.cyber.mil/stigs/cci/',
+        'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
+    ],
+    # ospp
+    'ospp': ['https://www.niap-ccevs.org/Profile/PP.cfm'],
+    # cis@PRODUCT or controls file
+    'cis': ['https://www.cisecurity.org/benchmark/red_hat_linux/'],
+    # anssi (controls file)
+    'anssi': ['https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf'],
+    # ism
+    'ism_o': ['https://www.cyber.gov.au/acsc/view-all-content/ism'],
+    # hipaa
+    'hipaa': ['https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf'],  # noqa: E501
+    # pcidss4
+    'pci-dss': ['https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf'],
+}
+
+
+profiles = oscap.global_ds().profiles
+# Parse from datastream all rules and all their references
+rule_references = defaultdict(set)
+for frames, elements in oscap.parse_xml(util.get_datastream()):
+    if len(frames) < 3 or frames[-3:] != ['Group', 'Rule', 'reference']:
+        continue
+
+    rule, reference = elements[-2:]
+    # TODO: use str.removeprefix on python 3.9+
+    rule = re.sub('^xccdf_org.ssgproject.content_rule_', '', rule.get('id'))
+    reference = reference.get('href')
+    rule_references[rule].add(reference)
+
+for profile, references in profile_references.items():
+    for rule in profiles[profile].rules:
+        for reference in references:
+            if reference in rule_references[rule]:
+                results.report('pass', f'{profile}/{rule}')
+            else:
+                results.report('fail', f'{profile}/{rule}', f"missing {reference}")
+
+results.report_and_exit()


### PR DESCRIPTION
Check for known references of individual profiles.

References are links with specific identifiers.
```
<xccdf-1.2:reference href="https://www.cisecurity.org/benchmark/red_hat_linux/">2.3.3</xccdf-1.2:reference>
```
It's not possible to automatically check whether the identifiers are correct as those are coming from policy requirements. However, we can test if policy references are assigned to profile rules.

The references mapping could be read from CaC/content `ssg/constants.py`. But as it lists references for all CaC/content profiles and products, most of that stuff would have to be filtered out and wouldn't simplify things much here. And so mapping is part of the test code.

~~Note: do not merge yet, a lot of failures caused by missing references in various profiles. I'm going to create CaC upstream issues for each individual rhel+profile combination and create waivers.~~