### PR TITLE
OPENSCAP-5344 - Use the latest available python3 interpreter on given RHEL version

### DIFF
--- a/docs/WAIVERS.md
+++ b/docs/WAIVERS.md
@@ -47,7 +47,7 @@ Each section consists of two parts:
         True if some_other_condition else False
 
 /some/more/test/results
-    rhel < 9 and oscap < '1.3.6'
+    rhel < 9
 ```
 
 ## Regular expressions
@@ -90,20 +90,17 @@ The expression has these globals available:
 - `arch` - platform (architecture) name (`x86_64`, `ppc64le`, etc.)
 - `rhel` - an object capable of RHEL version comparison, see
   [versions.rhel](lib/versions.py)
-- `oscap` - an object capable of `openscap-scanner` RPM version comparisons,
-  see [versions.oscap](lib/versions.py)
 - `env` - environment variable retrieval function, same as `os.environ.get()`
 - `Match` - a class for complex waive results, able to contain both a boolean
   expression as well as additional parameters
 
 The version comparison objects also support a boolean evaluation, with
-`bool(rhel)` returning `False` if not running on RHEL, and ie. `bool(oscap)`
-returning `False` if the RPM is not installed.
+`bool(rhel)` returning `False` if not running on RHEL or CentOS.
 
 ```python
 /some/result/name
     (rhel < 7.9 and 'some thing' in note) or \
-    (rhel < 8.4 and oscap < '0.1.66')
+    (rhel < 8.4 and arch == 'x86_64')
 
 /some/other/result
     rhel == 8 and 'some thing' in note and env('INFRA') == 'jenkins'

--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -1,5 +1,5 @@
 summary: Remediates VM via anaconda %addon, scans via oscap
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -19,7 +19,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs ansible remediation and scan inside VMs
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -23,7 +23,7 @@ recommend+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -1,5 +1,5 @@
 summary: Creates an OS using Anaconda's ostreecontainer and scans it
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
@@ -21,7 +21,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs bootc-image-builder remediation and scan inside VMs
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
@@ -21,7 +21,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs ansible remediation directly on the target system
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
@@ -12,7 +12,7 @@ recommend+:
   - rhc-worker-playbook
 tag:
   - destructive
-adjust:
+adjust+:
   - when: arch == aarch64
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs oscap remediation directly on the target system
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs ImageBuilder remediation and scan inside VMs
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -23,7 +23,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -1,5 +1,5 @@
 summary: Remediates VM via oscap-generated kickstart, scans via oscap
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -21,7 +21,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs oscap remediation and scan inside VMs
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -19,7 +19,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/lib/dnf_get_repos
+++ b/lib/dnf_get_repos
@@ -1,0 +1,44 @@
+#!/usr/libexec/platform-python
+
+import sys
+import json
+
+from pathlib import Path
+
+# we need to remove the directory of the running script (lib) from sys.path
+# to avoid importing the dnf module from lib instead of the system module
+script_dir = Path(__file__).resolve().parent
+if str(script_dir) in sys.path:
+    sys.path.remove(str(script_dir))
+
+# ruff: noqa: E402
+import dnf
+
+
+# TODO RHEL-11+ (RHEL-30615): the dnf4 API will change (confirmed by developers)
+def get_repos_dnf5():
+    pass
+
+
+# dnf up to dnf4
+def get_repos_dnf():
+    db = dnf.Base()
+    # black magic to make the dnf python API load /etc/dnf/dnf.conf
+    # and variables from /etc/dnf/vars/*, used by CentOS Stream to
+    # define $stream, used in metalinks
+    # source: https://bugzilla.redhat.com/show_bug.cgi?id=1920735#c2
+    db.conf.read(priority=dnf.conf.PRIO_MAINCONFIG)
+    db.conf.substitutions.update_from_etc(installroot=db.conf.installroot, varsdir=db.conf.varsdir)
+    db.read_all_repos()
+    for name, repo in db.repos.items():
+        # no disabled repos
+        if not repo.enabled:
+            continue
+        repo.load()
+        baseurl = repo.remote_location('/')
+        data = dict(repo.cfg.items(name))
+        yield {'name': name, 'baseurl': baseurl, 'data': data, 'file': repo.repofile}
+
+
+if __name__ == '__main__':
+    json.dump(list(get_repos_dnf()), sys.stdout)

--- a/lib/waive.py
+++ b/lib/waive.py
@@ -205,7 +205,6 @@ def match_result(status, name, note):
         # platform related
         'arch': platform.machine(),
         'rhel': versions.rhel,
-        'oscap': versions.oscap,
         # environmental
         'env': os.environ.get,
         # special

--- a/main.fmf
+++ b/main.fmf
@@ -8,13 +8,9 @@ require:
 # shared by all tests
 recommend:
   - python3
-  - python36
   - python3-requests
-  - python36-requests
   - python3-pyyaml
-  - python36-pyyaml
-  - python3-rpm
-  - python36-rpm
+  - python3-dnf
   # - preparing/patching downloaded SRPM
   - rpm-build
 component:
@@ -26,3 +22,25 @@ environment:
     # use on-disk /var/tmp for all temporary directories, saving RAM by avoiding
     # the tmpfs on /tmp and giving tests more space to operate
     TMPDIR: /var/tmp
+
+# RHEL and python3 versions (https://access.redhat.com/solutions/6879401):
+# - RHEL-10 defaults to python 3.12, there is only python3 RPM package
+# - RHEL-9 defaults to python 3.9, python3.11 RPM is available since RHEL-9.2
+# - RHEL-8 defaults to python 3.6, python3.11 RPM is available since RHEL-8.8
+# Effectively, we are limited by RHEL-9.0 where only python 3.9 is available
+# so contest can currently only use python features up to version 3.9.
+adjust:
+  - when: distro >= rhel-10
+    environment+:
+        CONTEST_PYTHON: python3
+  - when: distro == rhel-8 or distro == rhel-9
+    environment+:
+        CONTEST_PYTHON: python3.11
+    recommend+:
+      - python3.11
+      - python3.11-requests
+      - python3.11-pyyaml
+      - python3.11-urllib3
+  - when: distro ~= rhel-9.0
+    environment+:
+        CONTEST_PYTHON: python3

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -7,7 +7,7 @@ description: |-
     built for the current platform.
     The RULE variable (with space-separated one or more rule names) can be used
     to override this and run tests for only specific rule(s).
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ..
@@ -35,7 +35,7 @@ recommend+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/scanning/disa-alignment/anaconda.fmf
+++ b/scanning/disa-alignment/anaconda.fmf
@@ -1,5 +1,5 @@
 summary: Compare SSG and DISA STIG benchmark scan results after Anaconda installation
-test: python3 -m lib.runtest ./anaconda.py
+test: $CONTEST_PYTHON -m lib.runtest ./anaconda.py
 result: custom
 environment+:
     PYTHONPATH: ../..

--- a/scanning/disa-alignment/ansible.fmf
+++ b/scanning/disa-alignment/ansible.fmf
@@ -1,5 +1,5 @@
 summary: Compare SSG and DISA STIG benchmark scan results after Ansible remediation
-test: python3 -m lib.runtest ./ansible.py
+test: $CONTEST_PYTHON -m lib.runtest ./ansible.py
 result: custom
 environment+:
     PYTHONPATH: ../..

--- a/scanning/disa-alignment/oscap.fmf
+++ b/scanning/disa-alignment/oscap.fmf
@@ -1,5 +1,5 @@
 summary: Compare SSG and DISA STIG benchmark scan results after Bash remediation
-test: python3 -m lib.runtest ./oscap.py
+test: $CONTEST_PYTHON -m lib.runtest ./oscap.py
 result: custom
 environment+:
     PYTHONPATH: ../..

--- a/scanning/oscap-debug/helgrind.fmf
+++ b/scanning/oscap-debug/helgrind.fmf
@@ -1,5 +1,5 @@
 summary: Runs oscap via valgrind - helgrind
-test: python3 -m lib.runtest ./helgrind.py
+test: $CONTEST_PYTHON -m lib.runtest ./helgrind.py
 duration: 4h
 require+:
   - valgrind

--- a/scanning/oscap-debug/sysctl-only.fmf
+++ b/scanning/oscap-debug/sysctl-only.fmf
@@ -1,9 +1,9 @@
 summary: Runs oscap many times to hopefully reproduce a freeze
-test: python3 -m lib.runtest ./sysctl-only.py
+test: $CONTEST_PYTHON -m lib.runtest ./sysctl-only.py
 duration: 4h
 require+:
   - gdb
-adjust:
+adjust+:
   - when: distro < rhel-9.5
     enabled: false
     because: we need a fairly modern gdb

--- a/scanning/oscap-debug/sysctl-oval-eval-parallel.fmf
+++ b/scanning/oscap-debug/sysctl-oval-eval-parallel.fmf
@@ -1,9 +1,9 @@
 summary: Runs oscap many times to hopefully reproduce a freeze (oval eval against sysctl*.xml OVALs)
-test: python3 -m lib.runtest ./sysctl-oval-eval-parallel.py
+test: $CONTEST_PYTHON -m lib.runtest ./sysctl-oval-eval-parallel.py
 duration: 4h
 require+:
   - gdb
-adjust:
+adjust+:
   - when: distro < rhel-9.5
     enabled: false
     because: we need a fairly modern gdb

--- a/scanning/oscap-debug/vm-scan.fmf
+++ b/scanning/oscap-debug/vm-scan.fmf
@@ -1,5 +1,5 @@
 summary: Runs oscap many times to hopefully reproduce a freeze
-test: python3 -m lib.runtest ./vm-scan.py
+test: $CONTEST_PYTHON -m lib.runtest ./vm-scan.py
 duration: 4h
 require+:
   # virt library dependencies
@@ -16,7 +16,7 @@ require+:
 extra-hardware: |
     keyvalue = HVM=1
     hostrequire = memory>=3720
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only

--- a/scanning/oscap-eval/main.fmf
+++ b/scanning/oscap-eval/main.fmf
@@ -1,5 +1,5 @@
 summary: Runs oscap xccdf eval as a simple sanity check
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..

--- a/scripts/find_invalid_waivers.py
+++ b/scripts/find_invalid_waivers.py
@@ -27,14 +27,7 @@ MatchedWaiver = collections.namedtuple(
 )
 
 
-class _FakeRhel(versions._RpmVerCmp):
-    def __init__(self, fake_major, fake_minor):
-        self._release_separator = '.'
-        self.version = fake_major
-        self.release = fake_minor
-        self.major = int(fake_major)
-        self.minor = int(fake_minor)
-
+class _FakeRhel(versions._Rhel):
     @staticmethod
     def is_true_rhel():
         return True  # always assume we're on RHEL
@@ -62,8 +55,6 @@ def unwaive_note(waive_text, note):
 
 def match_result_mark_waiver(regexes_matched_list, version, arch, status, name, note):
     """This function is an updated version of the match_result() function from the lib/waive.py."""
-    v = version.split('.')
-
     # make sure "'something' in name" always works
     if name is None:
         name = ''
@@ -82,8 +73,7 @@ def match_result_mark_waiver(regexes_matched_list, version, arch, status, name, 
         'name': name,
         'note': note,
         'arch': arch,
-        'rhel': _FakeRhel(v[0], v[1]),
-        'oscap': '',
+        'rhel': _FakeRhel(version),
         'env': '',
         'Match': waive.Match,
     }

--- a/static-checks/ansible/allowed-modules/main.fmf
+++ b/static-checks/ansible/allowed-modules/main.fmf
@@ -3,7 +3,7 @@ description: |-
     Ansible modules which are allowed to be used in the scap-security-guide
     content include modules from the ansible-core RPM and modules from
     posix and community collections (on RHEL-8+ packaged in rhc-worker-playbook).
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
@@ -14,7 +14,7 @@ require+:
 recommend+:
   # needed for the ini_file ansible plugin, and more
   - rhc-worker-playbook
-adjust:
+adjust+:
   - when: arch == aarch64
     enabled: false
     because: RHEL-8+ requires rhc-worker-playbook which is not available for aarch64

--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -2,7 +2,7 @@ summary: Check Ansible playbooks syntax.
 description: |-
     Verify that all generated playbooks and all playbooks provided
     by the scap-security-guide package have correct Ansible syntax.
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
@@ -15,7 +15,7 @@ recommend+:
   - rhc-worker-playbook
   # individual rule playbooks
   - scap-security-guide-rule-playbooks
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: Ansible playbooks are same on all architectures

--- a/static-checks/diff/main.fmf
+++ b/static-checks/diff/main.fmf
@@ -4,29 +4,29 @@ environment+:
 duration: 10m
 tag:
   - always-fails
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: datastream is same on all architectures
 
 /profiles:
     summary: Diff datastreams, output added/removed profiles
-    test: python3 -m lib.runtest ./profiles.py
+    test: $CONTEST_PYTHON -m lib.runtest ./profiles.py
 
 /profile-titles:
     summary: Diff datastreams, output profile title differences
-    test: python3 -m lib.runtest ./profile-titles.py
+    test: $CONTEST_PYTHON -m lib.runtest ./profile-titles.py
 
 /profile-rules:
     summary: Diff datastreams, output profile rule/variable differences
-    test: python3 -m lib.runtest ./profile-rules.py
+    test: $CONTEST_PYTHON -m lib.runtest ./profile-rules.py
 
 /profile-variables:
     summary: Diff datastreams, output profile variable refine differences
-    test: python3 -m lib.runtest ./profile-variables.py
+    test: $CONTEST_PYTHON -m lib.runtest ./profile-variables.py
 
 /audit-sample-rules:
     summary: Diff audit.rules between Content and installed auditd samples
-    test: python3 -m lib.runtest ./audit-sample-rules.py
+    test: $CONTEST_PYTHON -m lib.runtest ./audit-sample-rules.py
     require+:
       - audit

--- a/static-checks/html-links/main.fmf
+++ b/static-checks/html-links/main.fmf
@@ -1,12 +1,12 @@
 summary: Verify that HTML links from datastream are accessible.
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 5m
 recommend+:
   - python3-requests
-adjust:
+adjust+:
   - enabled: false
     when: arch != x86_64
     continue: false

--- a/static-checks/nist-validation/main.fmf
+++ b/static-checks/nist-validation/main.fmf
@@ -1,5 +1,5 @@
 summary: Check content with NIST SCAP Content Validation Tool.
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -7,7 +7,7 @@ duration: 15m
 recommend+:
   - java-17-openjdk
   - java-21-openjdk
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: the test is not architecture-specific, one is enough

--- a/static-checks/removed-rules/main.fmf
+++ b/static-checks/removed-rules/main.fmf
@@ -1,10 +1,10 @@
 summary: Check that no rule has been removed between old/new datastreams
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
 duration: 10m
-adjust:
+adjust+:
   - when: arch != x86_64
     enabled: false
     because: datastream is same on all architectures

--- a/static-checks/rpmbuild-ctest/main.fmf
+++ b/static-checks/rpmbuild-ctest/main.fmf
@@ -1,5 +1,5 @@
 summary: Builds from source and runs ctest
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..
@@ -19,7 +19,7 @@ recommend+:
   - ansible-core
   - rhc-worker-playbook
   - bats
-adjust:
+adjust+:
   - when: arch == aarch64 and distro == rhel-9.0
     enabled: false
     because: rhc-worker-playbook or community.general collection not available there

--- a/static-checks/rule-identifiers/main.fmf
+++ b/static-checks/rule-identifiers/main.fmf
@@ -1,5 +1,5 @@
 summary: Search for policy references in rules
-test: python3 -m lib.runtest ./test.py
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../..


### PR DESCRIPTION
Remove dependency on `python3-dnf` and `python3-rpm` to make it possible
to use the latest python3 version available in a given RHEL version.

Currently, we run tests on the following RHEL versions:
8.8, 8.10, 9.0, 9.2, 9.4, 9.5, 9.6 and 10.0.

RHEL and python3 versions (https://access.redhat.com/solutions/6879401):
- RHEL-10 defaults to python 3.12, there is only python3 RPM package
- RHEL-9 defaults to python 3.9, python3.11 RPM is available since RHEL-9.2
- RHEL-8 defaults to python 3.6, python3.11 RPM is available since RHEL-8.8

Effectively, we are limited by RHEL-9.0 where only python 3.9 is available
so contest can currently only use python features up to version 3.9.

Resolves https://github.com/RHSecurityCompliance/contest/issues/227