### PR TITLE
Remove `openssh-server` from `lib.virt` requires

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -111,6 +111,9 @@
 # https://issues.redhat.com/browse/RHEL-25574
 /hardening/image-builder/ccn_[^/]+
     rhel == 9 and status == 'error'
+# https://github.com/ComplianceAsCode/content/issues/12968
+/hardening/image-builder/stig
+    rhel == 9 and status == 'error'
 
 # DISA Alignment waivers
 #

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -353,7 +353,6 @@ class Guest:
     """
 
     GUEST_REQUIRES = [
-        'openssh-server',
         'qemu-guest-agent',
     ]
 


### PR DESCRIPTION
From the commit:

```
    This breaks content remediations when GUEST_REQUIRES are added
    to RpmPack and then a remediation does

      dnf -y remove openssh-server
      dnf -y install openssh-server

    as the first command removes the RpmPack, removing also all system
    dnf repositories.

    I can't find why I added 'openssh-server' as a kickstart dependency
    back when refactoring startup scripts, but I don't see a good
    reason for it to be there - I guess the idea was (at some point)
    to enforce our RpmPack RPM scripts to run later in the transaction,
    but I again can't find anything that would rely on it anymore.
```