### PR TITLE
/hardening/container: use openscap from RHEL9 compose

### DIFF
--- a/hardening/container/bootc-image-builder/test.py
+++ b/hardening/container/bootc-image-builder/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import os
 import shutil
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from conf import remediation
 virt.Host.setup()
 
 _, variant, profile = util.get_test_name().rsplit('/', 2)
+oscap_repo = os.environ.get('CONTEST_OSCAP_REPOFILE')
 
 oscap.unselect_rules(util.get_datastream(), 'remediation-ds.xml', remediation.excludes())
 
@@ -27,37 +29,26 @@ if versions.rhel.is_true_rhel():
 else:
     src_image = f'quay.io/centos-bootc/centos-bootc:stream{major}'
 
-# TODO: remove after new OpenSCAP with oscap-im is released on RHEL-9
-if versions.rhel <= 9:
-    copr = 'packit/OpenSCAP-openscap-maint-1.3'
-    openscap_from_copr = [
-        'RUN dnf -y install dnf-plugins-core',
-        f'RUN dnf -y copr enable {copr} centos-stream-{versions.rhel.major}-x86_64',
-    ]
-    openscap_from_copr_str = '\n    '.join(openscap_from_copr)
-else:
-    openscap_from_copr_str = ''
-
 # prepare a RpmPack with testing-specific hacks
 # - copy it to CWD because podman cannot handle absolute paths (or relative ones
 #   going above CWD) as source for COPY or RUN --mount
 pack = util.RpmPack()
+if oscap_repo:
+    pack.add_file(oscap_repo)
 pack.add_sshd_late_start()
 with pack.build() as pack_binrpm:
-    shutil.copy(pack_binrpm, 'contest-rpmpack.rpm')
+    shutil.copy(pack_binrpm, 'contest-pack.rpm')
 
 # prepare a Container file for making a hardened image
 cfile = podman.Containerfile()
 cfile += util.dedent(fr'''
     FROM {src_image}
     # install testing-specific RpmPack
-    COPY contest-rpmpack.rpm /root/.
-    RUN dnf -y install /root/contest-rpmpack.rpm
-    RUN rm -f /root/contest-rpmpack.rpm
+    COPY contest-pack.rpm /root/.
+    RUN dnf -y install /root/contest-pack.rpm && rm -f /root/contest-pack.rpm
     # copy over testing-specific datastream
     COPY remediation-ds.xml /root/.
     # install and run oscap-im to harden the image
-    {openscap_from_copr_str}
     RUN dnf -y install openscap-utils
     RUN oscap-im --profile '{profile}' \
         --results-arf /root/remediation-arf.xml /root/remediation-ds.xml

--- a/lib/util/rpmpack.py
+++ b/lib/util/rpmpack.py
@@ -44,15 +44,24 @@ class RpmPack:
     # for simplicity reasons
     # - RPM does auto-create them on install, so the only issue is them being
     #   left there after RPM uninstall, which we don't care about here
-    def add_file(self, source, target):
+    def add_file(self, source, target=None):
         """
         Add a file path to the RPM, 'source' specifies a file path on the host,
         'target' is the installed path in the RPM.
+
+        If 'target' is not specified, it is equal to 'source', which then must
+        be an absolute path.
         """
-        target = Path(target)
-        if not target.is_absolute():
-            raise SyntaxError(f"target {target} not an absolute path")
-        entry = self.FilePath(Path(source).absolute(), target)
+        source = Path(source)
+        if target:
+            target = Path(target)
+            if not target.is_absolute():
+                raise SyntaxError(f"target {target} not an absolute path")
+        else:
+            if not source.is_absolute():
+                raise SyntaxError(f"source {source} must be absolute if target is missing")
+            target = source
+        entry = self.FilePath(source.absolute(), target)
         self.files.append(entry)
 
     def add_file_contents(self, target, contents):

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -68,6 +68,7 @@ adjust:
                 exit 0
             fi
             repofile=/etc/yum.repos.d/openscap-upstream-packit.repo
+            echo "CONTEST_OSCAP_REPOFILE=$repofile" >> "$TMT_PLAN_ENVIRONMENT_FILE"
             rm -f "$repofile"
             if rpm -q openscap-scanner; then
                 # the RPM might have been upgraded from another PR, sanitize it


### PR DESCRIPTION
RHEL-9.6 composes should already contain a new build of openscap which supports Image Mode for RHEL.

We also extend `contest-rpmpack` RPM to include openscap Packit repository
provided through `CONTEST_OSCAP_BRANCH` or `CONTEST_OSCAP_PR` environment
variables which allows us to test custom openscap builds in RHEL Image Mode
tests. In case these environment variables are defined the tmt plan also
defines `CONTEST_OSCAP_REPOFILE` environment variable containing a path to
the Packit repository on the host which is then added to `contest-rpmpack`
RPM which is installed into a bootc container through Containerfile.