### PR TITLE
Add disa-alignment waiver for auditd_audispd_configure_sufficiently_large_partition

### DIFF
--- a/conf/waivers/10-unknown
+++ b/conf/waivers/10-unknown
@@ -94,6 +94,8 @@
 /scanning/disa-alignment/.*/sshd_set_keepalive
 # https://github.com/ComplianceAsCode/content/issues/11693
 /scanning/disa-alignment/(oscap|ansible)/accounts_password_pam_retry
+# https://github.com/ComplianceAsCode/content/issues/11802
+/scanning/disa-alignment/[^/]+/auditd_audispd_configure_sufficiently_large_partition
     rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/13108
 /scanning/disa-alignment/.*/configure_crypto_policy


### PR DESCRIPTION
The waiver has been removed in https://github.com/RHSecurityCompliance/contest/pull/350 because it was not failing in stabilization of `v0.1.76` but the fail appeared again in productization results from the `master` branch.

Also re-opening https://github.com/ComplianceAsCode/content/issues/11802