### PR TITLE
OPENSCAP-5414 Change DISA Alignment test

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -96,11 +96,6 @@
 # https://github.com/ComplianceAsCode/content/issues/12561
 /scanning/disa-alignment/.*/logind_session_timeout
     rhel == 8
-# https://github.com/ComplianceAsCode/content/issues/13020
-/scanning/disa-alignment/.*/accounts_passwords_pam_faillock_interval
-/scanning/disa-alignment/.*/accounts_passwords_pam_faillock_silent
-/scanning/disa-alignment/.*/accounts_passwords_pam_faillock_unlock_time
-    rhel == 8
 # https://github.com/ComplianceAsCode/content/issues/13033
 /scanning/disa-alignment/(oscap|ansible)/file_permission_user_init_files_root
     rhel == 8

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python3
-import os
-import subprocess
 
 import shared
 from lib import util, results, virt, oscap, versions

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -46,12 +46,7 @@ with g.booted(), util.get_content(build=False) as content_dir:
     g.copy_from('disa-report.html')
     g.copy_from('disa-arf.xml')
 
-    # Compare ARFs via CaC/content script and report results from output
-    compare_script = content_dir / 'utils' / 'compare_results.py'
-    env = os.environ.copy()
-    env['PYTHONPATH'] = str(content_dir)
-    cmd = [compare_script, 'ssg-arf.xml', 'disa-arf.xml']
-    proc = util.subprocess_run(cmd, env=env, universal_newlines=True, stdout=subprocess.PIPE)
-    shared.comparison_report(proc.stdout.rstrip('\n'))
+    # Compare ARFs and report results from output
+    shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
 results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -51,12 +51,7 @@ with g.snapshotted():
         g.copy_from('disa-report.html')
         g.copy_from('disa-arf.xml')
 
-        # Compare ARFs via CaC/content script and report results from output
-        compare_script = content_dir / 'utils' / 'compare_results.py'
-        env = os.environ.copy()
-        env['PYTHONPATH'] = str(content_dir)
-        cmd = [compare_script, 'ssg-arf.xml', 'disa-arf.xml']
-        proc = util.subprocess_run(cmd, env=env, universal_newlines=True, stdout=subprocess.PIPE)
-        shared.comparison_report(proc.stdout.rstrip('\n'))
+        # Compare ARFs and report results from output
+        shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
 results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 import os
-import subprocess
 
 import shared
 from lib import util, results, virt, versions, ansible

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python3
-import os
-import subprocess
 
 import shared
 from lib import util, results, virt, oscap, versions

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -45,12 +45,7 @@ with g.snapshotted():
         g.copy_from('disa-report.html')
         g.copy_from('disa-arf.xml')
 
-        # Compare ARFs via CaC/content script and report results from output
-        compare_script = content_dir / 'utils' / 'compare_results.py'
-        env = os.environ.copy()
-        env['PYTHONPATH'] = str(content_dir)
-        cmd = [compare_script, 'ssg-arf.xml', 'disa-arf.xml']
-        proc = util.subprocess_run(cmd, env=env, universal_newlines=True, stdout=subprocess.PIPE)
-        shared.comparison_report(proc.stdout.rstrip('\n'))
+        # Compare ARFs and report results from output
+        shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
 results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -153,7 +153,7 @@ def compare_results(ssg_results, disa_results):
 
 
 def get_disa_result_to_str(stig_ids_results):
-    if stig_ids_results:
+    if len(stig_ids_results) == 0:
         return "Empty"
     ll = (f"{k}:{v}" for k, v in stig_ids_results.items())
     return ", ".join(ll)

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -1,11 +1,46 @@
-import re
+from collections import namedtuple
+import xml.etree.ElementTree as ET
 
 from lib import results
 
+nsmap = {
+    "xccdf": "http://checklists.nist.gov/xccdf/1.2",
+}
+STIG_REF = "https://public.cyber.mil/stigs/srg-stig-tools/"
+CCE = "https://ncp.nist.gov/cce"
+SSG_RULE_PREFIX = "xccdf_org.ssgproject.content_rule_"
+DISA_RULE_PREFIX = "xccdf_mil.disa.stig_rule_"
+
+DISARuleResult = namedtuple('DISARuleResult', ['rule_id', 'result'])
 
 profile = 'stig'
 
 shared_cmd = ['oscap', 'xccdf', 'eval', '--progress']
+
+class SSGRuleResult:
+    def __init__(self, rule_id, cce_id, rule_title, stig_ids, result):
+        self.rule_id = rule_id
+        self.cce_id = cce_id
+        self.rule_title = rule_title
+        self.stig_ids = stig_ids
+        self.result = result
+        self.stig_ids_results = dict()
+        self.final_result = None
+
+    def __repr__(self):
+        return (
+            f"SSGRuleResult(rule_id='{self.rule_id}', cce_id='{self.cce_id}',"
+            f"rule_title='{self.rule_title}', stig_ids={self.stig_ids}', "
+            f"result='{self.result}', "
+            f"comparison_with_stig_ids={self.stig_ids_results}, "
+            f"final_result={self.final_result})"
+        )
+
+
+class ComparisonResult:
+    SAME = "SAME"
+    DIFFERENT = "DIFFERENT"
+    MISSING = "MISSING"
 
 
 def content_scan(host, ds, html, arf):
@@ -17,7 +52,7 @@ def content_scan(host, ds, html, arf):
         *shared_cmd,
         '--profile', profile,
         '--report', html,
-        '--stig-viewer', arf,
+        '--results-arf', arf,
         ds,
     ]
     proc = host.ssh(' '. join(cmd))
@@ -42,27 +77,122 @@ def disa_scan(host, ds, html, arf):
         raise RuntimeError(f"remediation oscap failed with {proc.returncode}")
 
 
-def comparison_report(comparison_output):
-    """
-    Parse CaC/content utils/compare_results.py output and report different results.
-      Same result format:      CCE CCI - DISA_RULE_ID SSG_RULE_ID     RESULT
-      Different result format: CCE CCI - DISA_RULE_ID SSG_RULE_ID     SSG_RESULT - DISA_RESULT
-    """
-    result_regex = re.compile(r'([\w-]+) [\w-]+ - [\w-]+ (\w*)\s+(\w+)(?: - *(\w+))*')
-    for match in result_regex.finditer(comparison_output):
-        rule_cce, rule_id, ssg_result, disa_result = match.groups()
-        if not rule_id:
-            rule_id = rule_cce
-        # Only 1 result matched - same results
-        if not disa_result:
-            results.report('pass', rule_id)
-        # SSG CPE checks can make rule notapplicable by different reason (package not
-        # installed, architecture, RHEL version). DISA bechmark doesn't have this
-        # capability, it just 'pass'. Ignore such result misalignments
-        elif ssg_result == 'notapplicable' and disa_result == 'pass':
-            result_note = 'SSG result: notapplicable, DISA result: pass'
-            results.report('pass', rule_id, result_note)
-        # Different results
+def parse_ssg_results(ssg_path):
+    ssg_results = {}
+    root = ET.parse(ssg_path).getroot()
+    xccdf_benchmark = root.find(".//xccdf:Benchmark", nsmap)
+    xccdf_results = root.find(".//xccdf:TestResult", nsmap)
+    for rule_result in xccdf_results.findall("xccdf:rule-result", nsmap):
+        full_rule_id = rule_result.get("idref")
+        result = rule_result.find("xccdf:result", nsmap).text
+        if result == "notselected":
+            continue
+        rule = xccdf_benchmark.find(
+            f".//xccdf:Rule[@id='{full_rule_id}']", nsmap)
+        title = rule.find("xccdf:title", nsmap).text
+        cce_id = rule.find(f"xccdf:ident[@system='{CCE}']", nsmap).text
+        stig_ids = []
+        xpath = f"xccdf:reference[@href='{STIG_REF}']"
+        for stig_ref_el in rule.findall(xpath, nsmap):
+            if stig_ref_el is not None:
+                stig_ids.append(stig_ref_el.text)
+        rule_id = full_rule_id.replace(SSG_RULE_PREFIX, "")
+        sr = SSGRuleResult(rule_id, cce_id, title, stig_ids, result)
+        ssg_results[rule_id] = sr
+    return ssg_results
+
+
+def parse_disa_results(disa_path):
+    disa_results = {}
+    root = ET.parse(disa_path).getroot()
+    xccdf_results = root.find(".//xccdf:TestResult", nsmap)
+    for rule_result in xccdf_results.findall("xccdf:rule-result", nsmap):
+        full_rule_id = rule_result.get("idref")
+        rule_id = full_rule_id.replace(DISA_RULE_PREFIX, "")
+        result = rule_result.find("xccdf:result", nsmap).text
+        disa_results[rule_id] = result
+    return disa_results
+
+
+def compare_result_with_stig_id(result, stig_id, disa_results):
+    if stig_id in disa_results:
+        disa_result = disa_results[stig_id]
+        if result == disa_result:
+            return ComparisonResult.SAME
         else:
-            result_note = f'SSG result: {ssg_result}, DISA result: {disa_result}'
-            results.report('fail', rule_id, result_note)
+            return ComparisonResult.DIFFERENT
+    else:
+        return ComparisonResult.MISSING
+
+
+def compare_results(ssg_results, disa_results):
+    for ssg_rule_result in ssg_results.values():
+        same = 0
+        different = 0
+        missing = 0
+        if len(ssg_rule_result.stig_ids) == 0:
+            ssg_rule_result.final_result = ComparisonResult.MISSING
+        for stig_id in ssg_rule_result.stig_ids:
+            comparison_result = compare_result_with_stig_id(
+                ssg_rule_result.result, stig_id, disa_results)
+            disa_result = disa_results.get(stig_id, "not found")
+            ssg_rule_result.stig_ids_results[stig_id] = disa_result
+            if comparison_result == ComparisonResult.SAME:
+                same += 1
+            elif comparison_result == ComparisonResult.DIFFERENT:
+                different += 1
+            elif comparison_result == ComparisonResult.MISSING:
+                missing += 1
+        if same >= 1:
+            ssg_rule_result.final_result = ComparisonResult.SAME
+        elif different >= 1:
+            ssg_rule_result.final_result = ComparisonResult.DIFFERENT
+        elif missing >= 1:
+            ssg_rule_result.final_result = ComparisonResult.MISSING
+
+
+def get_disa_result_to_str(stig_ids_results):
+    if len(stig_ids_results) == 0:
+        return "Empty"
+    ll = [f"{k}:{v}" for k, v in stig_ids_results.items()]
+    return ", ".join(ll)
+
+
+def print_ssg_results(ssg_results):
+    print(
+        "Alignment CCE         Rule ID               Result                "
+        "Stig ID:DISA Result")
+    for ssg_result in ssg_results.values():
+        disa = get_disa_result_to_str(ssg_result.stig_ids_results)
+        print(
+            f"{ssg_result.final_result:<10}"
+            f"{ssg_result.cce_id} "
+            f"{ssg_result.rule_id:<55} "
+            f"{ssg_result.result:<20} "
+            f"{disa}"
+        )
+
+
+def report_misalignments(ssg_results):
+    # SSG CPE checks can make rule notapplicable by different reason (package
+    # not installed, architecture, RHEL version). DISA benchmark doesn't have
+    # this capability, it just 'pass'. Ignore such result misalignments.
+    for ssg_result in ssg_results.values():
+        result = "pass"
+        disa = get_disa_result_to_str(ssg_result.stig_ids_results)
+        result_note = (
+            f"{ssg_result.rule_id}: "
+            f"SSG result: {ssg_result.result}, "
+            f"DISA result(s): {disa}")
+        if ssg_result.final_result == ComparisonResult.DIFFERENT and \
+                ssg_result.result != "notapplicable":
+            result = "fail"
+        results.report(result, ssg_result.rule_id, result_note)
+
+
+def compare_arfs(ssg_path, disa_path):
+    ssg_results = parse_ssg_results(ssg_path)
+    disa_results = parse_disa_results(disa_path)
+    compare_results(ssg_results, disa_results)
+    print_ssg_results(ssg_results)
+    report_misalignments(ssg_results)

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+import collections
 import xml.etree.ElementTree as ET
 
 from lib import results
@@ -11,7 +11,7 @@ CCE = "https://ncp.nist.gov/cce"
 SSG_RULE_PREFIX = "xccdf_org.ssgproject.content_rule_"
 DISA_RULE_PREFIX = "xccdf_mil.disa.stig_rule_"
 
-DISARuleResult = namedtuple('DISARuleResult', ['rule_id', 'result'])
+DISARuleResult = collections.namedtuple('DISARuleResult', ['rule_id', 'result'])
 
 profile = 'stig'
 
@@ -37,10 +37,10 @@ class SSGRuleResult:
         )
 
 
-class ComparisonResult:
-    SAME = "SAME"
-    DIFFERENT = "DIFFERENT"
-    MISSING = "MISSING"
+class ComparisonResult(enum.Enum):
+    SAME = enum.auto()
+    DIFFERENT = enum.auto()
+    MISSING = enum.auto()
 
 
 def content_scan(host, ds, html, arf):
@@ -152,9 +152,9 @@ def compare_results(ssg_results, disa_results):
 
 
 def get_disa_result_to_str(stig_ids_results):
-    if len(stig_ids_results) == 0:
+    if stig_ids_results:
         return "Empty"
-    ll = [f"{k}:{v}" for k, v in stig_ids_results.items()]
+    ll = (f"{k}:{v}" for k, v in stig_ids_results.items())
     return ", ".join(ll)
 
 

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -24,7 +24,7 @@ class SSGRuleResult:
         self.rule_title = rule_title
         self.stig_ids = stig_ids
         self.result = result
-        self.stig_ids_results = dict()
+        self.stig_ids_results = {}
         self.final_result = None
 
     def __repr__(self):
@@ -169,8 +169,7 @@ def print_ssg_results(ssg_results):
             f"{ssg_result.cce_id} "
             f"{ssg_result.rule_id:<55} "
             f"{ssg_result.result:<20} "
-            f"{disa}"
-        )
+            f"{disa}")
 
 
 def report_misalignments(ssg_results):

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -1,4 +1,5 @@
 import collections
+import enum
 import xml.etree.ElementTree as ET
 
 from lib import results

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -180,10 +180,7 @@ def report_misalignments(ssg_results):
     for ssg_result in ssg_results.values():
         result = "pass"
         disa = get_disa_result_to_str(ssg_result.stig_ids_results)
-        result_note = (
-            f"{ssg_result.rule_id}: "
-            f"SSG result: {ssg_result.result}, "
-            f"DISA result(s): {disa}")
+        result_note = f"SSG result: {ssg_result.result}, DISA result(s): {disa}"
         if ssg_result.final_result == ComparisonResult.DIFFERENT and \
                 ssg_result.result != "notapplicable":
             result = "fail"


### PR DESCRIPTION
The DISA Alignment test had problem that it doesn't account for situations when a single SSG rule maps to multiple DISA rules or when a single DISA rule maps to multiple SSG rules. In these situations we get false positive results. This commit attempts to fix these issues. The test will not use `compare_results.py` from ComplianceAsCode because that script is too complex but we will process the results by functions in `scanning/disa-alignment/shared.py`.

Fixes: https://github.com/ComplianceAsCode/content/issues/13020

We will also remove the waivers of the upstream issue.