### PR TITLE
increase disk size of installed guests to 30 Gb

### DIFF
--- a/lib/virt.py
+++ b/lib/virt.py
@@ -440,7 +440,7 @@ class Guest:
                 # to RAM, leading to notably higher memory requirements during
                 # installation - we reduce it down to 2000M after install
                 '--name', self.name, '--vcpus', str(cpus), '--memory', '3072',
-                '--disk', f'path={disk_path},size=20,format={disk_format},cache=unsafe',
+                '--disk', f'path={disk_path},size=30,format={disk_format},cache=unsafe',
                 '--network', 'network=default', '--location', location,
                 '--graphics', 'none', '--console', 'pty', '--rng', '/dev/urandom',
                 # this has nothing to do with rhel8, it just tells v-i to use virtio


### PR DESCRIPTION
Recently, it seems that current 20 Gb is not enough.
I recently tried some Anaconda installation with my Autocontest project (simple interface to this project) and it seems that 30 Gb  is curently fine.