### PR TITLE
Update /static-checks/rule-identifiers waivers

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -133,22 +133,17 @@
 /static-checks/audit-sample-rules/audit_ospp_general.*
     (rhel == 9 and rhel <= 9.3) or rhel == 8.8
 
-# RHEL8 https://github.com/ComplianceAsCode/content/issues/12421
-# RHEL9 https://github.com/ComplianceAsCode/content/issues/12424
-# RHEL10 - No official RHEL10 STIG benchmark yet
-/static-checks/rule-identifiers/stig/.*
-    rhel == 8 or rhel == 9 or rhel == 10
+# RHEL10 - No official RHEL10 STIG/CIS benchmark yet
+/static-checks/rule-identifiers/(stig|cis.*)/.*
+    rhel == 10
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12425
 /static-checks/rule-identifiers/ospp/.*
     rhel == 8 or rhel == 9
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
-# https://github.com/ComplianceAsCode/content/issues/12430
+# RHEL10 https://github.com/ComplianceAsCode/content/issues/12430
 /static-checks/rule-identifiers/ism_o/.*
     rhel == 8 or rhel == 9 or rhel == 10
-# https://github.com/ComplianceAsCode/content/issues/12426
-/static-checks/rule-identifiers/hipaa/sshd_use_directory_configuration
-    rhel == 9
 
 # vim: syntax=python

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -48,6 +48,12 @@
 /static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
     True
 
+# Rule identifiers waivers
+#
+# no STIG ID, but the rule is needed for other authselect rules
+/static-checks/rule-identifiers/stig/enable_authselect
+    rhel == 8
+
 # DISA Alignment waivers
 #
 # DISA benchmark allows only released OS versions. Our content is fine with unreleased versions.


### PR DESCRIPTION
Recent changes in content added multiple references and thus fixed some of the issues. Also move to 30-permanent those where we know they are expected.