### PR TITLE
Update waivers for crypto policy rules

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -236,4 +236,12 @@
 /scanning/disa-alignment/.+/audit_privileged_commands_.+
     rhel == 9
 
+# These rules require OpenSCAP 1.3.12 or 1.4.2 to pass because they depend on
+# processing negative numbers by textfilecontent54_probe which is fixed by
+# https://github.com/OpenSCAP/openscap/pull/2210
+/hardening/.+/configure_gnutls_tls_crypto_policy
+/hardening/.+/harden_sshd_ciphers_opensshserver_conf_crypto_policy
+/hardening/.+/harden_sshd_macs_opensshserver_conf_crypto_policy
+    rhel == 8
+
 # vim: syntax=python


### PR DESCRIPTION
These waivers are added to be able to merge the pull request https://github.com/ComplianceAsCode/content/pull/13374 This PR adds changes that work only with new OpenSCAP, but the new OpenSCAP hasn't been shipped in CentOS/RHEL yet, which means the Testing farm tests fail in CI gating. At the same time, we don't want to delay the PR. Therefore, we introduce this waiver, that can be removed once the new OpenSCAP is released.

Specifically, these rules require OpenSCAP 1.3.12 or 1.4.2 to pass because they depend on processing negative numbers by textfilecontent54_probe which is fixed by
https://github.com/OpenSCAP/openscap/pull/2210