### PR TITLE
Move building of content to python code

### DIFF
--- a/lib/util/old_content.py
+++ b/lib/util/old_content.py
@@ -55,7 +55,8 @@ def get_old_datastream():
 
     # "new" content is CONTEST_CONTENT,
     # "old" is the installed scap-security-guide RPM
-    if util.user_content:
+    user_content = util.get_user_content(build=False)
+    if user_content:
         yield ssg_datastream
 
     # "new" is the installed scap-security-guide RPM,

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -115,7 +115,8 @@ if not g.is_installed():
     ks.packages.append('tar')
     g.install(kickstart=ks, disk_format='qcow2')
 
-with util.get_content() as content_dir, g.booted():
+with util.get_source_content() as content_dir, g.booted():
+    util.build_content(content_dir)
     env = os.environ.copy()
     env['SSH_ADDITIONAL_OPTIONS'] = f'-o IdentityFile={g.ssh_keyfile_path}'
     cmd = [
@@ -123,6 +124,7 @@ with util.get_content() as content_dir, g.booted():
         '--libvirt', 'qemu:///system', virt.GUEST_NAME,
         '--product', f'rhel{versions.rhel.major}',
         '--dontclean', '--remediate-using', fix_type,
+        '--datastream', util.get_datastream(),
         *our_rules,
     ]
     _, lines = util.subprocess_stream(

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -39,20 +39,6 @@ adjust:
                 git checkout FETCH_HEAD
             fi
             echo "CONTEST_CONTENT=$content_dir" >> "$TMT_PLAN_ENVIRONMENT_FILE"
-      - how: shell
-        name: Build CONTEST_CONTENT (if specified)
-        script: |
-            set -xe
-            . "$TMT_PLAN_ENVIRONMENT_FILE"  # not done automatically
-            [ -z "$CONTEST_CONTENT" ] && exit 0
-            cd "$CONTEST_CONTENT"
-            distro=$(. /etc/os-release && echo "$ID")
-            [ "$distro" = "centos" ] && derivatives=--derivatives || derivatives=
-            major=$(. /etc/os-release && echo "${VERSION_ID%%.*}")
-            # already built
-            [ -e "build/ssg-rhel${major}-ds.xml" ] && exit 0
-            dnf -y builddep --spec scap-security-guide.spec
-            ./build_product --playbook-per-rule $derivatives "rhel${major}"
 
   - prepare+:
       - how: shell

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -30,7 +30,7 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
 
     g.install(kickstart=ks)
 
-with g.booted(), util.get_content(build=False) as content_dir:
+with g.booted(), util.get_source_content() as content_dir:
     g.copy_to(util.get_datastream(), 'ssg-ds.xml')
     shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
     g.copy_from('ssg-report.html')

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -35,7 +35,7 @@ with g.snapshotted():
     ansible.report_from_output(lines)
     g.soft_reboot()
 
-    with util.get_content(build=False) as content_dir:
+    with util.get_source_content() as content_dir:
         g.copy_to(util.get_datastream(), 'ssg-ds.xml')
         shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
         g.copy_from('ssg-report.html')

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -29,7 +29,7 @@ with g.snapshotted():
             raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
         g.soft_reboot()
 
-    with util.get_content(build=False) as content_dir:
+    with util.get_source_content() as content_dir:
         g.copy_to(util.get_datastream(), 'ssg-ds.xml')
         shared.content_scan(g, 'ssg-ds.xml', html='ssg-report.html', arf='ssg-arf.xml')
         g.copy_from('ssg-report.html')

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -2,44 +2,17 @@
 
 import re
 
-from lib import util, results, versions, ansible
+from lib import util, results, ansible
 
-
-# options are taken from scap-security-guide spec file
-if versions.rhel.is_true_rhel():
-    cmake_options = [
-        f'-DSSG_PRODUCT_RHEL{versions.rhel.major}:BOOLEAN=TRUE',
-        '-DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE',
-        '-DSSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED:BOOL=OFF',
-        '-DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=OFF',
-        '-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL=ON',
-    ]
-elif versions.rhel.is_centos():
-    cmake_options = [
-        f'-DSSG_PRODUCT_RHEL{versions.rhel.major}:BOOLEAN=TRUE',
-        '-DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE',
-        '-DSSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED:BOOL=OFF',
-        '-DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=ON',
-        '-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL=ON',
-    ]
-else:
-    cmake_options = [
-        '-DSSG_SEPARATE_SCAP_FILES_ENABLED=OFF',
-        '-DSSG_BASH_SCRIPTS_ENABLED=OFF',
-        '-DSSG_BUILD_SCAP_12_DS=OFF',
-    ]
 
 ansible.install_deps()
 # Extra modules to enable more unit tests
 python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'cmakelint']
 util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])
 
-with util.get_content(build=False) as content_dir:
-    build_dir = content_dir / 'build'
-    build_dir.mkdir(exist_ok=True)
-
-    util.subprocess_run(['cmake', '../', *cmake_options], cwd=build_dir, check=True)
-    util.subprocess_run(['make', '-j4'], cwd=build_dir, check=True)
+with util.get_source_content() as content_dir:
+    util.build_content(content_dir, {'SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL': 'ON'})
+    build_dir = content_dir / util.CONTENT_BUILD_DIR
 
     # ctest
     cmd = [


### PR DESCRIPTION
This effectively reverts https://github.com/RHSecurityCompliance/contest/pull/260/commits/9c3184d8717e5e5395f8ddfffdaf31115d3b0617 and replaces it with a more comprehensive tunable python building logic.

The main reason is that some tests already do that (namely `rpmbuild-ctest`) because of specific CMake build options. And I would like to add more - a new `/per-rule` rewrite done via https://github.com/ComplianceAsCode/content/pull/13029 needing `SSG_THIN_DS:BOOL=ON` along with `SSG_BUILT_TESTS_ENABLED:BOOL=ON`.

So via this PR I propose a two-part logic:
* Have tests explicitly request CMake build options if they need them, otherwise default to some defaults
* Pre-build content in runcontest/productization using 16 CPU cores, with some maximum possible option set, then upload built content to all Beaker VMs

All of this is safely guarded by the built options check that re-builds the content if the requested options differ from how it was built:
* Tests that don't care simply don't specify such options (ie. most tests won't care about thin datastreams)
* Tests that care and want them disabled will rebuild content (request option value different)
* Tests that care and want them enabled will also rebuild content (request option value different)

The end result shouldn't have any negative effect on our productization testing (we're not adding build time to test `duration` because we'll pre-build content on Gitlab runner), but should be cleaner for ad-hoc executions since a developer `rsync`ing built content won't accidentally forget `--playbooks-per-rule` (breaking a test) - the test will just rebuild if needed.

I also took the opportunity to document the complexity of `lib.util.content`, and moved building to a separate function, since most `get_content()` users did not want it built anyway.