### PR TITLE
Rebuild content for some tests

### DIFF
--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -108,7 +108,7 @@
 # Caused by SCE content being built by default, enabled
 # in https://github.com/ComplianceAsCode/content/pull/12488
 /static-checks/nist-validation/ssg-(rhel\d+|cs\d+)-ds/SRC-118
-    rhel >= 9
+    True
 
 # bootc waivers
 

--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -171,7 +171,7 @@ def _parse_cmake_config(path):
             yield (name, value)
 
 
-def build_content(path, extra_cmake_opts=None):
+def build_content(path, extra_cmake_opts=None, force=False):
     """
     Given a CaC/content source as 'path', build it with some sensible CMake
     options.
@@ -179,6 +179,8 @@ def build_content(path, extra_cmake_opts=None):
     Specify any additional ones as 'extra_cmake_opts' (dict); make sure to use
     the full option name with :DATATYPE as visible in CMakeCache.txt.
     See also https://cmake.org/cmake/help/latest/prop_cache/TYPE.html.
+
+    Set 'force=True' to always re-build content, even with compatible options.
     """
     path = Path(path)
     build_dir = path / CONTENT_BUILD_DIR
@@ -200,7 +202,7 @@ def build_content(path, extra_cmake_opts=None):
     # if there is pre-built content, check if it was built with options
     # we care about - if it was, do not rebuild it
     cmake_cache = build_dir / 'CMakeCache.txt'
-    if cmake_cache.exists():
+    if cmake_cache.exists() and not force:
         built_opts = dict(_parse_cmake_config(cmake_cache))
         for key, value in cmake_opts.items():
             if key not in built_opts or value != built_opts[key]:

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -116,7 +116,7 @@ if not g.is_installed():
     g.install(kickstart=ks, disk_format='qcow2')
 
 with util.get_source_content() as content_dir, g.booted():
-    util.build_content(content_dir)
+    util.build_content(content_dir, force=True)
     env = os.environ.copy()
     env['SSH_ADDITIONAL_OPTIONS'] = f'-o IdentityFile={g.ssh_keyfile_path}'
     cmd = [

--- a/static-checks/rpmbuild-ctest/test.py
+++ b/static-checks/rpmbuild-ctest/test.py
@@ -11,7 +11,13 @@ python_modules = ['lxml', 'pytest', 'trestle', 'openpyxl', 'cmakelint']
 util.subprocess_run(['python3', '-m', 'pip', 'install', *python_modules])
 
 with util.get_source_content() as content_dir:
-    util.build_content(content_dir, {'SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL': 'ON'})
+    # force a build, because CTest uses absolute paths somewhere in the built
+    # content, which breaks when the content was pre-build elsewhere
+    util.build_content(
+        content_dir,
+        {'SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL': 'ON'},
+        force=True,
+    )
     build_dir = content_dir / util.CONTENT_BUILD_DIR
 
     # ctest


### PR DESCRIPTION
It seems the built content hardcodes some absolute paths that break some tests.

"Fix" it by rebuilding it inside those tests.