### PR TITLE
enable ruff in preview-checking mode

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -35,7 +35,7 @@ def excludes():
             'ensure_gpgcheck_repo_metadata',
         ]
         # Remove when CentOS repos use at least 3072b RSA key
-        if versions.rhel.major == 9 and re.fullmatch('/hardening/.+/ospp', test_name):
+        if versions.rhel.major == 9 and re.fullmatch(r'/hardening/.+/ospp', test_name):
             rules += [
                 'configure_crypto_policy',
                 'enable_fips_mode',

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -272,7 +272,7 @@ class Guest(virt.Guest):
                 sys.stdout.write(ret.stdout)
                 if ret.returncode == 0:
                     break
-                elif re.match('ERROR: Depsolve Error: Get "[^"]+": EOF\n', ret.stdout):
+                elif re.match(r'ERROR: Depsolve Error: Get "[^"]+": EOF\n', ret.stdout):
                     continue
                 else:
                     raise RuntimeError(f"depsolve:\n{ret.stdout}")
@@ -366,7 +366,7 @@ def translate_oscap_blueprint(lines, datastream):
     # however replace only the first occurence of 'name', as later sections
     # like [[packages]] would also match ^name=...
     bp_text = re.sub(
-        '^name = .*',
+        r'^name = .*',
         f'name = "{Blueprint.NAME}"',
         bp_text, count=1, flags=re.M,
     )

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -73,9 +73,12 @@ class Datastream:
         #   self.path = Path(file_the_datastream_was_parsed_from)
         def make_profile():
             return types.SimpleNamespace(title=None, rules=set(), values=set())
+
         self.profiles = collections.defaultdict(make_profile)
+
         def make_rule():
             return types.SimpleNamespace(fixes=self.FixType(0))
+
         self.rules = collections.defaultdict(make_rule)
         self._parse_datastream_xml(xml_file)
         self.path = Path(xml_file)
@@ -94,14 +97,14 @@ class Datastream:
             if frames[-1] == 'Profile':
                 profile = elements[-1].get('id')
                 # TODO: use str.removeprefix on python 3.9+
-                profile = re.sub('^xccdf_org.ssgproject.content_profile_', '', profile)
+                profile = re.sub(r'^xccdf_org.ssgproject.content_profile_', '', profile)
                 self.profiles[profile]  # let defaultdict fill in the values
 
             # profile contents
             elif frames[-2] == 'Profile':
                 profile = elements[-2].get('id')
                 # TODO: use str.removeprefix on python 3.9+
-                profile = re.sub('^xccdf_org.ssgproject.content_profile_', '', profile)
+                profile = re.sub(r'^xccdf_org.ssgproject.content_profile_', '', profile)
                 # title
                 if frames[-1] == 'title':
                     text = elements[-1].text
@@ -111,13 +114,13 @@ class Datastream:
                     if elements[-1].get('selected') == 'true':
                         rule = elements[-1].get('idref')
                         # TODO: use str.removeprefix on python 3.9+
-                        rule = re.sub('^xccdf_org.ssgproject.content_rule_', '', rule)
+                        rule = re.sub(r'^xccdf_org.ssgproject.content_rule_', '', rule)
                         self.profiles[profile].rules.add(rule)
                 # variable refinement
                 elif frames[-1] == 'refine-value':
                     name = elements[-1].get('idref')
                     # TODO: use str.removeprefix on python 3.9+
-                    name = re.sub('^xccdf_org.ssgproject.content_value_', '', name)
+                    name = re.sub(r'^xccdf_org.ssgproject.content_value_', '', name)
                     contents = elements[-1].get('selector')
                     self.profiles[profile].values.add((name, contents))
 
@@ -125,7 +128,7 @@ class Datastream:
             elif frames[-1] == 'Rule':
                 rule_id = elements[-1].get('id')
                 # TODO: use str.removeprefix on python 3.9+
-                rule_id = re.sub('^xccdf_org.ssgproject.content_rule_', '', rule_id)
+                rule_id = re.sub(r'^xccdf_org.ssgproject.content_rule_', '', rule_id)
                 self.rules[rule_id]  # let defaultdict fill in the values
 
             # fixes / remediations

--- a/lib/podman.py
+++ b/lib/podman.py
@@ -115,7 +115,7 @@ class Registry:
         """
         proc = podman('container', 'port', self.name, stdout=subprocess.PIPE)
         portmap = proc.stdout.rstrip('\n')
-        match = re.fullmatch('[0-9]+/tcp -> ([^:]+):([0-9]+)', portmap)
+        match = re.fullmatch(r'[0-9]+/tcp -> ([^:]+):([0-9]+)', portmap)
         if not match:
             raise RuntimeError(f"could not parse port mapping from: {portmap}")
         host, port = match.groups()

--- a/lib/util/old_content.py
+++ b/lib/util/old_content.py
@@ -51,7 +51,7 @@ def get_old_datastream():
     installed = _installed_ssg_version()
     ssg_datastream = util.get_datastream(force_ssg=True)
     if not ssg_datastream.exists():
-        raise RuntimeError("DS not found on {ssg_datastream}, no clue what to diff")
+        raise RuntimeError(f"DS not found on {ssg_datastream}, no clue what to diff")
 
     # "new" content is CONTEST_CONTENT,
     # "old" is the installed scap-security-guide RPM

--- a/lib/versions.py
+++ b/lib/versions.py
@@ -74,13 +74,16 @@ class _Rhel(_RpmVerCmp):
             self.major = int(v[0])
             self.minor = int(v[1])
 
-    def is_true_rhel(self):
+    @staticmethod
+    def is_true_rhel():
         return _os_release['ID'] == 'rhel'
 
-    def is_centos(self):
+    @staticmethod
+    def is_centos():
         return _os_release['ID'] == 'centos'
 
-    def __bool__(self):
+    @staticmethod
+    def __bool__():
         return _os_release['ID'] in ['rhel', 'centos']
 
 

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -38,7 +38,7 @@ def report_test_with_log(status, note, log_dir, rule_name, test_name):
         # rule_name-test_name.sh-initial.html -> initial.html
         # TODO: python 3.9+
         #basename = path.name.removeprefix(extras_prefix)
-        basename = re.sub(f'^{extras_prefix}', '', path.name, count=1)
+        basename = re.sub(fr'^{extras_prefix}', '', path.name, count=1)
         path.rename(path.parent / basename)
         path = path.parent / basename
 
@@ -139,7 +139,7 @@ with util.get_source_content() as content_dir, g.booted():
         sys.stdout.flush()
 
         # cut off log level
-        line = re.sub('^[A-Z]+ - ', '', line, count=1, flags=re.M)
+        line = re.sub(r'^[A-Z]+ - ', '', line, count=1, flags=re.M)
 
         # rule without remediation
         match = re.fullmatch(r'''No remediation is available for rule 'xccdf_org\.ssgproject\.content_rule_(.+)'\.''', line)  # noqa
@@ -150,7 +150,7 @@ with util.get_source_content() as content_dir, g.booted():
 
         # remember the log file for log parsing/upload
         #   INFO - Logging into /tmp/.../logs/rule-custom-2024-02-17-1859/test_suite.log
-        match = re.fullmatch('Logging into (.+)', line)
+        match = re.fullmatch(r'Logging into (.+)', line)
         if match:
             log_dir = Path(match.group(1)).parent
             util.log(f"using automatus log dir: {log_dir}")
@@ -173,7 +173,7 @@ with util.get_source_content() as content_dir, g.booted():
             test_name, profile, status = match.groups()
             # TODO: python 3.9+
             #profile = profile.removeprefix('xccdf_org.ssgproject.content_profile_')
-            profile = re.sub('^xccdf_org.ssgproject.content_profile_', '', profile, count=1)
+            profile = re.sub(r'^xccdf_org.ssgproject.content_profile_', '', profile, count=1)
 
             if status == 'OK':
                 status = 'pass'

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,7 @@ indent-width = 4
 target-version = "py37"  # doesn't support older
 
 [lint]
+preview = true
 select = [
     "F",    # Pyflakes
     "E",    # pycodestyle
@@ -33,6 +34,16 @@ ignore = [
     "PLW2901",  # redefined-loop-name
     "RUF010",   # explicit-f-string-type-conversion
     "RUF012",   # mutable-class-default
+
+    # rules from preview
+    "E226",     # missing-whitespace-around-arithmetic-operator
+    "E231",     # missing-whitespace
+    "E265",     # no-space-after-block-comment
+    "PLR0904",  # too-many-public-methods
+    "PLR0917",  # too-many-positional-arguments
+    "PLR6201",  # literal-membership
+    "PLW1514",  # unspecified-encoding
+    "PLW1641",  # eq-without-hash
 ]
 
 [format]

--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -18,6 +18,7 @@ profile = 'stig'
 
 shared_cmd = ['oscap', 'xccdf', 'eval', '--progress']
 
+
 class SSGRuleResult:
     def __init__(self, rule_id, cce_id, rule_title, stig_ids, result):
         self.rule_id = rule_id

--- a/scanning/oscap-eval/test.py
+++ b/scanning/oscap-eval/test.py
@@ -31,13 +31,13 @@ for line in lines:
 
     # random spurious ERRORs / WARNINGs
     elif line.startswith(('E: ', 'ERROR: ')):
-        line = re.sub(' +', ' ', line)
+        line = re.sub(r' +', ' ', line)
         if line not in problems_seen:
             results.report('fail', 'ERROR', line)
             problems_seen.add(line)
 
     elif line.startswith(('W: ', 'WARNING: ')):
-        line = re.sub(' +', ' ', line)
+        line = re.sub(r' +', ' ', line)
         if line not in problems_seen:
             results.report('warn', 'WARNING', line)
             problems_seen.add(line)

--- a/static-checks/diff/audit-sample-rules.py
+++ b/static-checks/diff/audit-sample-rules.py
@@ -18,9 +18,9 @@ def get_ds_remediations():
 
         group, rule, fix = elements[-3:]
         # TODO: use str.removeprefix on python 3.9+
-        group_name = re.sub('^xccdf_org.ssgproject.content_group_', '', group.get('id'))
+        group_name = re.sub(r'^xccdf_org.ssgproject.content_group_', '', group.get('id'))
         # TODO: use str.removeprefix on python 3.9+
-        rule_name = re.sub('^xccdf_org.ssgproject.content_rule_', '', rule.get('id'))
+        rule_name = re.sub(r'^xccdf_org.ssgproject.content_rule_', '', rule.get('id'))
 
         # only rules in the policy_rules group
         if group_name != 'policy_rules':

--- a/static-checks/rule-identifiers/test.py
+++ b/static-checks/rule-identifiers/test.py
@@ -37,7 +37,7 @@ for frames, elements in oscap.parse_xml(util.get_datastream()):
 
     rule, reference = elements[-2:]
     # TODO: use str.removeprefix on python 3.9+
-    rule = re.sub('^xccdf_org.ssgproject.content_rule_', '', rule.get('id'))
+    rule = re.sub(r'^xccdf_org.ssgproject.content_rule_', '', rule.get('id'))
     reference = reference.get('href')
     rule_references[rule].add(reference)
 


### PR DESCRIPTION
This returns some of the functionality we lost with flake8, like checking for proper line spacing between functions/classes.

This commit also adds some sensible ignores we have in flake8, which coincidentally also avoids checks with unstable behavior in preview mode.