### PR TITLE
Install VMs with FIPS of bootable containers

### DIFF
--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -149,10 +149,6 @@
 # https://issues.redhat.com/browse/OPENSCAP-5272
 /hardening/container/[^/]+/[^/]+/enable_authselect
     rhel == 9
-# https://issues.redhat.com/browse/RHEL-66155 and
-# https://issues.redhat.com/browse/RHEL-73029
-/hardening/container/anaconda-ostree/[^/]+/enable_fips_mode
-    True
 # https://issues.redhat.com/browse/RHEL-77158
 # (we unselect max_age in conf/remediations.py)
 /hardening/container/anaconda-ostree/.+/accounts_password_set_min_life_existing

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -66,8 +66,12 @@ adjust:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -76,6 +80,8 @@ adjust:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -56,6 +56,8 @@ adjust:
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false


### PR DESCRIPTION
Set the WITH_FIPS environment variable for tests in the test `/hardening/container/anaconda-ostree` for profiles that require FIPS mode. Consequently, the rule enable_fips_mode will start to pass, so we can remove the waiver for it.

The trigger seems to be that the following bugs have been fixed in Anaconda: https://issues.redhat.com/browse/RHEL-76923 https://issues.redhat.com/browse/RHEL-73029. This revealed that our tests aren't ready for FIPS mode.

Resolves: https://github.com/ComplianceAsCode/content/issues/13036