### PR TITLE
Fix logind_session_timeout alignment waiver

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -86,6 +86,7 @@
 #
 # https://github.com/ComplianceAsCode/content/issues/12561
 /scanning/disa-alignment/.*/logind_session_timeout
+    rhel == 8
 # https://github.com/ComplianceAsCode/content/issues/11804
 /scanning/disa-alignment/.*/harden_sshd_ciphers_openssh_conf_crypto_policy
 # https://github.com/ComplianceAsCode/content/issues/11692


### PR DESCRIPTION
The recently added waiver #280  does not apply to problematic RHEL8. It applies only on RHEL9 where it is aligned with DISA.
This fixes the condition.