### PR TITLE
Don't scan after a failed Ansible remediation

### DIFF
--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -41,10 +41,8 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-    proc, lines = util.subprocess_stream(ansible_cmd)
-    failed = ansible.report_from_output(lines)
-    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
-        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
+    _, lines = util.subprocess_stream(ansible_cmd, check=True)
+    ansible.report_from_output(lines)
     g.soft_reboot()
 
     # scan the remediated system

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -25,10 +25,8 @@ if util.get_reboot_count() == 0:
         *skip_tags_arg,
         playbook,
     ]
-    proc, lines = util.subprocess_stream(cmd)
-    failed = ansible.report_from_output(lines)
-    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
-        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
+    _, lines = util.subprocess_stream(cmd, check=True)
+    ansible.report_from_output(lines)
 
     # restore basic login functionality
     with open('/etc/sysconfig/sshd', 'a') as f:

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -31,10 +31,8 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-    proc, lines = util.subprocess_stream(ansible_cmd)
-    failed = ansible.report_from_output(lines)
-    if proc.returncode not in [0,2] or proc.returncode == 2 and not failed:
-        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
+    _, lines = util.subprocess_stream(ansible_cmd, check=True)
+    ansible.report_from_output(lines)
     g.soft_reboot()
 
     with util.get_content(build=False) as content_dir:


### PR DESCRIPTION
The original idea was to provide at least some scan results when (a few) Ansible tasks fail to remediate - to print the failed remediations as `error` + failing oscap rules as a nice double-check.

However RHEL-10 work has shown that this is not generally a good idea - we cannot tell if Ansible failed on something fatal (and thus about 100+ rules will fail) or if only 1-2 tasks failed and the scan won't be a wall of red lines.

So, to be on the safer side, don't do the scan when Ansible fails for any reason.

All the non-fatal remediation errors should still be reported (instead of only the first failing one) as `check=True` raises an exception only when all the output lines have been processed.