### PR TITLE
Disable `/static-checks/rpmbuild-ctest` in 8.8 OSCI

### DIFF
--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -26,3 +26,6 @@ adjust:
   - when: newa_batch is defined and arch == s390x or newa_batch is defined and arch == ppc64le
     enabled: false
     because: srpm repo is not available, see https://issues.redhat.com/browse/TFT-2972
+  - when: trigger == build and distro == rhel-8.8
+    enabled: false
+    because: python3-pip fails to install in OSCI due to testing-farm-tag repo


### PR DESCRIPTION
Something there installs broken python3-pip from a (disabled at test runtime) testing-farm-tag repository.

```
  Problem: package python3-pip-9.0.3-22.3.el8_8.noarch requires platform-python-pip = 9.0.3-22.3.el8_8, but none of the providers can be installed
   - package platform-python-pip-9.0.3-22.3.el8_8.noarch requires platform-python >= 3.6.8-51.el8_8.5, but none of the providers can be installed
   - platform-python-3.6.8-51.el8_8.7.i686 has inferior architecture
   - cannot install both platform-python-3.6.8-51.el8.x86_64 and platform-python-3.6.8-51.el8_8.7.x86_64
   - cannot install both platform-python-3.6.8-51.el8_8.7.x86_64 and platform-python-3.6.8-51.el8.x86_64
   - package python3-devel-3.6.8-51.el8.x86_64 requires platform-python = 3.6.8-51.el8, but none of the providers can be installed
   - cannot install the best candidate for the job
```

We could re-enable the repository, but that would probably bring its own set of side-effects.

Given that it seems to impact only RHEL-8.8, it might be better to just disable the test.