### PR TITLE
Update nist-validation test to provide more granular results

### DIFF
--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -84,4 +84,11 @@
 /hardening/.*/ospp/configure_crypto_policy
     rhel.is_centos() and rhel == 9
 
+# scapval waivers
+#
+# Caused by SCE content being built by default, enabled
+# in https://github.com/ComplianceAsCode/content/pull/12488
+/static-checks/nist-validation/ssg-rhel9-ds/SRC-118
+    rhel >= 9
+
 # vim: syntax=python

--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -4,14 +4,10 @@ result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 15m
-require+:
-  # we use java-17 specifically here because the NIST tool needs it and does not
-  # work with any newer version
+recommend+:
   - java-17-openjdk
+  - java-21-openjdk
 adjust:
   - when: arch != x86_64
     enabled: false
     because: the test is not architecture-specific, one is enough
-  - when: distro == rhel-10
-    enabled: false
-    because: TODO - RHEL-10 doesn't have Java 17, see requires above


### PR DESCRIPTION
Scapval tool is failing when we build SCE content by default in RHEL 9 and RHEL 10 data streams because it doesn't expect content to use checking systems other than the OVAL and OCIL (base requirement `SRC-118`). For more details see https://github.com/ComplianceAsCode/content/pull/12488

We can waive this fail, it shouldn't cause any problems for 3rd party scanners as our content still contains also OVAL checks. To do so the test has been updated to parse XML results file generated by the scapval tool.

The test is also updated to work on RHEL 10 where `java-21-openjdk` is the default as scapval tool has no problem running with this newer version of java.