### PR TITLE
Report waived results as pass for TF environment

### DIFF
--- a/lib/waive.py
+++ b/lib/waive.py
@@ -221,6 +221,10 @@ def match_result(status, name, note):
 
 
 def rewrite_result(status, name, note, new_status='warn'):
+    # In TF, show waived as 'pass' because 'warn' results are shown as failures
+    if os.environ.get('TESTING_FARM_REQUEST_ID'):
+        new_status='pass'
+
     if os.environ.get('CONTEST_VERBATIM_RESULTS') == '1' or status in ['info', 'warn']:
         return (status, name, note)
 


### PR DESCRIPTION
For TF runs, tmt correctly shows waived results as `warn`, but then TF shows them as failures and that a huge mess mainly for our Errata test run where we check for missing identifiers (hundreds of waived rules https://github.com/RHSecurityCompliance/contest/blob/main/conf/waivers/20-long-term#L124).