### PR TITLE
Make available repo with brew rpms for Errata testing

### DIFF
--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -19,6 +19,9 @@ adjust:
   - when: newa_batch is defined
     report:
         how: reportportal
+    prepare+:
+        how: shell
+        script: curl -ks https://gitlab.cee.redhat.com/rhel-tests/distribution/-/raw/main/setup/configure-repo-with-rpms-from-brew/run.sh | bash
   - environment:
         CONTEST_VERBOSE: 0
 


### PR DESCRIPTION
According to NEWA guide, this should make available repo with rpms from Brew.
And we need that for our errata testing, otherwise compose package will be installed.

Initially, we didn't want to go this way and wanted to wait for nightly composes with new builds but after few days of waiting for a new compose I've decided to not wait anymore and to try this way.