### PR TITLE
Waiver for CentOS STIG ID references

### DIFF
--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -53,6 +53,9 @@
 # no STIG ID, but the rule is needed for other authselect rules
 /static-checks/rule-identifiers/stig/enable_authselect
     rhel == 8
+# no STIG ID for CentOS products
+/static-checks/rule-identifiers/stig/.*
+    rhel.is_centos() and note == 'missing https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux'
 
 # DISA Alignment waivers
 #


### PR DESCRIPTION
In upstream CI, CentOS Stream datastream is used for testing. The CentOS datastream doesn't have STIG ID reference as those are distro specific in content (e.g. `stigid@rhel8: ...`) and there are no references for CentOS. Thus, waive it.