### PR TITLE
OPENSCAP-5453 - Enable UEFI tests on RHEL-10+

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -139,7 +139,7 @@
 
 # kdump being forcibly enabled somewhere
 # https://github.com/ComplianceAsCode/content/issues/12832
-/hardening/kickstart(/with-gui)?/(hipaa|stig|stig_gui)/service_kdump_disabled
+/hardening/kickstart(/with-gui|/uefi)?/(hipaa|stig|stig_gui)/service_kdump_disabled
     rhel == 10
 
 # caused by one of:

--- a/hardening/ansible/uefi.fmf
+++ b/hardening/ansible/uefi.fmf
@@ -32,6 +32,8 @@ adjust+:
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -42,8 +44,12 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -52,6 +58,8 @@ adjust+:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/ansible/uefi.fmf
+++ b/hardening/ansible/uefi.fmf
@@ -1,5 +1,9 @@
-tag+:
-  - broken
+adjust+:
+  - when: distro < rhel-10
+    enabled: false
+    because: >
+        we don't have capacity to test this everywhere, but RHEL-10 is UEFI
+        by default, so run it at least there
 
 /anssi_bp28_high:
 

--- a/hardening/image-builder/uefi.fmf
+++ b/hardening/image-builder/uefi.fmf
@@ -1,5 +1,9 @@
-tag+:
-  - broken
+adjust+:
+  - when: distro < rhel-10
+    enabled: false
+    because: >
+        we don't have capacity to test this everywhere, but RHEL-10 is UEFI
+        by default, so run it at least there
 
 /anssi_bp28_high:
 

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -27,9 +27,7 @@ adjust:
     because: we want to run virtualization on x86_64 only
   - when: distro < rhel-10
     enabled: false
-    because: >
-        too late in the RHEL-8 lifecycle for this,
-        TODO enable this on RHEL-9 once OpenSCAP v1.4 is there
+    because: on RHEL <= 9 oscap-anaconda-addon is used instead
 
 /anssi_bp28_high:
 
@@ -61,8 +59,7 @@ adjust:
     environment+:
         WITH_FIPS: 1
     adjust+:
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
@@ -77,8 +74,7 @@ adjust:
     environment+:
         WITH_FIPS: 1
     adjust+:
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no OSPP profile on RHEL-10+
 
 /pci-dss:
@@ -90,26 +86,26 @@ adjust:
 /stig_gui:
     adjust+:
       - enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: only supported with GUI installations
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -29,8 +29,7 @@ tag+:
 
 /cui:
     adjust+:
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
@@ -41,8 +40,7 @@ tag+:
 
 /ospp:
     adjust+:
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no OSPP profile on RHEL-10+
 
 /pci-dss:
@@ -52,26 +50,26 @@ tag+:
 /stig_gui:
     adjust+:
       - enabled: false
-        because: CCN profiles are not present on RHEL-8
+        because: only supported with GUI installations
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -32,6 +32,8 @@ adjust+:
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - enabled: false
         because: there is no CUI profile on RHEL-10+
@@ -41,8 +43,12 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - enabled: false
         because: there is no OSPP profile on RHEL-10+
@@ -50,6 +56,8 @@ adjust+:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -1,5 +1,9 @@
-tag+:
-  - broken
+adjust+:
+  - when: distro < rhel-10
+    enabled: false
+    because: >
+        we don't have capacity to test this everywhere, but RHEL-10 is UEFI
+        by default, so run it at least there
 
 /anssi_bp28_high:
 

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -40,13 +40,7 @@ duration: 2h
     environment+:
         WITH_FIPS: 1
     adjust+:
-      - when: distro == rhel-8
-        enabled: false
-        because: >
-            not supported on RHEL-8 according to RHEL documentation,
-            the "Profiles not compatible with Server with GUI" table
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no CUI profile on RHEL-10+
 
 /e8:
@@ -61,13 +55,7 @@ duration: 2h
     environment+:
         WITH_FIPS: 1
     adjust+:
-      - when: distro == rhel-8
-        enabled: false
-        because: >
-            not supported on RHEL-8 according to RHEL documentation,
-            the "Profiles not compatible with Server with GUI" table
-      - when: distro >= rhel-10
-        enabled: false
+      - enabled: false
         because: there is no OSPP profile on RHEL-10+
 
 /pci-dss:
@@ -77,8 +65,6 @@ duration: 2h
       - enabled: false
         because: >
             not supported with GUI, use stig_gui instead;
-            not supported on RHEL-8 or RHEL-9 according to RHEL documentation,
-            the "Profiles not compatible with Server with GUI" table
 
 /stig_gui:
     environment+:
@@ -86,22 +72,22 @@ duration: 2h
 
 /ccn_advanced:
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_intermediate:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10
 
 /ccn_basic:
     tag+:
       - subset-profile
     adjust+:
-      - when: distro == rhel-8 or distro == rhel-10
+      - when: distro == rhel-10
         enabled: false
-        because: CCN profiles are not present on RHEL-8 and on RHEL-10
+        because: CCN profiles are not present on RHEL-10

--- a/hardening/oscap/uefi.fmf
+++ b/hardening/oscap/uefi.fmf
@@ -32,6 +32,8 @@ adjust+:
       - subset-profile
 
 /cui:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -42,8 +44,12 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    environment+:
+        WITH_FIPS: 1
 
 /ospp:
+    environment+:
+        WITH_FIPS: 1
     adjust+:
       - when: distro >= rhel-10
         enabled: false
@@ -52,6 +58,8 @@ adjust+:
 /pci-dss:
 
 /stig:
+    environment+:
+        WITH_FIPS: 1
 
 /stig_gui:
     adjust+:

--- a/hardening/oscap/uefi.fmf
+++ b/hardening/oscap/uefi.fmf
@@ -1,5 +1,9 @@
-tag+:
-  - broken
+adjust+:
+  - when: distro < rhel-10
+    enabled: false
+    because: >
+        we don't have capacity to test this everywhere, but RHEL-10 is UEFI
+        by default, so run it at least there
 
 /anssi_bp28_high:
 

--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -8,12 +8,14 @@ discover:
       - tag:-subset-profile
     test:
       # every remediation method, but only the basic reference environment,
-      # without GUI/UEFI/etc. variants
+      # without GUI variants
       - /hardening/oscap/[^/]+$
       - /hardening/anaconda/[^/]+$
       - /hardening/kickstart/[^/]+$
       - /hardening/ansible/[^/]+$
       - /hardening/image-builder/[^/]+$
+      # UEFI tests, due to capacity we run them only on RHEL-10
+      - /hardening/[^/]+/uefi
       # add stig_gui as an exception here, since it needs to be tested somehow
       # but the only way to do it is via GUI
       - /hardening/oscap/with-gui/stig_gui


### PR DESCRIPTION
```
$ tmt --quiet -c distro=rhel-9.6 -c arch=x86_64 run plans -n /plans/default discover -h fmf --fmf-id -t "/hardening/.*"  | grep name: | grep uefi
$ tmt --quiet -c distro=rhel-10.0 -c arch=x86_64 run plans -n /plans/default discover -h fmf --fmf-id -t "/hardening/.*"  | grep name: | grep uefi
name: /hardening/ansible/uefi/anssi_bp28_enhanced
name: /hardening/ansible/uefi/anssi_bp28_high
name: /hardening/ansible/uefi/anssi_bp28_intermediary
name: /hardening/ansible/uefi/anssi_bp28_minimal
name: /hardening/ansible/uefi/cis
name: /hardening/ansible/uefi/cis_server_l1
name: /hardening/ansible/uefi/cis_workstation_l1
name: /hardening/ansible/uefi/cis_workstation_l2
name: /hardening/ansible/uefi/e8
name: /hardening/ansible/uefi/hipaa
name: /hardening/ansible/uefi/ism_o
name: /hardening/ansible/uefi/pci-dss
name: /hardening/ansible/uefi/stig
name: /hardening/image-builder/uefi/anssi_bp28_enhanced
name: /hardening/image-builder/uefi/anssi_bp28_high
name: /hardening/image-builder/uefi/anssi_bp28_intermediary
name: /hardening/image-builder/uefi/anssi_bp28_minimal
name: /hardening/image-builder/uefi/cis
name: /hardening/image-builder/uefi/cis_server_l1
name: /hardening/image-builder/uefi/cis_workstation_l1
name: /hardening/image-builder/uefi/cis_workstation_l2
name: /hardening/image-builder/uefi/e8
name: /hardening/image-builder/uefi/hipaa
name: /hardening/image-builder/uefi/ism_o
name: /hardening/image-builder/uefi/pci-dss
name: /hardening/image-builder/uefi/stig
name: /hardening/kickstart/uefi/anssi_bp28_enhanced
name: /hardening/kickstart/uefi/anssi_bp28_high
name: /hardening/kickstart/uefi/anssi_bp28_intermediary
name: /hardening/kickstart/uefi/anssi_bp28_minimal
name: /hardening/kickstart/uefi/cis
name: /hardening/kickstart/uefi/cis_server_l1
name: /hardening/kickstart/uefi/cis_workstation_l1
name: /hardening/kickstart/uefi/cis_workstation_l2
name: /hardening/kickstart/uefi/e8
name: /hardening/kickstart/uefi/hipaa
name: /hardening/kickstart/uefi/ism_o
name: /hardening/kickstart/uefi/pci-dss
name: /hardening/kickstart/uefi/stig
name: /hardening/oscap/uefi/anssi_bp28_enhanced
name: /hardening/oscap/uefi/anssi_bp28_high
name: /hardening/oscap/uefi/anssi_bp28_intermediary
name: /hardening/oscap/uefi/anssi_bp28_minimal
name: /hardening/oscap/uefi/cis
name: /hardening/oscap/uefi/cis_server_l1
name: /hardening/oscap/uefi/cis_workstation_l1
name: /hardening/oscap/uefi/cis_workstation_l2
name: /hardening/oscap/uefi/e8
name: /hardening/oscap/uefi/hipaa
name: /hardening/oscap/uefi/ism_o
name: /hardening/oscap/uefi/pci-dss
name: /hardening/oscap/uefi/stig
```

Note: There is one more commit which updates fmf metadata for `/hardening/kickstart` test because it is supposed to be RHEL-10+ only test.