### PR TITLE
Extend SCAPVAL waiver

### DIFF
--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -97,7 +97,7 @@
 #
 # Caused by SCE content being built by default, enabled
 # in https://github.com/ComplianceAsCode/content/pull/12488
-/static-checks/nist-validation/ssg-(rhel9|cs9)-ds/SRC-118
+/static-checks/nist-validation/ssg-(rhel\d+|cs\d+)-ds/SRC-118
     rhel >= 9
 
 # vim: syntax=python


### PR DESCRIPTION
The SCE checks are included also in RHEL 10 and CentOS Stream 10 data streams, therefore, the item that waiwes requirement 118 on RHEL 9 should be extended.