### PR TITLE
modify waivers related to Imagebuilder rules

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -75,6 +75,9 @@
 # https://github.com/ComplianceAsCode/content/pull/12755.
 /hardening/container/.+/file_groupownership_sshd_private_key
 /hardening/container/.+/file_permissions_sshd_private_key
+# There is no mounted /tmp directory when hardening the system during osbuild image creation.
+# Therefore, the rule cannot be remediated.
+/hardening/image-builder(/.+)?/anssi_[^/]+/mount_option_tmp_noexec
     True
 
 # vim: syntax=python

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -200,10 +200,6 @@
 # https://github.com/ComplianceAsCode/content/issues/11567
 /hardening/image-builder/.*/enable_dracut_fips_module
 /hardening/image-builder/.*/enable_fips_mode
-# https://github.com/ComplianceAsCode/content/issues/13127
-/hardening/image-builder(/.+)?/anssi_[^/]+/mount_option_tmp_noexec
-/hardening/image-builder(/.+)?/anssi_[^/]+/sebool_polyinstantiation_enabled
-/hardening/image-builder(/.+)?/hipaa/sebool_selinuxuser_execmod
     True
 # OpenSCAP unsupported profile: xccdf_org.ssgproject.content_profile_ccn_advanced
 # https://issues.redhat.com/browse/RHEL-25574


### PR DESCRIPTION
Relevant issue: https://github.com/ComplianceAsCode/content/issues/13127

Sebool rules were fixed in https://github.com/ComplianceAsCode/content/pull/13173 The rule mount_option_tmp_noexec is correctly not applicable in osbuild environment because there seems to be no relevant /tmp partition.