### PR TITLE
Align FIPS environment settings in GUI test

### DIFF
--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -37,6 +37,8 @@ duration: 2h
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -52,8 +54,12 @@ duration: 2h
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -37,6 +37,8 @@ duration: 2h
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -52,8 +54,12 @@ duration: 2h
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -37,6 +37,8 @@ duration: 2h
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -52,8 +54,12 @@ duration: 2h
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -37,6 +37,8 @@ duration: 2h
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false
@@ -52,8 +54,12 @@ duration: 2h
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro == rhel-8
         enabled: false


### PR DESCRIPTION
Align FIPS environment settings so that the WITH_FIPS is set to 1 in all GUI tests where it's set in the corresponding non-GUI test (non-GUI tests are defined in main.fmf whereas GUI tests are defined in with-gui.fmf). The exception is STIG where we have a special stig_gui profile where the WITH_FIPS environment variable is already set.