### PR TITLE
Disable `BUILD_DISA_DELTA_FILES` and `SEPARATE_SCAP_FILES`

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -192,6 +192,8 @@ def build_content(path, extra_cmake_opts=None):
         f'SSG_PRODUCT_RHEL{versions.rhel.major}:BOOL': 'ON',
         'SSG_SCE_ENABLED:BOOL': 'ON',
         'SSG_BASH_SCRIPTS_ENABLED:BOOL': 'OFF',
+        'SSG_BUILD_DISA_DELTA_FILES:BOOL': 'OFF',
+        'SSG_SEPARATE_SCAP_FILES_ENABLED:BOOL': 'OFF',
     }
     cmake_opts.update(extra_cmake_opts)
 


### PR DESCRIPTION
These build options are disabled in `scap-security-guide.spec`, and we probably don't need them for testing, so try to stay as close to SSG RPM build as possible.