### PR TITLE
Support not touching partitions in `lib.virt.Kickstart`

### DIFF
--- a/lib/virt.py
+++ b/lib/virt.py
@@ -252,13 +252,21 @@ class Kickstart:
     ]
 
     def __init__(self, template=TEMPLATE, packages=PACKAGES, partitions=None):
+        """
+        You can override 'template' / 'packages' with your own copy of
+        self.TEMPLATE and self.PACKAGES.
+
+        Partitions should be specified as a list of (mntpoint,size) tuples,
+        where None (default) uses one partition for the entire OS and an empty
+        list doesn't add any partitions.
+        """
         self.ks = template
         self.appends = []
         self.packages = packages
         self.partitions = partitions
 
     def assemble(self):
-        if self.partitions:
+        if self.partitions is not None:
             partitions_block = '\n'.join(
                 (f'part {mountpoint} --size={size}' for mountpoint, size in self.partitions),
             )
@@ -847,7 +855,7 @@ def translate_ssg_kickstart(ks_file):
 
     # leave original %packages - Anaconda can handle multiple %packages sections
     # just fine (when we later add ours during installation)
-    return Kickstart(template=ks_text)
+    return Kickstart(template=ks_text, partitions=[])
 
 
 def translate_oscap_kickstart(lines, datastream):
@@ -891,7 +899,7 @@ def translate_oscap_kickstart(lines, datastream):
 
     # leave original %packages - Anaconda can handle multiple %packages sections
     # just fine (when we later add ours during installation)
-    return Kickstart(template=ks_text)
+    return Kickstart(template=ks_text, partitions=[])
 
 
 #


### PR DESCRIPTION
This fixes a bug where the `translate_*` functions would add their own partitions, and `class Kickstart` would also append its own `part / --size=1 --grow` line, breaking the kickstart.

Tested manually on
* `/hardening/anaconda/cui` (random profile) where the kickstart looks sane (no `part / --size=1 --grow`, just the translated partitions
* `/hardening/oscap/cui` where the kickstart has partitions defined in `conf.partitions` and no others
* `/scanning/oscap-debug/vm-scan` where the kickstart has `part / --size=1 --grow` and no other partitions

I haven't tested all cases thoroughly, but all 3 above pass Anaconda's storage validation, so it at least should be an improvement to how things are now.