### PR TITLE
Extend static-checks/ansible/syntax-check duration

### DIFF
--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -6,7 +6,7 @@ test: python3 -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
-duration: 2h
+duration: 3h
 require+:
   - openscap-scanner
   - ansible-core


### PR DESCRIPTION
During last errata testing, 2 runs out of 4 exceeded 2 hours duration.