### PR TITLE
Rewrite `/per-rule` to use pre-built tests

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -80,4 +80,15 @@
 /hardening/image-builder(/.+)?/anssi_[^/]+/mount_option_tmp_noexec
     True
 
+# these tests modify /etc/bashrc to set PATH, but our current /per-rule test
+# implementation doesn't re-execute the shell runner before executing 'oscap'
+# (doing so would incur a performance penalty for all tests), so the 'oscap'
+# inherits an outdated PATH, making the scan fail
+/per-rule/oscap/.+/root_path_no_dot/absolute_path.fail
+/per-rule/oscap/.+/root_path_no_dot/colon_on_path.fail
+/per-rule/oscap/.+/root_path_no_dot/doublecolon_on_path.fail
+/per-rule/oscap/.+/root_path_no_dot/doubleperiod_on_path.fail
+/per-rule/oscap/.+/root_path_no_dot/period_on_path.fail
+    True
+
 # vim: syntax=python

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -20,26 +20,6 @@
 /hardening/oscap/old-new/.*/enable_fips_mode
     rhel == 8 or rhel == 9
 
-# https://github.com/ComplianceAsCode/content/issues/13126
-/per-rule/.+/accounts_password_set_max_life_root/correct.pass
-/per-rule/.+/accounts_password_set_max_life_root/wrong.fail
-/per-rule/.+/postfix_client_configure_mail_alias/correct.pass
-/per-rule/.+/package_quagga_removed/package-installed.fail
-/per-rule/.+/package_rsh-server_removed/package-installed.fail
-/per-rule/.+/package_rsh_removed/package-installed.fail
-/per-rule/.+/package_mcafeetp_installed/package-installed.pass
-    True
-/per-rule/.+/grub2_audit_backlog_limit_argument/correct_grubenv.pass
-/per-rule/.+/grub2_password/invalid_username.fail
-/per-rule/.+/harden_sshd_ciphers_openssh_conf_crypto_policy/stig_correct.pass
-/per-rule/.+/harden_sshd_ciphers_openssh_conf_crypto_policy/stig_correct_followed_by_incorrect_commented.pass
-/per-rule/.+/sudo_add_umask/0027_var_multiple_values.pass
-    rhel == 8
-/per-rule/.+/package_xinetd_removed/package-installed.fail
-/per-rule/.+/package_ypbind_removed/package-installed.fail
-/per-rule/.+/package_ypserv_removed/package-installed.fail
-/per-rule/.+/service_telnet_disabled/service_disabled.pass
-    rhel == 9
 
 # https://github.com/ComplianceAsCode/content/issues/12561
 /scanning/disa-alignment/.*/logind_session_timeout

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -11,8 +11,7 @@ test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ..
-    TOTAL_SLICES: 15
-duration: 3h
+duration: 2h
 require+:
   # virt library dependencies
   - libvirt-daemon
@@ -25,13 +24,6 @@ require+:
   - virt-install
   - rpm-build
   - createrepo
-  # automatus dependencies (oscap-ssh, etc.)
-  - openscap-utils
-  # for ansible variant
-  - ansible-core
-recommend+:
-  # needed for the ini_file ansible plugin, and more
-  - rhc-worker-playbook
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=6000
@@ -39,70 +31,37 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
+  - when: distro == rhel-9.0
+    enabled: false
+    because: xmlstarlet not available on 9.0
 
-# for use with the RULE environment variable
-/from-env:
-    tag:
-      - needs-param
-    /oscap:
-    /ansible:
+/oscap:
+    environment+:
+        TOTAL_SLICES: 5
+    /1:
+    /2:
+    /3:
+    /4:
+    /5:
+    # for use with the RULE environment variable
+    /from-env:
+        tag+:
+          - needs-param
 
-/1:
-    /oscap:
-    /ansible:
-
-/2:
-    /oscap:
-    /ansible:
-
-/3:
-    /oscap:
-    /ansible:
-
-/4:
-    /oscap:
-    /ansible:
-
-/5:
-    /oscap:
-    /ansible:
-
-/6:
-    /oscap:
-    /ansible:
-
-/7:
-    /oscap:
-    /ansible:
-
-/8:
-    /oscap:
-    /ansible:
-
-/9:
-    /oscap:
-    /ansible:
-
-/10:
-    /oscap:
-    /ansible:
-
-/11:
-    /oscap:
-    /ansible:
-
-/12:
-    /oscap:
-    /ansible:
-
-/13:
-    /oscap:
-    /ansible:
-
-/14:
-    /oscap:
-    /ansible:
-
-/15:
-    /oscap:
-    /ansible:
+/ansible:
+    environment+:
+        TOTAL_SLICES: 10
+    /1:
+    /2:
+    /3:
+    /4:
+    /5:
+    /6:
+    /7:
+    /8:
+    /9:
+    /10:
+    # for use with the RULE environment variable
+    /from-env:
+        tag+:
+          - needs-param

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+# log everything (stdout + stderr + bash trace) to runner.log
+# but keep original stdout and collect it from parent test.py as 'note'
+exec 0</dev/null {orig_stdout}>&1 2>runner.log 1>&2
+
+# Exit codes of this script mimic oscap:
+#   0 = executing the test script + oscap was according to expectations
+#   1 = unknown error occurred
+#   2 = test found a potential bug (controlled fail)
+function exit_pass { [[ $# -gt 0 ]] && echo -e "$1" >&$orig_stdout; exit 0; }
+function exit_err  { [[ $# -gt 0 ]] && echo -e "$1" >&$orig_stdout; exit 1; }
+function exit_fail { [[ $# -gt 0 ]] && echo -e "$1" >&$orig_stdout; exit 2; }
+function exit_skip { [[ $# -gt 0 ]] && echo -e "$1" >&$orig_stdout; exit 3; }
+
+set -x -e
+
+tests_dir=tests
+tests_shared=$tests_dir/shared
+variables_dir=variables
+playbooks_dir=playbooks
+thin_ds_dir=thin_ds
+
+rule=$1             # some_rule_name
+test_name=$2        # some_test_name
+test_type=$3        # pass or fail
+remediation=$4      # oscap or ansible or none
+debug_arg=$5        # debug or nodebug
+
+function debug { [[ $debug_arg == debug ]]; }
+
+datastream=$thin_ds_dir/$rule.xml
+playbook=$playbooks_dir/$rule.yml
+variables_file=$variables_dir/$rule/$test_name.$test_type
+
+# if variables were given, modify datastream/playbook
+if [[ -f $variables_file ]]; then
+    while IFS='=' read -r key value; do
+        # tests may specify variable values either as datastream "selectors"
+        # or as raw values - list selector names and check whether the value
+        # is amongst them and if so, resolve it
+        #
+        # we do this loop + retrieval instead of straight retrieval because
+        # values can be super crazy and contain quotes, which break @id='...'
+        # quote syntax, so we rely on selectors having sensible non-crazy names
+        # and when the value == selector, we can probably safely use it inside
+        # the @id='...' string
+        xccdf_key=xccdf_org.ssgproject.content_value_$key
+        # (read with empty -d exits with 1 on EOF, hence the 'true')
+        IFS=$'\n' read -r -d '' -a selectors < <(
+            xmlstarlet select \
+                -t -v "//xccdf-1.2:Value[@id='$xccdf_key']/xccdf-1.2:value/@selector" -n \
+                "$datastream"
+        ) || true
+        for selector in "${selectors[@]}"; do
+            if [[ $value == $selector ]]; then
+                value=$(
+                    xmlstarlet select \
+                    -t -v "//xccdf-1.2:Value[@id='$xccdf_key']/xccdf-1.2:value[@selector='$value']" \
+                    -n "$datastream"
+                )
+                break
+            fi
+        done
+
+        # we need to always change the datastream, even for ansible
+        # (because it's used for scanning)
+        #
+        # <xccdf-1.2:Value id="xccdf_org.ssgproject.content_value_var_something" type="number">
+        #  <xccdf-1.2:title>Some title</xccdf-1.2:title>
+        #  <xccdf-1.2:description>Some description</xccdf-1.2:description>
+        #  <xccdf-1.2:value selector="100MB">100</xccdf-1.2:value>
+        #  <xccdf-1.2:value selector="250MB">250</xccdf-1.2:value>
+        #  <xccdf-1.2:value selector="500MB">500</xccdf-1.2:value>
+        #  <xccdf-1.2:value>100</xccdf-1.2:value>                     <-- we're changing this
+        # </xccdf-1.2:Value>
+        xmlstarlet edit \
+            --inplace \
+            --update "//xccdf-1.2:Value[@id='$xccdf_key']/xccdf-1.2:value[not(@selector)]" \
+            --value "$value" \
+            "$datastream"
+
+        if [[ $remediation == ansible ]]; then
+            # - name: Some title
+            #   vars:
+            #     var_something: '100'
+            # use awk instead of sed because key/values may contain quotes
+            # and awk allows us to work around that by passing variables via CLI options
+            awk -i inplace -v key="$key" -v value="$value" \
+                "{ print gensub(\"^([[:space:]]+)\"key\":.*\", \"\\\1\"key\": '\"value\"'\", 1) }" \
+                "$playbook"
+        fi
+    done < "$variables_file"
+fi
+
+if debug; then
+    ln "$datastream" ds.xml
+    [[ $remediation == ansible ]] && ln "$playbook" playbook.yml
+fi
+
+rule_full=xccdf_org.ssgproject.content_rule_$rule
+
+# do a scan prior to running the test script
+if debug; then
+    rc=0
+    out=$(
+        oscap xccdf eval --profile '(all)' --rule "$rule_full" --progress \
+        --report initial-report.html --results-arf initial-results-arf.xml \
+        "$datastream"
+    ) || rc=$?
+    if [[ $rc != 0 && $rc != 2 ]]; then
+        exit_err "oscap exited unexpectedly with $rc"
+    fi
+fi
+
+# run test script
+test_cwd=$tests_dir/$rule
+test_file=$test_name.$test_type.sh
+rc=0
+(
+    # we need to call $SHELL because some tests don't start with shebang
+    export SHARED=$(realpath "$tests_shared") && \
+    cd "$test_cwd" && \
+    exec "$SHELL" -x "$test_file"
+) &> test.log || rc=$?
+if [[ $rc != 0 ]]; then
+    exit_err "test script failed with $rc"
+fi
+debug && cp --reflink=always "$test_cwd/$test_file" "test.$test_type.sh"
+
+# reminder:
+#   'something.pass.sh' = test prepares OS, oscap scan should pass
+#   'something.fail.sh' = test breaks OS, oscap should remediate + pass
+#   'something.fail.sh' with remediation=none = test breaks OS, oscap should fail
+
+if debug; then
+    oscap_reports=(--report report.html --results-arf results-arf.xml)
+else
+    oscap_report=()
+fi
+
+# just do an oscap scan, expect it to pass
+if [[ $test_type == pass ]]; then
+    rc=0
+    out=$(
+        oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+        --progress "${oscap_reports[@]}" "$datastream"
+    ) || rc=$?
+    if [[ $rc != 0 && $rc != 2 ]]; then
+        exit_err "oscap exited unexpectedly with $rc"
+    fi
+
+    IFS=: read -r oscap_rule oscap_status <<<"$out"
+    if [[ $oscap_rule != $rule_full ]]; then
+        exit_err "oscap returned malformed output:\n$out"
+    elif [[ $oscap_status == notapplicable ]]; then
+        exit_skip
+    elif [[ $oscap_status != pass ]]; then
+        exit_fail "oscap scan returned $oscap_status, expected 'pass'"
+    fi
+
+    exit_pass
+
+elif [[ $test_type == fail ]]; then
+    # just do an oscap scan, expect it to fail
+    if [[ $remediation == none ]]; then
+        rc=0
+        out=$(
+            oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+            --progress "${oscap_reports[@]}" "$datastream"
+        ) || rc=$?
+
+        if [[ $rc != 0 && $rc != 2 ]]; then
+            exit_err "oscap exited unexpectedly with $rc"
+        fi
+
+        IFS=: read -r oscap_rule oscap_status <<<"$out"
+        if [[ $oscap_rule != $rule_full ]]; then
+            exit_err "oscap returned malformed output:\n$out"
+        elif [[ $oscap_status == notapplicable ]]; then
+            exit_skip
+        elif [[ $oscap_status != fail ]]; then
+            exit_fail "oscap scan returned $oscap_status, expected 'fail'"
+        fi
+
+        exit_pass
+
+    # remediate+scap using oscap, expect it to pass
+    elif [[ $remediation == oscap ]]; then
+        rc=0
+        out=$(
+            oscap xccdf eval --profile '(all)' --rule "$rule_full" --remediate \
+            --progress "${oscap_reports[@]}" "$datastream"
+        ) || rc=$?
+
+        if [[ $rc != 0 && $rc != 2 ]]; then
+            exit_err "oscap exited unexpectedly with $rc"
+        fi
+
+        # read all oscap output, as lines, into bash array
+        # (read with empty -d exits with 1 on EOF, hence the 'true')
+        IFS=$'\n' read -r -d '' -a lines <<<"$out" || true
+        if [[ ${#lines[@]} -eq 0 ]]; then
+            exit_err "oscap returned malformed output:\n$out"
+        fi
+
+        # first line: fail
+        IFS=: read -r oscap_rule oscap_status <<<"${lines[0]}"
+        if [[ $oscap_rule != $rule_full ]]; then
+            exit_err "oscap returned malformed output on first line:\n$out"
+        elif [[ $oscap_status == notapplicable ]]; then
+            exit_skip
+        elif [[ $oscap_status != fail ]]; then
+            exit_fail "oscap initial scan returned $oscap_status, expected 'fail'"
+        fi
+
+        if [[ ${#lines[@]} -ne 2 ]]; then
+            exit_err "oscap did not output 2 lines (fail+fixed):\n$out"
+        fi
+
+        # second line: fixed
+        IFS=: read -r oscap_rule oscap_status <<<"${lines[1]}"
+        if [[ $oscap_rule != $rule_full ]]; then
+            exit_err "oscap returned malformed output on second line:\n$out"
+        elif [[ $oscap_status != fixed ]]; then
+            exit_fail "oscap fixing returned $oscap_status, expected 'fixed'"
+        fi
+
+        exit_pass
+
+    # remediate via ansible-playbook + scan via oscap, expect it to pass
+    elif [[ $remediation == ansible ]]; then
+        rc=0
+        out=$(
+            ansible-playbook -v -c local -i 127.0.0.1, "$playbook"
+        ) || rc=$?
+
+        if [[ $rc != 0 ]]; then
+            exit_err "ansible-playbook exited unexpectedly with $rc"
+        fi
+
+        rc=0
+        out=$(
+            oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+            --progress "${oscap_reports[@]}" "$datastream"
+        ) || rc=$?
+
+        if [[ $rc != 0 && $rc != 2 ]]; then
+            exit_err "oscap exited unexpectedly with $rc"
+        fi
+
+        IFS=: read -r oscap_rule oscap_status <<<"$out"
+        if [[ $oscap_rule != $rule_full ]]; then
+            exit_err "oscap returned malformed output:\n$out"
+        elif [[ $oscap_status == notapplicable ]]; then
+            exit_skip
+        elif [[ $oscap_status != pass ]]; then
+            exit_fail "oscap scan returned $oscap_status, expected 'pass'"
+        fi
+
+        exit_pass
+
+    else
+        exit_err "unknown remediation type: $remediation"
+    fi
+else
+    exit_err "wrong test_type: $test_type"
+fi
+
+exit_err "reached the end of runner (bug)"

--- a/per-rule/setup.sh
+++ b/per-rule/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+thin_ds_dir=thin_ds
+playbooks_dir=playbooks
+tests_dir=tests
+
+# strip-off the leading product prefix from all 'thin_ds' datastreams
+# to make accessing thme easier/faster for the runner
+rhel_major=$(. /etc/os-release && echo ${VERSION_ID%%.*})
+ssg_ds_prefix="ssg-rhel${rhel_major}-ds_"
+while IFS= read -r -d '' file; do
+    if [[ $file =~ ^$ssg_ds_prefix ]]; then
+        new_file=${file#$ssg_ds_prefix}
+        mv -f "$thin_ds_dir/$file" "$thin_ds_dir/$new_file"
+    fi
+done < <(find "$thin_ds_dir" -maxdepth 1 -type f -printf '%P\0')
+
+# remove extra metadata from per-rule ansible playbooks to make them
+# usable with local ansible-playbook runs
+while IFS= read -r -d '' file; do
+    sed -i \
+        -e '/^[[:space:]]\+hosts:/s/@@HOSTS@@/all/' \
+        -e '/^[[:space:]]\+become:/d' \
+         "$file"
+done < <(find "$playbooks_dir" -maxdepth 1 -type f -print0)
+
+# make all files inside tests dir executable
+# (some tests execute other .sh files directly)
+chmod +x -R "$tests_dir"
+
+exit 0


### PR DESCRIPTION
This makes the test use custom python+bash logic and content-built test scripts, rather than `automatus.py`.

The upside is that we can use Contest VM snapshotting, and do additional optimizations (upload built tests to the VM, prepare everything ahead of time, etc., .. shortening the snapshot loop as much as possible).