### PR TITLE
For errata testing, install beakerlib from epel

### DIFF
--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -21,7 +21,11 @@ adjust:
         how: reportportal
     prepare+:
         how: shell
-        script: curl -ks https://gitlab.cee.redhat.com/rhel-tests/distribution/-/raw/main/setup/configure-repo-with-rpms-from-brew/run.sh | bash
+        script:
+          - . /etc/os-release; yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${VERSION_ID%.*}.noarch.rpm || true
+          - dnf config-manager --set-enabled epel || true
+          - dnf -y install beakerlib
+          - curl -ks https://gitlab.cee.redhat.com/rhel-tests/distribution/-/raw/main/setup/configure-repo-with-rpms-from-brew/run.sh | bash
   - environment:
         CONTEST_VERBOSE: 0
 


### PR DESCRIPTION
As `setup/configure-repo-with-rpms-from-brew` requires `beakerlib` and it is not installed by default on s390x and ppc64le systems, we need to install them manually.