### PR TITLE
/hardening/container: pull base image to local registry before running build

### DIFF
--- a/hardening/container/anaconda-ostree/test.py
+++ b/hardening/container/anaconda-ostree/test.py
@@ -55,6 +55,7 @@ cfile += util.dedent(fr'''
 cfile.add_ssh_pubkey(guest.ssh_pubkey)
 cfile.write_to('Containerfile')
 
+podman.podman('pull', src_image)
 podman.podman('image', 'build', '--tag', 'contest-hardened', '.')
 
 # we can't use standard CaC/content style partitioning scheme because the

--- a/hardening/container/bootc-image-builder/test.py
+++ b/hardening/container/bootc-image-builder/test.py
@@ -56,6 +56,7 @@ cfile += util.dedent(fr'''
 cfile.add_ssh_pubkey(guest.ssh_pubkey)
 cfile.write_to('Containerfile')
 
+podman.podman('pull', src_image)
 podman.podman('image', 'build', '--tag', 'contest-hardened', '.')
 
 # pre-create a directory (inside GUEST_IMG_DIR) for storing the


### PR DESCRIPTION
This will print additional timestamps so we can clearly see on the output how long does it take to pull a base image from container registry and how long does it take to build a hardened image afterwards (build will use the already pulled base image from local registry).