### PR TITLE
Enable source repositories for NEWA test runs

### DIFF
--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -15,6 +15,9 @@ discover:
       - /static-checks/html-links
 adjust:
   - when: newa_batch is defined
+    prepare:
+      how: shell
+      script: dnf config-manager --set-enabled *-source
     report:
       how: reportportal
 


### PR DESCRIPTION
According to Testing Farm team, source repo should be already there and we just need to enable it.