### PR TITLE
Waive enable_fips_mode issue on /hardening/container/anaconda-ostree

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -156,5 +156,9 @@
 # https://issues.redhat.com/browse/OPENSCAP-5272
 /hardening/container/[^/]+/[^/]+/enable_authselect
     rhel == 9
+# https://issues.redhat.com/browse/RHEL-66155 and
+# https://issues.redhat.com/browse/RHEL-73029
+/hardening/container/anaconda-ostree/[^/]+/enable_fips_mode
+    True
 
 # vim: syntax=python


### PR DESCRIPTION
The rule `enable_fips_mode` currently doesn't work with Anaconda because Anaconda doesn't merge kernel arguments from bootc kargs API.

See:
https://issues.redhat.com/browse/RHEL-66155
https://issues.redhat.com/browse/RHEL-73029