### PR TITLE
Improve waiver related to systemwide crypto policy

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -83,7 +83,9 @@
     rhel >= 9
 
 # https://github.com/ComplianceAsCode/content/issues/12942
+# https://issues.redhat.com/browse/RHEL-4722
 /hardening/anaconda/ospp/configure_crypto_policy
+/hardening/anaconda/ospp/enable_fips_mode
 /hardening/anaconda/.+/configure_gnutls_tls_crypto_policy
 /hardening/anaconda/.+/harden_sshd_ciphers_openssh_conf_crypto_policy
 /hardening/anaconda/.+/harden_sshd_ciphers_opensshserver_conf_crypto_policy


### PR DESCRIPTION
The rule configure_crypto_policy fails in test /hardening/anaconda/ospp on RHEL 8 because the OSPP profile requires the policy to be set to FIPS:OSPP, but the actual state of the policy is FIPS. This is a known bug in Anaconda: https://issues.redhat.com/browse/RHEL-4722. For the same reason the rule enable_fips_mode fails the same test as well.