### PR TITLE
Extend OSPP crypto policy exclusion to CentOS Stream 10 as well

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -35,7 +35,7 @@ def excludes():
             'ensure_gpgcheck_repo_metadata',
         ]
         # Remove when CentOS repos use at least 3072b RSA key
-        if versions.rhel.major == 9 and re.fullmatch(r'/hardening/.+/ospp', test_name):
+        if versions.rhel.major in [9,10] and re.fullmatch(r'/hardening/.+/ospp', test_name):
             rules += [
                 'configure_crypto_policy',
                 'enable_fips_mode',

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -111,7 +111,7 @@ adjust:
                 | sed 's/ .*//'
             }
             rpms=$(list_foreign_rpms)
-            [[ $rpms ]] && dnf downgrade -y --skip-broken $rpms
+            [[ $rpms ]] && dnf downgrade -y --skip-broken $rpms || true
             rpms=$(list_foreign_rpms)
             [[ $rpms ]] && dnf remove -y --noautoremove $rpms
             dnf clean all


### PR DESCRIPTION
This should fix CentOS Stream 10, which seems to have the same issue, ie.
```
Curl error (35): SSL connect error for https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/x86_64/toplink/vol/koji02/packages/dnf/4.20.0/14.el10/noarch/dnf-automatic-4.20.0-14.el10.noarch.rpm [TLS connect error: error:0A0000B5:SSL routines::no ciphers available]
```

The other commit (see its commit msg) is unrelated, but a small fix to a recent https://github.com/RHSecurityCompliance/contest/pull/402 and I forgot I had it on my branch, but hopefully it's not a big deal here.