### PR TITLE
Fix fmf tag filtering by declaring empty `tag` array

### DIFF
--- a/main.fmf
+++ b/main.fmf
@@ -24,6 +24,10 @@ environment:
     TMPDIR: /var/tmp
     CONTEST_PYTHON: python3
 
+# needed for fmf filtering because some tests use tag+: without any parent
+# defining tag: without the +
+tag: []
+
 # RHEL and python3 versions (https://access.redhat.com/solutions/6879401):
 # - RHEL-10 defaults to python 3.12, there is only python3 RPM package
 # - RHEL-9 defaults to python 3.9, python3.11 RPM is available since RHEL-9.2


### PR DESCRIPTION
This is needed for using pure `fmf` to parse the metadata (important for potential new infrastructure code), rather than using `tmt` specific logic.

There are other places that use `+` without a parent, like `prepare+` in plans, but that works fine. This is only about using fmf `filter` logic to filter tests, so we don't care about plans.

Without the change:
```
$ fmf ls --filter tag:-subset-profile
/hardening/host-os/ansible/anssi_bp28_high
/hardening/host-os/ansible/ccn_advanced
/hardening/host-os/ansible/cis
/hardening/host-os/ansible/cis_workstation_l2
/hardening/host-os/ansible/cui
/hardening/host-os/ansible/e8
/hardening/host-os/ansible/hipaa
/hardening/host-os/ansible/ism_o
/hardening/host-os/ansible/ospp
/hardening/host-os/ansible/pci-dss
/hardening/host-os/ansible/stig
/hardening/host-os/ansible/stig_gui
/hardening/host-os/oscap/anssi_bp28_high
/hardening/host-os/oscap/ccn_advanced
/hardening/host-os/oscap/cis
/hardening/host-os/oscap/cis_workstation_l2
/hardening/host-os/oscap/cui
/hardening/host-os/oscap/e8
/hardening/host-os/oscap/hipaa
/hardening/host-os/oscap/ism_o
/hardening/host-os/oscap/ospp
/hardening/host-os/oscap/pci-dss
/hardening/host-os/oscap/stig
/hardening/host-os/oscap/stig_gui
/per-rule/from-env/ansible
/per-rule/from-env/oscap
/scanning/oscap-debug/helgrind
/scanning/oscap-debug/sysctl-only
/scanning/oscap-debug/sysctl-oval-eval-parallel
/scanning/oscap-debug/vm-scan
/static-checks/diff/audit-sample-rules
/static-checks/diff/profile-rules
/static-checks/diff/profile-titles
/static-checks/diff/profile-variables
/static-checks/diff/profiles
```

With the change:
```
/hardening/anaconda/anssi_bp28_high
/hardening/anaconda/ccn_advanced
/hardening/anaconda/cis
/hardening/anaconda/cis_workstation_l2
/hardening/anaconda/cui
/hardening/anaconda/e8
/hardening/anaconda/hipaa
/hardening/anaconda/ism_o
/hardening/anaconda/ospp
/hardening/anaconda/pci-dss
/hardening/anaconda/stig
/hardening/anaconda/stig_gui
/hardening/anaconda/with-gui/anssi_bp28_high
/hardening/anaconda/with-gui/ccn_advanced
/hardening/anaconda/with-gui/cis
/hardening/anaconda/with-gui/cis_workstation_l2
/hardening/anaconda/with-gui/cui
/hardening/anaconda/with-gui/e8
/hardening/anaconda/with-gui/hipaa
/hardening/anaconda/with-gui/ism_o
/hardening/anaconda/with-gui/ospp
/hardening/anaconda/with-gui/pci-dss
/hardening/anaconda/with-gui/stig
/hardening/anaconda/with-gui/stig_gui
/hardening/ansible/anssi_bp28_high
/hardening/ansible/ccn_advanced
/hardening/ansible/cis
/hardening/ansible/cis_workstation_l2
/hardening/ansible/cui
/hardening/ansible/e8
/hardening/ansible/hipaa
/hardening/ansible/ism_o
/hardening/ansible/ospp
/hardening/ansible/pci-dss
/hardening/ansible/stig
/hardening/ansible/stig_gui
/hardening/ansible/uefi/anssi_bp28_high
/hardening/ansible/uefi/ccn_advanced
/hardening/ansible/uefi/cis
/hardening/ansible/uefi/cis_workstation_l2
/hardening/ansible/uefi/cui
/hardening/ansible/uefi/e8
/hardening/ansible/uefi/hipaa
/hardening/ansible/uefi/ism_o
/hardening/ansible/uefi/ospp
/hardening/ansible/uefi/pci-dss
/hardening/ansible/uefi/stig
/hardening/ansible/uefi/stig_gui
/hardening/ansible/with-gui/anssi_bp28_high
/hardening/ansible/with-gui/ccn_advanced
/hardening/ansible/with-gui/cis
/hardening/ansible/with-gui/cis_workstation_l2
/hardening/ansible/with-gui/cui
/hardening/ansible/with-gui/e8
/hardening/ansible/with-gui/hipaa
/hardening/ansible/with-gui/ism_o
/hardening/ansible/with-gui/ospp
/hardening/ansible/with-gui/pci-dss
/hardening/ansible/with-gui/stig
/hardening/ansible/with-gui/stig_gui
/hardening/container/anaconda-ostree/anssi_bp28_high
/hardening/container/anaconda-ostree/ccn_advanced
/hardening/container/anaconda-ostree/cis
/hardening/container/anaconda-ostree/cis_workstation_l2
/hardening/container/anaconda-ostree/cui
/hardening/container/anaconda-ostree/e8
/hardening/container/anaconda-ostree/hipaa
/hardening/container/anaconda-ostree/ism_o
/hardening/container/anaconda-ostree/ospp
/hardening/container/anaconda-ostree/pci-dss
/hardening/container/anaconda-ostree/stig
/hardening/container/anaconda-ostree/stig_gui
/hardening/container/bootc-image-builder/anssi_bp28_high
/hardening/container/bootc-image-builder/ccn_advanced
/hardening/container/bootc-image-builder/cis
/hardening/container/bootc-image-builder/cis_workstation_l2
/hardening/container/bootc-image-builder/cui
/hardening/container/bootc-image-builder/e8
/hardening/container/bootc-image-builder/hipaa
/hardening/container/bootc-image-builder/ism_o
/hardening/container/bootc-image-builder/ospp
/hardening/container/bootc-image-builder/pci-dss
/hardening/container/bootc-image-builder/stig
/hardening/container/bootc-image-builder/stig_gui
/hardening/host-os/ansible/anssi_bp28_high
/hardening/host-os/ansible/ccn_advanced
/hardening/host-os/ansible/cis
/hardening/host-os/ansible/cis_workstation_l2
/hardening/host-os/ansible/cui
/hardening/host-os/ansible/e8
/hardening/host-os/ansible/hipaa
/hardening/host-os/ansible/ism_o
/hardening/host-os/ansible/ospp
/hardening/host-os/ansible/pci-dss
/hardening/host-os/ansible/stig
/hardening/host-os/ansible/stig_gui
/hardening/host-os/oscap/anssi_bp28_high
/hardening/host-os/oscap/ccn_advanced
/hardening/host-os/oscap/cis
/hardening/host-os/oscap/cis_workstation_l2
/hardening/host-os/oscap/cui
/hardening/host-os/oscap/e8
/hardening/host-os/oscap/hipaa
/hardening/host-os/oscap/ism_o
/hardening/host-os/oscap/ospp
/hardening/host-os/oscap/pci-dss
/hardening/host-os/oscap/stig
/hardening/host-os/oscap/stig_gui
/hardening/image-builder/anssi_bp28_high
/hardening/image-builder/ccn_advanced
/hardening/image-builder/cis
/hardening/image-builder/cis_workstation_l2
/hardening/image-builder/cui
/hardening/image-builder/e8
/hardening/image-builder/hipaa
/hardening/image-builder/ism_o
/hardening/image-builder/ospp
/hardening/image-builder/pci-dss
/hardening/image-builder/stig
/hardening/image-builder/stig_gui
/hardening/image-builder/uefi/anssi_bp28_high
/hardening/image-builder/uefi/ccn_advanced
/hardening/image-builder/uefi/cis
/hardening/image-builder/uefi/cis_workstation_l2
/hardening/image-builder/uefi/cui
/hardening/image-builder/uefi/e8
/hardening/image-builder/uefi/hipaa
/hardening/image-builder/uefi/ism_o
/hardening/image-builder/uefi/ospp
/hardening/image-builder/uefi/pci-dss
/hardening/image-builder/uefi/stig
/hardening/image-builder/uefi/stig_gui
/hardening/kickstart/anssi_bp28_high
/hardening/kickstart/ccn_advanced
/hardening/kickstart/cis
/hardening/kickstart/cis_workstation_l2
/hardening/kickstart/cui
/hardening/kickstart/e8
/hardening/kickstart/hipaa
/hardening/kickstart/ism_o
/hardening/kickstart/ospp
/hardening/kickstart/pci-dss
/hardening/kickstart/stig
/hardening/kickstart/stig_gui
/hardening/kickstart/uefi/anssi_bp28_high
/hardening/kickstart/uefi/ccn_advanced
/hardening/kickstart/uefi/cis
/hardening/kickstart/uefi/cis_workstation_l2
/hardening/kickstart/uefi/cui
/hardening/kickstart/uefi/e8
/hardening/kickstart/uefi/hipaa
/hardening/kickstart/uefi/ism_o
/hardening/kickstart/uefi/ospp
/hardening/kickstart/uefi/pci-dss
/hardening/kickstart/uefi/stig
/hardening/kickstart/uefi/stig_gui
/hardening/kickstart/with-gui/anssi_bp28_high
/hardening/kickstart/with-gui/ccn_advanced
/hardening/kickstart/with-gui/cis
/hardening/kickstart/with-gui/cis_workstation_l2
/hardening/kickstart/with-gui/cui
/hardening/kickstart/with-gui/e8
/hardening/kickstart/with-gui/hipaa
/hardening/kickstart/with-gui/ism_o
/hardening/kickstart/with-gui/ospp
/hardening/kickstart/with-gui/pci-dss
/hardening/kickstart/with-gui/stig
/hardening/kickstart/with-gui/stig_gui
/hardening/oscap/anssi_bp28_high
/hardening/oscap/ccn_advanced
/hardening/oscap/cis
/hardening/oscap/cis_workstation_l2
/hardening/oscap/cui
/hardening/oscap/e8
/hardening/oscap/hipaa
/hardening/oscap/ism_o
/hardening/oscap/old-new/anssi_bp28_high
/hardening/oscap/old-new/ccn_advanced
/hardening/oscap/old-new/cis
/hardening/oscap/old-new/cis_workstation_l2
/hardening/oscap/old-new/cui
/hardening/oscap/old-new/e8
/hardening/oscap/old-new/hipaa
/hardening/oscap/old-new/ism_o
/hardening/oscap/old-new/ospp
/hardening/oscap/old-new/pci-dss
/hardening/oscap/old-new/stig
/hardening/oscap/old-new/stig_gui
/hardening/oscap/ospp
/hardening/oscap/pci-dss
/hardening/oscap/stig
/hardening/oscap/stig_gui
/hardening/oscap/uefi/anssi_bp28_high
/hardening/oscap/uefi/ccn_advanced
/hardening/oscap/uefi/cis
/hardening/oscap/uefi/cis_workstation_l2
/hardening/oscap/uefi/cui
/hardening/oscap/uefi/e8
/hardening/oscap/uefi/hipaa
/hardening/oscap/uefi/ism_o
/hardening/oscap/uefi/ospp
/hardening/oscap/uefi/pci-dss
/hardening/oscap/uefi/stig
/hardening/oscap/uefi/stig_gui
/hardening/oscap/with-gui/anssi_bp28_high
/hardening/oscap/with-gui/ccn_advanced
/hardening/oscap/with-gui/cis
/hardening/oscap/with-gui/cis_workstation_l2
/hardening/oscap/with-gui/cui
/hardening/oscap/with-gui/e8
/hardening/oscap/with-gui/hipaa
/hardening/oscap/with-gui/ism_o
/hardening/oscap/with-gui/ospp
/hardening/oscap/with-gui/pci-dss
/hardening/oscap/with-gui/stig
/hardening/oscap/with-gui/stig_gui
/per-rule/1/ansible
/per-rule/1/oscap
/per-rule/10/ansible
/per-rule/10/oscap
/per-rule/11/ansible
/per-rule/11/oscap
/per-rule/12/ansible
/per-rule/12/oscap
/per-rule/13/ansible
/per-rule/13/oscap
/per-rule/14/ansible
/per-rule/14/oscap
/per-rule/15/ansible
/per-rule/15/oscap
/per-rule/2/ansible
/per-rule/2/oscap
/per-rule/3/ansible
/per-rule/3/oscap
/per-rule/4/ansible
/per-rule/4/oscap
/per-rule/5/ansible
/per-rule/5/oscap
/per-rule/6/ansible
/per-rule/6/oscap
/per-rule/7/ansible
/per-rule/7/oscap
/per-rule/8/ansible
/per-rule/8/oscap
/per-rule/9/ansible
/per-rule/9/oscap
/per-rule/from-env/ansible
/per-rule/from-env/oscap
/scanning/disa-alignment/anaconda
/scanning/disa-alignment/ansible
/scanning/disa-alignment/oscap
/scanning/oscap-debug/helgrind
/scanning/oscap-debug/sysctl-only
/scanning/oscap-debug/sysctl-oval-eval-parallel
/scanning/oscap-debug/vm-scan
/scanning/oscap-eval
/static-checks/ansible/allowed-modules
/static-checks/ansible/syntax-check
/static-checks/diff/audit-sample-rules
/static-checks/diff/profile-rules
/static-checks/diff/profile-titles
/static-checks/diff/profile-variables
/static-checks/diff/profiles
/static-checks/html-links
/static-checks/nist-validation
/static-checks/removed-rules
/static-checks/rpmbuild-ctest
/static-checks/rule-identifiers
/static-checks/unit-tests-metadata
```