### PR TITLE
Remove invalid waivers

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -21,13 +21,6 @@
 /hardening/ansible/with-gui/stig_gui/sysctl_net_ipv4_conf_all_forwarding
     rhel == 8
 
-# Ansible, on 9.0 / 9.2 / 9.6 / 8.10
-# https://github.com/ComplianceAsCode/content/issues/12831
-# https://github.com/ComplianceAsCode/content/issues/12870
-/hardening/host-os/ansible/anssi_.+/timer_dnf-automatic_enabled
-/hardening/host-os/ansible/anssi_.+/timer_logrotate_enabled
-    True
-
 # https://github.com/ComplianceAsCode/content/issues/10901
 # not sure what enables the service, but second remediation fixes the problem
 # TODO: we do run double remediation, but this still sometimes fails,
@@ -49,13 +42,6 @@
 /per-rule/.+/harden_sshd_ciphers_openssh_conf_crypto_policy/stig_correct_followed_by_incorrect_commented.pass
 /per-rule/.+/sudo_add_umask/0027_var_multiple_values.pass
     rhel == 8
-/per-rule/.+/directory_permissions_var_log_audit/correct_value_0700.pass
-/per-rule/.+/directory_permissions_var_log_audit/incorrect_value_0700.fail
-/per-rule/.+/dconf_gnome_lock_screen_on_smartcard_removal/wrong_value.fail
-/per-rule/.+/file_ownership_var_log_audit_stig/correct_value_default_file.pass
-/per-rule/.+/tftpd_uses_secure_mode/correct.pass
-/per-rule/.+/tftpd_uses_secure_mode/wrong.fail
-    rhel == 9
 # unit tests that try installing packages that don't even exist in the repos,
 # or messing with services of packages that are not installed
 /per-rule/.+/package_quagga_removed/package-installed.fail
@@ -63,8 +49,6 @@
 /per-rule/.+/package_rsh_removed/package-installed.fail
 /per-rule/.+/package_mcafeetp_installed/package-installed.pass
     True
-/per-rule/.+/package_talk_removed/package-installed.fail
-    rhel == 8
 /per-rule/.+/package_xinetd_removed/package-installed.fail
 /per-rule/.+/package_ypbind_removed/package-installed.fail
 /per-rule/.+/package_ypserv_removed/package-installed.fail
@@ -77,19 +61,6 @@
 /hardening/host-os/oscap/[^/]+/timer_.+_enabled
 /hardening/host-os/oscap/[^/]+/package_.+_installed
     True
-
-# RHEL-10 specific /per-rule issues
-#
-# audit rules, https://github.com/ComplianceAsCode/content/pull/12867
-# TODO: unfixed
-/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_arch.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_open_rule_order/ordered_filter.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_arch.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_rule_order/ordered_filter.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_last.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_rules.pass
-/per-rule/.+/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/o_trunc.pass
-    rhel == 10
 
 # DISA Alignment waivers
 #
@@ -107,9 +78,6 @@
 /scanning/disa-alignment/.*/grub2_audit_argument
 /scanning/disa-alignment/.*/grub2_audit_backlog_limit_argument
     rhel == 8
-# https://github.com/ComplianceAsCode/content/issues/12149
-/scanning/disa-alignment/.*/harden_sshd_ciphers_opensshserver_conf_crypto_policy
-    rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/11804
 /scanning/disa-alignment/.*/harden_sshd_ciphers_openssh_conf_crypto_policy
 # https://github.com/ComplianceAsCode/content/issues/11692
@@ -127,9 +95,6 @@
 # https://github.com/ComplianceAsCode/content/issues/11693
 /scanning/disa-alignment/(oscap|ansible)/accounts_password_pam_retry
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/11802
-/scanning/disa-alignment/[^/]+/auditd_audispd_configure_sufficiently_large_partition
-    True
 
 # https://github.com/ComplianceAsCode/content/issues/13100
 /hardening/.*/file_permission_user_init_files_root

--- a/conf/waivers/20-long-term
+++ b/conf/waivers/20-long-term
@@ -36,13 +36,6 @@
 /hardening/[^/]+/with-gui/[^/]+/sysctl_net_ipv4_ip_forward
     rhel == 8
 
-# https://github.com/ComplianceAsCode/content/issues/10424
-# happens on host-os hardening too, probably because Beaker doesn't have
-# firewall enabled or even installed
-# TODO: unfixed
-/hardening/host-os/oscap/[^/]+/service_nftables_disabled
-    True
-
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
 # https://issues.redhat.com/browse/RHEL-45706
@@ -98,15 +91,9 @@
 # https://issues.redhat.com/browse/RHEL-25574
 /hardening/image-builder/ccn_[^/]+
     rhel == 9 and status == 'error'
-# https://github.com/ComplianceAsCode/content/issues/12968
-/hardening/image-builder/stig
-    rhel == 9 and status == 'error'
 
 # DISA Alignment waivers
 #
-# https://github.com/ComplianceAsCode/content/issues/9308 (DISA issue)
-/scanning/disa-alignment/.*/sysctl_kernel_core_pattern
-    rhel == 8
 # https://github.com/ComplianceAsCode/content/issues/9307 (DISA issue)
 /scanning/disa-alignment/.*/sysctl_kernel_yama_ptrace_scope
 # https://github.com/ComplianceAsCode/content/issues/10044 (DISA issue)

--- a/conf/waivers/30-permanent
+++ b/conf/waivers/30-permanent
@@ -36,22 +36,6 @@
 /hardening/host-os/.+/mount_option_boot_efi_nosuid
     True
 
-# Beaker-specific, possibly;
-# same for dnf-automatic and rsyslog (??), is this fully random?
-/hardening/host-os/oscap/[^/]+/package_dnf-automatic_installed
-/hardening/host-os/oscap/[^/]+/timer_dnf-automatic_enabled
-/hardening/host-os/oscap/[^/]+/package_rsyslog-gnutls_installed
-    True
-
-# https://github.com/ComplianceAsCode/content/issues/12119
-# https://github.com/ComplianceAsCode/content/issues/12234
-/hardening/host-os/.*/(ospp|cui)/timer_dnf-automatic_enabled
-    rhel == 8 or rhel == 9
-
-# https://bugzilla.redhat.com/show_bug.cgi?id=1797653 WONTFIX
-/scanning/oscap-eval/ERROR
-    rhel == 8 and note == 'E: oscap: Failed to convert OVAL state to SEXP, id: oval:ssg-state_file_groupowner_var_log_syslog_gid_4_0:ste:1.'
-
 # HTML links from datastreams waivers
 #
 # ignore SSL certificate expirations in html-links - these are generally

--- a/scripts/find_invalid_waivers.py
+++ b/scripts/find_invalid_waivers.py
@@ -92,8 +92,8 @@ def match_result_mark_waiver(regexes_matched_list, version, arch, status, name, 
                     raise RuntimeError(f"waiver python code did not return bool or Match: {ret}")
                 ret = waive.Match(ret)
 
-            if ret and status != 'pass':
-                # both regex and python code matched and the test result is not 'pass'
+            if ret:
+                # both regex and python code matched
                 if section.regexes not in regexes_matched_list:
                     regexes_matched_list.append(section.regexes)
 
@@ -106,7 +106,9 @@ def load_and_process_results(file, regexes_matched_list):
 
             if version == 'rhel':  # skip the header
                 continue
-            if status not in ['pass', 'fail', 'error', 'warn']:
+            # do not consider 'pass' test results, even if waivers would match them
+            # we still want to remove such waivers
+            if status not in ['fail', 'error', 'warn']:
                 continue
 
             match_result_mark_waiver(regexes_matched_list, version, arch, status, name, note)


### PR DESCRIPTION
The invalid waivers were detected using the `scripts/find_invalid_waivers.py`
and the latest test results from CaC/content stabilization of `v0.1.76`.

Note: I am keeping the following 3 waivers identified by the script:
```
/hardening/.*/file_permission_user_init_files_root
    True

/hardening/anaconda/with-gui/cis_workstation_l[12]
    status == 'error'

/static-checks/html-links/.+
    "failed: certificate has expired" in note
```
because:
* `/hardening/.*/file_permission_user_init_files_root` is a new issue https://github.com/ComplianceAsCode/content/issues/13100
* `/hardening/anaconda/with-gui/cis_workstation_l[12]` seems to occur only in rare cases per https://issues.redhat.com/browse/OPENSCAP-3321
* `/static-checks/html-links/.+` is a permanent waiver which should catch flukes when certificates of websites we link to in our content expire

In the future iteration of the script we might consider adding some waiver ignore list where we can list waivers which we want to keep even if they don't match any test results.