### PR TITLE
Search for extracted rpm src dir instead of hardcoded path

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -141,10 +141,14 @@ def get_content(build=True):
                     check=True, stdout=subprocess.PIPE, universal_newlines=True, cwd=tmpdir,
                 )
                 name_version = ret.stdout.strip()
-                extracted = Path(tmpdir) / 'BUILD' / name_version
+                # extracted sources directory varies across distro versions, thus
+                # try to search for the directory rather than using hardcoded path
+                try:
+                    builddir = Path(tmpdir) / 'BUILD'
+                    extracted = next(builddir.glob(f'**/{name_version}'))
+                except StopIteration:
+                    raise FileNotFoundError("extracted SRPM content sources not found")
                 util.log(f"using {extracted} as content source")
-                if not extracted.exists():
-                    raise FileNotFoundError(f"{extracted} not in extracted/patched SRPM")
                 # build content
                 if build:
                     cmd = ['./build_product', '--playbook-per-rule', f'rhel{rhel.major}']


### PR DESCRIPTION
In Fedora 41<=, RPM 4.20 introduced [Guaranteed per-build directory](https://github.com/rpm-software-management/rpm/issues/2078) causing rpmbuild process extract the sources to `BUILD/foo-<version>-build/foo-<version>/` instead of `BUILD/foo-<version>/`.
https://artifacts.dev.testing-farm.io/d009d9a8-6ded-4578-b2f8-31163d6ada1d/

The simplest and obvious solution to me (keeping it compatible with old RPM versions) is just to search for the directory. Hardcoding is not the right way. Citing one of comments from rpm Github issues:
> Rpm never gave any promises about the directory outside itself, but when a thing stays the same for 20+ years people start assuming it, fact of life.

So far only Fedora41<= is affected and blocks rpmbuild test introduction to content upstream CI (only Fedora jobs). I know Contest doesn't support Fedora, but wouldn't hold my breath they don't introduce it to RHEL10 Beta as well.

Being tested in https://github.com/ComplianceAsCode/content/pull/12176
