### PR TITLE
run `/hardening/oscap/old-new` only on x86_64 due to VMs

### DIFF
--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -9,7 +9,7 @@ description: |-
     successfully fixes the non-compliance, as verified by a scan.
 environment+:
     PYTHONPATH: ../../..
-adjust:
+adjust+:
   - when: distro == rhel-10
     enabled: false
     because: TODO - no old scap-security-guide release yet


### PR DESCRIPTION
The parent `/hardening/oscap` is already x86_64-only, all we need to do is to just inherit it.