### PR TITLE
Preparation for a new `/per-rule` runner

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -266,6 +266,36 @@ feel free to use them (under some appropriate name).
 
 Avoid (for now) using `@property` to hack this, we don't have public APIs.
 
+## Use walrus operators (`:=`) only with limited scope
+
+This is fine:
+
+```
+if match := re.fullmatch(r'/some/([^/]+)/test', test_name):
+    variant = match.group(1)
+```
+
+as long as `variant` never leaves the `if` scope. If it does, assign it without
+walrus above the condition:
+
+```
+test_type = os.environ.get('SOME_VAR')
+
+if test_type:
+    do_something(test_type)
+
+another_func(test_type)
+```
+
+Avoid this:
+
+```
+if test_type := os.environ.get('SOME_VAR'):
+    do_something(test_type)
+
+another_func(test_type)
+```
+
 ## Log tactically
 
 Use `util.log('something')` when something

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -204,7 +204,7 @@ class Blueprint:
     def set_openscap_datastream(self, ds_file):
         pre, header, post = self.assembled.partition('\n[customizations.openscap]\n')
         if not header:
-            raise SyntaxError("openscap section not found")
+            raise ValueError("openscap section not found")
         self.assembled = '\n'.join([
             pre,
             header.strip('\n'),

--- a/lib/results.py
+++ b/lib/results.py
@@ -204,7 +204,7 @@ def report(status, name=None, note=None, logs=None, *, add_output=True):
     Returns the final 'status', potentially modified by the waiving logic.
     """
     if status not in _valid_statuses:
-        raise SyntaxError(f"{status} is not a valid status")
+        raise ValueError(f"{status} is not a valid status")
 
     # apply to all report variants
     if name:

--- a/lib/unit_tests.py
+++ b/lib/unit_tests.py
@@ -1,0 +1,185 @@
+"""
+These are utilities for working with CaC/content unit tests, as built by
+the CaC/content built system.
+
+To satisfy various use cases, the logic is modularized into functions:
+
+ - iter_rules() iterates over all built tests, yielding rules
+
+ - iter_tests() iterates over .sh tests for one rule, yielding partial
+   UnitTest with info from the rule directory (rule, test, is_pass)
+
+ - fill_in_metadata() reads the .sh contents and completes UnitTest
+   based on metadata contained in the .sh file
+"""
+
+import re
+import io
+import contextlib
+import collections
+from pathlib import Path
+
+
+UnitTest = collections.namedtuple(
+    'UnitTest',
+    [
+        # str: rule name
+        'rule',
+        # str: test name without .pass.sh or .fail.sh
+        'test',
+        # bool: True if .pass.sh, False if .fail.sh
+        'is_pass',
+        # tuple of str or None: RPM package names
+        'packages',
+        # tuple of str or None: profiles the test should be run within
+        'profiles',
+        # dict or None: variables that should be changed in datastream/playbook
+        'variables',
+        # str or None: which remediation types should be tested (none, bash, ansible, ..)
+        'remediation',
+        # str or None: check engine type
+        'check',
+    ],
+    # last 5 fields are optional
+    defaults=[None, None, None, None, None],
+)
+
+
+# a=b,c=d,e=f  --> {'a': 'b', 'c': 'd', 'e': 'f'}
+# a=b,c        --> {'a': 'b,c'}
+# a=b , c      --> {'a': 'b , c'}           # preserved space
+# a=b, c ,d=e  --> {'a': 'b, c', 'd': 'e'}
+# a=b, c=d     --> {'a': 'b', 'c': 'd'}
+# a=b,c= d     --> {'a': 'b', 'c': 'd'}
+# a=b,c =d     --> {'a': 'b', 'c': 'd'}
+# a=b, c = d   --> {'a': 'b', 'c': 'd'}
+# a=b , c = d  --> {'a': 'b', 'c': 'd'}
+# a=,b=c       --> {'a': '', 'b': 'c'}
+# a=b,=c       --> error key empty
+# a            --> error missing key
+def parse_variables(line):
+    variables = {}
+    key = None
+    for part in line.split(','):
+        if '=' in part:
+            key, _, value = part.partition('=')
+            key = key.strip()
+            value = value.lstrip()
+            if not key:
+                raise ValueError(f"key empty: {part}")
+            variables[key] = value
+        else:
+            if key is None:
+                raise ValueError(f"no key=value pair given: {part}")
+            variables[key] += f',{part}'
+    # trim any trailing spaces in values
+    # (we need to do it here because we might have added space-containing
+    #  equals-less extra values to a previous key via the 'else' branch)
+    for key, value in variables.items():
+        variables[key] = value.rstrip()
+    return variables
+
+
+def fill_in_metadata(unit_test, test_file):
+    """
+    Given an (incomplete) UnitTest tuple as 'unit_test', fill in values
+    from unit test file metadata, returning the complete UnitTest.
+
+    'test_file' may be a file path or a file-like object.
+    """
+    packages = None
+    profiles = None
+    variables = None
+    remediation = None
+    check = None
+
+    with contextlib.ExitStack() as stack:
+        if isinstance(test_file, io.IOBase):
+            f = test_file
+        else:
+            f = stack.enter_context(open(test_file))
+
+        for line in f:
+            line = line.rstrip('\n')
+            # skip empty lines and comments
+            if not line or re.fullmatch(r'\s+', line):
+                continue
+            # packages
+            if m := re.fullmatch(r'# packages = (.+)', line):
+                if packages is not None:
+                    raise ValueError(f"packages already defined as: {packages}")
+                # save memory by using const tuples
+                packages = tuple(re.split(r' *, *', m.group(1)))
+                continue
+            # profiles
+            if m := re.fullmatch(r'# profiles = (.+)', line):
+                if profiles is not None:
+                    raise ValueError(f"profiles already defined as: {profiles}")
+                # save memory by using const tuples
+                profiles = tuple(re.split(r' *, *', m.group(1)))
+                continue
+            # variables
+            if m := re.fullmatch(r'# variables = (.+)', line):
+                if variables is not None:
+                    raise ValueError(f"variables already defined as: {variables}")
+                variables = parse_variables(m.group(1))
+                continue
+            # remediation
+            if m := re.fullmatch(r'# remediation = (.+)', line):
+                if remediation is not None:
+                    raise ValueError(f"remediation already defined as: {remediation}")
+                remediation = m.group(1)
+                continue
+            # check
+            if m := re.fullmatch(r'# check = (.+)', line):
+                if check is not None:
+                    raise ValueError(f"check already defined as: {check}")
+                check = m.group(1)
+                continue
+            # other unrecognized comments
+            if line.startswith('#'):
+                continue
+            # first non-metadata line hit, abort parsing
+            break
+
+    return unit_test._replace(
+        packages=packages,
+        profiles=profiles,
+        variables=variables,
+        remediation=remediation,
+        check=check,
+    )
+
+
+def iter_tests(rule_dir):
+    """
+    Given a rule directory containing tests, yield tuples of
+    (partial UnitTest , test file path) representing tests found in that
+    directory.
+    """
+    rule_dir = Path(rule_dir)
+    for test_file in sorted(rule_dir.iterdir(), key=lambda x: x.name):
+        file_name = test_file.name
+        if file_name.endswith('.pass.sh'):
+            test = file_name.removesuffix('.pass.sh')
+            is_pass = True
+        elif file_name.endswith('.fail.sh'):
+            test = file_name.removesuffix('.fail.sh')
+            is_pass = False
+        else:
+            # skip non-test files that might be present
+            continue
+        yield (UnitTest(rule_dir.name, test, is_pass), test_file)
+
+
+def iter_rules(built_tests_dir):
+    """
+    Given a directory with built tests, yield pathlib.Path directories
+    with tests, the names of which should correspond to rule names,
+    plus the special directory 'shared'.
+    """
+    built_tests_dir = Path(built_tests_dir)
+    for rule_dir in sorted(Path(built_tests_dir).iterdir(), key=lambda x: x.name):
+        # tests are inside rule-named directories, skip non-dir files
+        if rule_dir.is_dir():
+            yield rule_dir

--- a/lib/util/log.py
+++ b/lib/util/log.py
@@ -38,7 +38,7 @@ def log(msg, *, skip_frames=0):
     """
     stack = inspect.stack()
     if len(stack)-1 <= skip_frames:
-        raise SyntaxError("skip_frames exceeds call stack (frame count)")
+        raise ValueError("skip_frames exceeds call stack (frame count)")
     stack = stack[skip_frames+1:]
 
     # bottom of the stack, or runpy executed module

--- a/lib/util/network.py
+++ b/lib/util/network.py
@@ -14,7 +14,7 @@ def wait_for_tcp(host, port, *, timeout=600, to_shutdown=False, compare=None):
     Useful for waiting for b'SSH-' to start answering on port 22.
     """
     if compare is not None and to_shutdown:
-        raise SyntaxError("compare and to_shutdown are mutually exclusive")
+        raise ValueError("compare and to_shutdown are mutually exclusive")
 
     state = 'stop' if to_shutdown else 'start'
     util.log(f"waiting for {host}:{port} to {state} listening for {timeout}s", skip_frames=1)

--- a/lib/util/rpmpack.py
+++ b/lib/util/rpmpack.py
@@ -56,10 +56,10 @@ class RpmPack:
         if target:
             target = Path(target)
             if not target.is_absolute():
-                raise SyntaxError(f"target {target} not an absolute path")
+                raise ValueError(f"target {target} not an absolute path")
         else:
             if not source.is_absolute():
-                raise SyntaxError(f"source {source} must be absolute if target is missing")
+                raise ValueError(f"source {source} must be absolute if target is missing")
             target = source
         entry = self.FilePath(source.absolute(), target)
         self.files.append(entry)
@@ -72,7 +72,7 @@ class RpmPack:
         """
         target = Path(target)
         if not target.is_absolute():
-            raise SyntaxError(f"target {target} not an absolute path")
+            raise ValueError(f"target {target} not an absolute path")
         entry = self.FileContents(target, contents)
         self.files.append(entry)
 

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -375,7 +375,7 @@ class Guest:
 
     def install_basic(
         self, location=None, kickstart=None, secure_boot=False, virt_install_args=None,
-        kernel_args=None, disk_format='raw',
+        kernel_args=None, final_mem=2000, disk_format='raw',
     ):
         """
         Install a new guest, to a shut down state.
@@ -390,6 +390,10 @@ class Guest:
 
         'virt_install_args' are an optional list of extra 'virt-install' arguments
         and 'kernel_args' an optional list to be passed to kernel during installation.
+
+        By default, we shrink the guest to 2 GB RAM after install to give more space
+        to the host running tests. Specify 'final_mem' in MBs to override this.
+        A value of None will disable the feature.
         """
         util.log(f"installing guest {self.name}")
 
@@ -449,7 +453,8 @@ class Guest:
                 raise e from None
 
         # installed system doesn't need as much RAM, alleviate swap pressure
-        set_domain_memory(self.name, 2000)
+        if final_mem:
+            set_domain_memory(self.name, final_mem)
 
         self.install_ready_path.write_text(self.tag)
 

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -635,11 +635,11 @@ class Guest:
         self._destroy_snapshotted()
 
         cmd = [
-            'qemu-img', 'create', '-f', 'qcow2',
+            'qemu-img', 'create', '-q', '-f', 'qcow2',
             '-b', self.disk_path, '-F', self.disk_format,
             self.snapshot_path,
         ]
-        util.subprocess_run(cmd, check=True)
+        subprocess.run(cmd, check=True)
 
         virsh('restore', self.state_file_path, check=True)
 
@@ -667,7 +667,6 @@ class Guest:
         self._restore_snapshotted()
         self.ipaddr = wait_for_ifaddr(self.name)
         wait_for_ssh(self.ipaddr)
-        util.log(f"guest {self.name} ready")
         try:
             yield self
         finally:
@@ -688,7 +687,6 @@ class Guest:
         self.start()
         self.ipaddr = wait_for_ifaddr(self.name)
         wait_for_ssh(self.ipaddr)
-        util.log(f"guest {self.name} ready")
         try:
             yield self
         finally:
@@ -737,7 +735,7 @@ class Guest:
 
     def _do_rsync(self, *args):
         ssh = (
-            f'ssh -i {self.ssh_keyfile_path}'
+            f'ssh -q -i {self.ssh_keyfile_path}'
             ' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
         )
         return util.subprocess_run(['rsync', '-a', '-e', ssh, *args], check=True)

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -746,11 +746,19 @@ class Guest:
         )
         return util.subprocess_run(['rsync', '-a', '-e', ssh, *args], check=True)
 
-    def rsync_from(self, remote_path, local_path='.'):
-        self._do_rsync(f'{GUEST_SSH_USER}@{self.ipaddr}:{remote_path}', local_path)
+    def rsync_from(self, remote_path, local_path='.', rsync_opts=()):
+        if isinstance(remote_path, (tuple,list)):
+            remote_args = (f'{GUEST_SSH_USER}@{self.ipaddr}:{x}' for x in remote_path)
+        else:
+            remote_args = (f'{GUEST_SSH_USER}@{self.ipaddr}:{remote_path}',)
+        self._do_rsync(*rsync_opts, *remote_args, local_path)
 
-    def rsync_to(self, local_path, remote_path='.'):
-        self._do_rsync(local_path, f'{GUEST_SSH_USER}@{self.ipaddr}:{remote_path}')
+    def rsync_to(self, local_path, remote_path='.', rsync_opts=()):
+        if isinstance(local_path, (tuple,list)):
+            local_args = local_path
+        else:
+            local_args = (local_path,)
+        self._do_rsync(*rsync_opts, *local_args, f'{GUEST_SSH_USER}@{self.ipaddr}:{remote_path}')
 
     def generate_ssh_keypair(self):
         private = self.ssh_keyfile_path

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -78,7 +78,6 @@ import sys
 import re
 import time
 import subprocess
-import collections
 import textwrap
 import contextlib
 import tempfile
@@ -115,6 +114,7 @@ INSTALL_FAILURES = [
     # Anaconda died due to oscap crashing (or other reasons)
     br"Kernel panic - not syncing",
     br"The installer will now terminate",
+    br"Failed to start .*the anaconda installation program",
 ]
 
 PIPE = subprocess.PIPE
@@ -432,12 +432,11 @@ class Guest:
             executable = util.libdir / 'pseudotty'
             proc = subprocess.Popen(virt_install, stdout=PIPE, executable=executable)
             fail_exprs = [re.compile(x) for x in INSTALL_FAILURES]
-            # keep only the last 100 lines
-            line_buff = collections.deque(maxlen=100)
 
             try:
                 for line in proc.stdout:
-                    line_buff.append(line)
+                    sys.stdout.buffer.write(line)
+                    sys.stdout.buffer.flush()
                     if any(x.search(line) for x in fail_exprs):
                         proc.terminate()
                         proc.wait()
@@ -445,9 +444,6 @@ class Guest:
                 if proc.wait() > 0:
                     raise RuntimeError("virt-install failed")
             except Exception as e:
-                for line in line_buff:
-                    sys.stdout.buffer.write(line)
-                sys.stdout.buffer.flush()
                 self.destroy()
                 self.undefine()
                 raise e from None

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -670,8 +670,9 @@ class Guest:
         if not self.can_be_snapshotted():
             raise RuntimeError(f"guest {self.name} not ready for snapshotting")
         self._restore_snapshotted()
-        self.ipaddr = wait_for_ifaddr(self.name)
-        wait_for_ssh(self.ipaddr)
+        if not self.ipaddr:
+            self.ipaddr = wait_for_ifaddr(self.name)
+            wait_for_ssh(self.ipaddr)
         try:
             yield self
         finally:

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,6 +25,7 @@ ignore = [
     "SIM102",   # collapsible-if
     "SIM117",   # multiple-with-statements
     "SIM401",   # if-else-block-instead-of-dict-get
+    "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
     "PLR2004",  # magic-value-comparison
@@ -36,9 +37,11 @@ ignore = [
     "RUF012",   # mutable-class-default
 
     # rules from preview
+    "E115",     # no-indented-block-comment
     "E226",     # missing-whitespace-around-arithmetic-operator
     "E231",     # missing-whitespace
     "E265",     # no-space-after-block-comment
+    "E266",     # multiple-leading-hashes-for-block-comment
     "PLR0904",  # too-many-public-methods
     "PLR0917",  # too-many-positional-arguments
     "PLR6201",  # literal-membership

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 99
 indent-width = 4
-target-version = "py37"  # doesn't support older
+target-version = "py39"
 
 [lint]
 preview = true

--- a/static-checks/unit-tests-metadata/main.fmf
+++ b/static-checks/unit-tests-metadata/main.fmf
@@ -1,0 +1,10 @@
+summary: Check Automatus unit tests for metadata sanity
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
+result: custom
+environment+:
+    PYTHONPATH: ../..
+duration: 10m
+adjust+:
+  - when: arch != x86_64
+    enabled: false
+    because: tests are the same on all architectures

--- a/static-checks/unit-tests-metadata/test.py
+++ b/static-checks/unit-tests-metadata/test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+
+import io
+
+from lib import util, results, versions, unit_tests
+
+
+def check_file(partial, test_file):
+    if test_file.stat().st_size == 0:
+        return "file is empty"
+
+    # last line must have a terminating \n
+    with open(test_file, 'rb') as f:
+        f.seek(-1, io.SEEK_END)
+        if f.read() != b'\n':
+            return "last line doesn't end with a newline"
+
+    with open(test_file) as f:
+        # first line must be shebang
+        line = next(f)
+        if line != '#!/bin/bash\n':
+            return "first line is not a /bin/bash shebang"
+
+        try:
+            filled = unit_tests.fill_in_metadata(partial, f)
+        except ValueError as e:
+            return f"metadata syntax error: {str(e)}"
+
+        if filled.remediation:
+            if filled.remediation not in ['bash', 'ansible', 'none']:
+                return f"remediation={filled.remediation} is not valid"
+        if filled.check:
+            if filled.check not in ['oval', 'sce', 'any']:
+                return f"check={filled.check} is not valid"
+        if filled.remediation and filled.is_pass:
+            return f"remediation={filled.remediation} doesn't make sense for a .pass.sh test"
+
+        # metadata parsing stopped because it hit either EOF or non-metadata
+        # code, so a repeated attempt must not find any metadata
+        try:
+            filled = unit_tests.fill_in_metadata(partial, f)
+        except ValueError as e:
+            return f"metadata syntax error: {str(e)}"
+        if filled.packages:
+            return "packages defined after non-metadata code"
+        if filled.profiles:
+            return "profiles defined after non-metadata code"
+        if filled.variables:
+            return "variables defined after non-metadata code"
+        if filled.remediation:
+            return "remediation defined after non-metadata code"
+        if filled.check:
+            return "check defined after non-metadata code"
+
+
+with util.get_source_content() as content_dir:
+    util.build_content(
+        content_dir,
+        {'SSG_BUILT_TESTS_ENABLED:BOOL': 'ON'},
+    )
+    build_dir = content_dir / util.CONTENT_BUILD_DIR
+    built_tests = build_dir / f'rhel{versions.rhel.major}' / 'tests'
+    util.log(f"using built tests: {str(built_tests)}")
+
+    for rule_dir in unit_tests.iter_rules(built_tests):
+        for partial, test_file in unit_tests.iter_tests(rule_dir):
+            pass_fail = 'pass' if partial.is_pass else 'fail'
+            result_name = f'{partial.rule}/{partial.test}.{pass_fail}'
+            if problem := check_file(partial, test_file):
+                results.report('fail', result_name, problem)
+            else:
+                results.report('pass', result_name)
+
+results.report_and_exit()

--- a/static-checks/unit-tests-metadata/test.py
+++ b/static-checks/unit-tests-metadata/test.py
@@ -15,42 +15,24 @@ def check_file(partial, test_file):
         if f.read() != b'\n':
             return "last line doesn't end with a newline"
 
+    # first line must be shebang
     with open(test_file) as f:
-        # first line must be shebang
-        line = next(f)
-        if line != '#!/bin/bash\n':
+        if next(f) != '#!/bin/bash\n':
             return "first line is not a /bin/bash shebang"
 
-        try:
-            filled = unit_tests.fill_in_metadata(partial, f)
-        except ValueError as e:
-            return f"metadata syntax error: {str(e)}"
+    try:
+        filled = unit_tests.fill_in_metadata(partial, test_file)
+    except ValueError as e:
+        return f"metadata syntax error: {str(e)}"
 
-        if filled.remediation:
-            if filled.remediation not in ['bash', 'ansible', 'none']:
-                return f"remediation={filled.remediation} is not valid"
-        if filled.check:
-            if filled.check not in ['oval', 'sce', 'any']:
-                return f"check={filled.check} is not valid"
-        if filled.remediation and filled.is_pass:
-            return f"remediation={filled.remediation} doesn't make sense for a .pass.sh test"
-
-        # metadata parsing stopped because it hit either EOF or non-metadata
-        # code, so a repeated attempt must not find any metadata
-        try:
-            filled = unit_tests.fill_in_metadata(partial, f)
-        except ValueError as e:
-            return f"metadata syntax error: {str(e)}"
-        if filled.packages:
-            return "packages defined after non-metadata code"
-        if filled.profiles:
-            return "profiles defined after non-metadata code"
-        if filled.variables:
-            return "variables defined after non-metadata code"
-        if filled.remediation:
-            return "remediation defined after non-metadata code"
-        if filled.check:
-            return "check defined after non-metadata code"
+    if filled.remediation:
+        if filled.remediation not in ['bash', 'ansible', 'none']:
+            return f"remediation={filled.remediation} is not valid"
+    if filled.check:
+        if filled.check not in ['oval', 'sce', 'any']:
+            return f"check={filled.check} is not valid"
+    if filled.remediation and filled.is_pass:
+        return f"remediation={filled.remediation} doesn't make sense for a .pass.sh test"
 
 
 with util.get_source_content() as content_dir:


### PR DESCRIPTION
Definitely review this by commits, oldest-first.

Aside from the misc `lib` changes, there is one new test added, `/static-checks/unit-tests-metadata`, the commit of which adds a new `lib.unit_tests` module that will be used by the new `/per-rule` rewrite, but I figured that since we parse tests, we might as well do some basic syntax checking in a separate test.

A follow-up commit 455b9455398 then changes one part of the checking behavior - since we might want to revert it in the future (enforcing top-metadata), I wanted to have it as a separate commit rather than squashing it to the test.

The code uses python 3.8 features, so I went ahead and updated `ruff.toml` to avoid PR checks failing.