### PR TITLE
Use bootc-ready OpenSCAP from Copr/Packit only on <= RHEL-9

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -124,6 +124,30 @@
 /per-rule/.+/ansible/accounts_root_gid_zero/other_user_uid_0.fail
     rhel == 9
 
+# RHEL-10 specific /per-rule issues
+#
+# audit rules, https://github.com/ComplianceAsCode/content/pull/12867
+/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_arch.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_filter.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_arch.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_filter.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_last.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_rules.pass
+/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_trunc.pass
+# https://github.com/ComplianceAsCode/content/issues/12880
+/per-rule/.+/audit_rules_privileged_commands_unix2_chkpwd/only_chkpwd_rule.fail
+# https://github.com/ComplianceAsCode/content/issues/12875
+/per-rule/.+/package_xinetd_removed/package-installed.fail
+# https://github.com/ComplianceAsCode/content/issues/12878
+/per-rule/.+/coredump_disable_storage/coredumps_storage_none.pass
+# https://github.com/ComplianceAsCode/content/issues/12876
+/per-rule/.+/logind_session_timeout/not_configured.fail
+# https://github.com/ComplianceAsCode/content/issues/12879
+/per-rule/.+/grub2_enable_fips_mode/grub_cmdline_linux_correct_value.pass
+# https://github.com/ComplianceAsCode/content/issues/12877
+/per-rule/.+/kernel_module_sctp_disabled/missing_blacklist.fail
+    rhel == 10
+
 # DISA Alignment waivers
 #
 # https://github.com/ComplianceAsCode/content/issues/12561

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -145,4 +145,11 @@
 /hardening/image-builder/uefi/.+/mount_option_boot_efi_nosuid
     True
 
+# Container / Image Mode remediations
+#
+# enable_authselect failing on image-mode
+# https://issues.redhat.com/browse/OPENSCAP-5272
+/hardening/container/bootc-image-builder/[^/]+/enable_authselect
+    rhel == 9
+
 # vim: syntax=python

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -25,7 +25,7 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9.6
+  - when: distro < rhel-9 or distro ~< rhel-9.6
     enabled: false
     because: Image Mode not supported for older RHELs
 

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -9,6 +9,10 @@ description: |-
     successfully fixes the non-compliance, as verified by a scan.
 environment+:
     PYTHONPATH: ../../..
+adjust:
+  - when: distro == rhel-10
+    enabled: false
+    because: TODO - no old scap-security-guide release yet
 
 /anssi_bp28_high:
 


### PR DESCRIPTION
(Also waive a few RHEL-10 related issues.)