### PR TITLE
Do not run ctest on RHEL 9.0 aarch64

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -19,3 +19,7 @@ recommend+:
   - ansible-core
   - rhc-worker-playbook
   - bats
+adjust:
+  - when: arch == aarch64 and rhel == 9.0
+    enabled: false
+    because: rhc-worker-playbook or community.general collection not available there


### PR DESCRIPTION
In productization, the test is re-runned 3 times and then errors on
```
CalledProcessError: Command '['ansible-galaxy', '-vvv', 'collection', 'install', 'community.general']' returned non-zero exit status 250.
```
because there is no `rhc-worker-playbook` nor `community.general` available for this distro and arch combination.