### PR TITLE
enable `/hardening/container/anaconda-ostree` with custom partitions

### DIFF
--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -25,14 +25,9 @@ adjust:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9.6
+  - when: distro < rhel-9 or distro ~< rhel-9.6
     enabled: false
     because: Image Mode not supported for older RHELs
-tag+:
-  # TODO: this test is currently broken by / blocked on Anaconda
-  # having broken ostreecontainer kickstart functionality,
-  # https://issues.redhat.com/browse/RHEL-66155
-  - broken
 
 /anssi_bp28_high:
 

--- a/hardening/container/anaconda-ostree/test.py
+++ b/hardening/container/anaconda-ostree/test.py
@@ -48,7 +48,17 @@ cfile.write_to('Containerfile')
 
 podman.podman('image', 'build', '--tag', 'contest-hardened', '.')
 
-ks = virt.Kickstart()
+# we can't use standard CaC/content style partitioning scheme because the
+# space distribution is different and the installer runs out of space,
+# so define this explicitly here for now
+# - note that Anaconda requires a separate /boot for 'ostreecontainer',
+#   otherwise it crashes on RHEL-66155
+partitions = [
+    ('/boot', 1000),
+    ('/', 18000),
+]
+
+ks = virt.Kickstart(partitions=partitions)
 
 # install the VM, using a locally-hosted podman registry serving
 # the hardened image for Anaconda's ostreecontainer


### PR DESCRIPTION
Turns out the Anaconda crash seems to not happen with a separate `/boot`.

The disk size (sum of all partitions) is 19GB, same as `conf.partitions.partitions` for oscap-style tests.