### PR TITLE
Waive bootc stig test on RHEL 10

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -153,4 +153,8 @@
 /hardening/image-builder(/.+)?/hipaa/sebool_selinuxuser_execmod
     rhel == 9
 
+# https://issues.redhat.com/browse/RHEL-74244
+/hardening/container/bootc-image-builder/stig
+    rhel == 10
+
 # vim: syntax=python


### PR DESCRIPTION
The fail of /hardening/container/bootc-image-builder/stig is caused by https://issues.redhat.com/browse/RHEL-74244.