### PR TITLE
Extend waiver for rule aide_use_fips_hashes

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -73,9 +73,9 @@
 /hardening/kickstart/.+/systemd_tmp_mount_enabled
     True
 
-# RHEL-9 is not FIPS certified yet
+# RHEL 9 and 10 are not FIPS certified yet
 /hardening/.+/aide_use_fips_hashes
-    rhel == 9
+    rhel >= 9
 
 # OAA just failed without an error, as usual
 # https://issues.redhat.com/browse/OPENSCAP-3321


### PR DESCRIPTION
The rule aide_use_fips_hashes fails during daily productization on RHEL 10 because the installed OS isn't FIPS 140 certified. With similar reasoning of RHEL 9 we will waive it.