### PR TITLE
boot Anaconda installer with `fips=1` if testing with FIPS

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -221,6 +221,18 @@ ret = func_call({
 However do not use this syntax if you would pass extra arguments to `func_call`
 after the dict.
 
+Function definition should also follow the same logic of closing `):` on the
+same level as the `def` keyword, if function arguments need to be broken down
+into multiple lines.
+```
+def func_name(
+    arg1, arg2, arg3,
+    arg4, arg5, arg6,
+):
+    function code here
+    more code
+```
+
 ## Use comma on the last line
 
 In list/dict/etc. and even function definitions and calls spread across multiple

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -64,8 +64,12 @@ adjust:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -74,6 +78,8 @@ adjust:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 from lib import util, results, virt, oscap
 from conf import remediation
 
@@ -31,7 +32,10 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
     }
     ks.add_oscap_addon(oscap_conf)
 
-    g.install(kickstart=ks)
+    g.install(
+        kickstart=ks,
+        kernel_args=['fips=1'] if os.environ.get('WITH_FIPS') == '1' else None,
+    )
 
 with g.booted():
     # copy the original DS to the guest

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -72,6 +72,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
+    environment+:
+        WITH_FIPS: 1
 
 /ccn_advanced:
     adjust+:

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -68,8 +68,12 @@ adjust:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -78,6 +82,8 @@ adjust:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/kickstart/test.py
+++ b/hardening/kickstart/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 from lib import util, results, virt, oscap
 from conf import remediation
 
@@ -28,7 +29,11 @@ ks = virt.translate_oscap_kickstart(lines, '/root/remediation-ds.xml')
 if variant == 'with-gui':
     ks.packages.append('@Server with GUI')
 
-g.install(kickstart=ks, rpmpack=rpmpack, secure_boot=(variant == 'uefi'))
+g.install(
+    kickstart=ks, rpmpack=rpmpack,
+    secure_boot=(variant == 'uefi'),
+    kernel_args=['fips=1'] if os.environ.get('WITH_FIPS') == '1' else None,
+)
 
 with g.booted():
     # copy the original DS to the guest

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -75,6 +75,8 @@ duration: 2h
             the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
+    environment+:
+        WITH_FIPS: 1
 
 /ccn_advanced:
     adjust+:


### PR DESCRIPTION
This is the official way to enable FIPS mode, and, as of RHEL-10, the only way.