### PR TITLE
/static-checks/ansible/syntax-check: avoid running oscap scans

### DIFF
--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -6,7 +6,7 @@ test: $CONTEST_PYTHON -m lib.runtest ./test.py
 result: custom
 environment+:
     PYTHONPATH: ../../..
-duration: 3h
+duration: 15m
 require+:
   - openscap-scanner
   - ansible-core

--- a/static-checks/ansible/syntax-check/test.py
+++ b/static-checks/ansible/syntax-check/test.py
@@ -2,41 +2,29 @@
 
 import subprocess
 
-from lib import ansible, util, oscap, results
+from lib import ansible, util, results
 
 
 ansible.install_deps()
 
 ds = util.get_datastream()
-all_profiles = oscap.Datastream(ds).profiles
 
-# Generated playbooks
-for profile in all_profiles:
-    # Get ARF from scan
-    cmd = [
-        'oscap', 'xccdf', 'eval', '--profile', profile,
-        '--progress', '--results-arf', 'arf.xml', ds,
-    ]
-    ret = util.subprocess_run(cmd)
-    if ret.returncode not in [0,2]:
-        raise RuntimeError("oscap failed unexpectedly")
+# Generate playbook from datastream and virtual (all) profile
+cmd = [
+    'oscap', 'xccdf', 'generate', 'fix', '--profile', '(all)',
+    '--fix-type', 'ansible', '--output', 'playbook.yml', ds,
+]
+ret = util.subprocess_run(cmd, check=True)
 
-    # Generate playbook from results ARF
-    cmd = [
-        'oscap', 'xccdf', 'generate', 'fix', '--profile', profile,
-        '--fix-type', 'ansible', '--output', 'playbook.yml', 'arf.xml',
-    ]
-    ret = util.subprocess_run(cmd, check=True)
+# Check syntax of generated playbook
+cmd = ['ansible-playbook', '--syntax-check', 'playbook.yml']
+ret = util.subprocess_run(cmd, stderr=subprocess.PIPE)
+if ret.returncode == 0:
+    results.report('pass', '(all) profile generated')
+else:
+    results.report('fail', '(all) profile generated', ret.stderr)
 
-    # Check syntax of generated playbook
-    cmd = ['ansible-playbook', '--syntax-check', 'playbook.yml']
-    ret = util.subprocess_run(cmd, stderr=subprocess.PIPE)
-    if ret.returncode == 0:
-        results.report('pass', f'{profile} scan generated')
-    else:
-        results.report('fail', f'{profile} scan generated', ret.stderr)
-
-# Shipped playbooks
+# Check syntax of shipped playbooks
 for playbook in util.iter_playbooks():
     cmd = ['ansible-playbook', '--syntax-check', playbook]
     ret = util.subprocess_run(cmd, stderr=subprocess.PIPE)


### PR DESCRIPTION
Use datastream and virtual `(all)` profile to generate Ansible playbook containing Ansible remediations for all rules from the datastream. This way we avoid running `oscap` which slowed down this test and also caused many freezes in upstream GH CI due to a bug in `oscap` codebase.

Fixes: OPENSCAP-5524