### PR TITLE
conf/find_invalid_waivers.py: new script to indetify invalid waivers

### DIFF
--- a/conf/find_invalid_waivers.py
+++ b/conf/find_invalid_waivers.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python3
+"""
+This is a standalone script which processes provided results.txt.gz files
+and identifies invalid waivers. The waiver is invalid if it:
+ - did not match any test results,
+ - or only matched the 'pass' test results.
+
+The identified invalid waivers are printed to the standard output.
+"""
+
+import re
+import sys
+import gzip
+import pathlib
+import argparse
+import textwrap
+
+# add the parent directory to the sys.path so we can import from the lib directory
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from lib import waive, versions
+
+_sections_cache = None
+
+
+def find_regexes_in_list(regexes_matched_list, regexes):
+    for index, (list_regexes, _) in enumerate(regexes_matched_list):
+        if list_regexes == regexes:
+            return index
+    return None
+
+
+def add_regexes_to_list(regexes_matched_list, regexes, non_pass_result):
+    index = find_regexes_in_list(regexes_matched_list, regexes)
+    if index is not None:
+        # tuple with the regexes is already in the list, the boolean value
+        # needs to be modified only in case we matched a non-pass test result
+        # and it is not already marked as such in the existing tuple
+        if non_pass_result is True and regexes_matched_list[index][1] is False:
+            regexes_matched_list[index] = (regexes_matched_list[index][0], non_pass_result)
+    else:
+        # tuple with the regexes not found, add it to the list
+        regexes_matched_list.append((regexes, non_pass_result))
+
+
+def unwaive_note(waive_text, note):
+    return note.lstrip(waive_text).rstrip(')')
+
+
+def match_result_mark_waiver(regexes_matched_list, version, arch, status, name, note):
+    """This function is an updated version of the match_result() function from the lib/waive.py."""
+    version = versions._Rhel(version=version, id='rhel')
+
+    # make sure "'something' in name" always works
+    if name is None:
+        name = ''
+    if note is None or note == '[]':
+        note = ''
+
+    if '(waived pass)' in note:
+        note = unwaive_note('(waived pass)', note)
+    elif '(waived fail)' in note:
+        note = unwaive_note('(waived fail)', note)
+        status = 'fail'
+    elif '(waived error)' in note:
+        note = unwaive_note('(waived error)', note)
+        status = 'error'
+
+    objs = {
+        'status': status,
+        'name': name,
+        'note': note,
+        'arch': arch,
+        'rhel': version,
+        'oscap': '',
+        'env': '',
+        'Match': waive.Match,
+    }
+
+    for section in _sections_cache:
+        if any(x.fullmatch(name) for x in section.regexes):
+            ret = eval(section.python_code, objs, None)
+
+            if not isinstance(ret, waive.Match):
+                if not isinstance(ret, bool):
+                    raise RuntimeError(f"waiver python code did not return bool or Match: {ret}")
+                ret = waive.Match(ret)
+
+            if ret:  # both regex and python code matched
+                add_regexes_to_list(regexes_matched_list, section.regexes, bool(status != 'pass'))
+
+
+def load_and_process_results(file, regexes_matched_list):
+    with gzip.open(file, 'rt') as f:
+        for line in f:
+            line = line.strip()
+            version, arch, status, name, note = line.split('\t')
+
+            if status not in ['pass', 'fail', 'error', 'warn']:
+                continue
+
+            match_result_mark_waiver(regexes_matched_list, version, arch, status, name, note)
+
+
+def main(result_file_list):
+    regexes_matched_list = []
+    """
+    [
+        # list of tuples containing regexes matching some test result and a Boolean value
+        # set to True if regexes matched any non-pass test result, otherwise False
+        (set(regexes), True/False),
+        (set(regexes), True/False),
+        ...
+    ]
+    """
+    global _sections_cache
+    _sections_cache = list(waive.collect_waivers())
+
+    for file in result_file_list:
+        load_and_process_results(file, regexes_matched_list)
+
+    print("===============================================================\n"
+          "The following waivers are no longer valid, they either did not\n"
+          "match any test results or only matched the 'pass' test results:\n"
+          "===============================================================\n")
+    for section in _sections_cache:
+        index = find_regexes_in_list(regexes_matched_list, section.regexes)
+        # if the section did not match any test results or only matched the 'pass' test results:
+        if index is None or regexes_matched_list[index][1] is False:
+            python_source = next(
+                (i.python_source for i in _sections_cache if i.regexes == section.regexes),
+                None,
+            )
+            # if "is_centos()" is in python_src_code variable and there is no "or"
+            # logical operator the section is only applicable for centos so skip it
+            or_operator_in_py_code = bool(re.search(r'\s+or\s+', python_source) is not None)
+            centos_section = bool('is_centos()' in python_source and not or_operator_in_py_code)
+            if not centos_section:
+                for regex in section.regexes:
+                    print(regex.pattern)
+                print(f"    {python_source}\n")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=textwrap.dedent("""
+        Process results.txt.gz files and identify invalid waivers.
+        The waiver is invalid if it did not match any test results
+        or only matched the 'pass' test results.
+
+        IMPORTANT: Test results for all RHEL versions need to be
+        provided, otherwise this script won't be able to identify
+        the invalid waivers properly.
+        """),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "result_file", nargs='+',
+        help="The results.txt.gz file with test results to process",
+    )
+    args = parser.parse_args()
+    main(args.result_file)

--- a/lib/versions.py
+++ b/lib/versions.py
@@ -60,10 +60,14 @@ class _RpmVerCmp:
 
 
 class _Rhel(_RpmVerCmp):
-    def __init__(self):
-        _update_os_release()
+    def __init__(self, version=None, id=None):
         self._release_separator = '.'
-        v = _os_release['VERSION_ID'].split(self._release_separator)
+        if version and id:
+            v = version.split(self._release_separator)
+            _os_release['ID'] = id
+        else:
+            _update_os_release()
+            v = _os_release['VERSION_ID'].split(self._release_separator)
         if len(v) == 1:
             self.version = v[0]
             self.major = int(v[0])

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -6,12 +6,16 @@ a custom file format. See WAIVERS.md.
 import os
 import re
 import platform
+import collections
 from pathlib import Path
 
 from lib import util, versions
 
+WaiverSection = collections.namedtuple(
+    'WaiverSection',
+    ['regexes', 'python_code', 'python_source'],
+)
 _sections_cache = None
-
 
 class _PushbackIterator:
     """
@@ -109,7 +113,9 @@ def _parse_waiver_file(stream, filename):
                 # non-indented line - either empty (between regex+python blocks)
                 # or the start of a new regex+python block -- either case, we're
                 # done with the current block, so add it to the list & cleanup
-                sections.append((regexes, _compile_eval(lines, python_code)))
+                sections.append(
+                    WaiverSection(regexes, _compile_eval(lines, python_code), python_code.strip()),
+                )
                 regexes = set()
                 python_code = ''
                 state = 'skipping_empty_lines'
@@ -123,7 +129,9 @@ def _parse_waiver_file(stream, filename):
     # in the text file after the last python block (not even an empty line),
     # so do the appending here
     if python_code:
-        sections.append((regexes, _compile_eval(lines, python_code)))
+        sections.append(
+            WaiverSection(regexes, _compile_eval(lines, python_code), python_code.strip()),
+        )
 
     return sections
 
@@ -175,7 +183,7 @@ def match_result(status, name, note):
     if _sections_cache is None:
         _sections_cache = list(collect_waivers())
 
-    # make sure "'someting' in name" always works
+    # make sure "'something' in name" always works
     if name is None:
         name = ''
     if note is None:
@@ -204,10 +212,8 @@ def match_result(status, name, note):
     }
 
     for section in _sections_cache:
-        regexes, python_code = section
-
-        if any(x.fullmatch(name) for x in regexes):
-            ret = eval(python_code, objs, None)
+        if any(x.fullmatch(name) for x in section.regexes):
+            ret = eval(section.python_code, objs, None)
 
             if not isinstance(ret, Match):
                 if not isinstance(ret, bool):


### PR DESCRIPTION
Example output using results from the latest CaC/content stabilization (v0.1.76):
```
$ ./find_invalid_waivers.py test_results/rhel10/results.txt.gz test_results/rhel9/results.txt.gz test_results/rhel8/results.txt.gz
2025-02-24 17:26:57 find_invalid_waivers.py:161: lib.waive.collect_waivers:149: using /home/matus/tests/contest/conf/waivers for waiving
===============================================================
The following waivers are no longer valid, they either did not
match any test results or only matched the 'pass' test results:
===============================================================

/hardening/host-os/ansible/anssi_.+/timer_logrotate_enabled
/hardening/host-os/ansible/anssi_.+/timer_dnf-automatic_enabled
    True

/per-rule/.+/directory_permissions_var_log_audit/incorrect_value_0700.fail
/per-rule/.+/tftpd_uses_secure_mode/correct.pass
/per-rule/.+/dconf_gnome_lock_screen_on_smartcard_removal/wrong_value.fail
/per-rule/.+/tftpd_uses_secure_mode/wrong.fail
/per-rule/.+/file_ownership_var_log_audit_stig/correct_value_default_file.pass
/per-rule/.+/directory_permissions_var_log_audit/correct_value_0700.pass
    rhel == 9

/per-rule/.+/package_talk_removed/package-installed.fail
    rhel == 8

/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_rules.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_trunc.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_filter.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_arch.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_arch.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_last.pass
/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_filter.pass
    rhel == 10

/scanning/disa-alignment/.*/harden_sshd_ciphers_opensshserver_conf_crypto_policy
    rhel == 9

/scanning/disa-alignment/[^/]+/auditd_audispd_configure_sufficiently_large_partition
    True

/hardening/host-os/oscap/[^/]+/service_nftables_disabled
    True

/hardening/anaconda/with-gui/cis_workstation_l[12]
    status == 'error'

/hardening/image-builder/stig
    rhel == 9 and status == 'error'

/scanning/disa-alignment/.*/sysctl_kernel_core_pattern
    rhel == 8

/hardening/host-os/oscap/[^/]+/package_dnf-automatic_installed
/hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
/hardening/host-os/oscap/[^/]+/timer_dnf-automatic_enabled
    True

/hardening/host-os/.*/(ospp|cui)/timer_dnf-automatic_enabled
    rhel == 8 or rhel == 9

/scanning/oscap-eval/ERROR
    rhel == 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'

/static-checks/html-links/.+
    "failed: certificate has expired" in note

```