### PR TITLE
exclude `/static-checks/removed-rules` on RHEL-10 for now

### DIFF
--- a/static-checks/removed-rules/main.fmf
+++ b/static-checks/removed-rules/main.fmf
@@ -8,3 +8,6 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: datastream is same on all architectures
+  - when: distro == rhel-10
+    enabled: false
+    because: TODO - no scap-security-guide release on RHEL-10 yet


### PR DESCRIPTION
This test doesn't make sense because we have no scap-security-guide release on RHEL-10 yet, so it tries to compare against a nonsensical package found in the repository, likely ported from some older release.

The TODO is there because we shouldn't forget to re-enable it after we have scap-security-guide for RHEL-10.