### PR TITLE
install/use `rngd` on rhel-8 host-os tests

### DIFF
--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -48,6 +48,11 @@ adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
+      - when: distro == rhel-8
+        require+: [rng-tools]
+        because: >
+            RHEL-8 doesn't have fast /dev/random under OSPP/CUI,
+            compensate with rngd
 
 /e8:
 
@@ -60,6 +65,11 @@ adjust+:
       - when: distro >= rhel-10
         enabled: false
         because: there is no OSPP profile on RHEL-10+
+      - when: distro == rhel-8
+        require+: [rng-tools]
+        because: >
+            RHEL-8 doesn't have fast /dev/random under OSPP/CUI,
+            compensate with rngd
 
 /pci-dss:
 

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -40,6 +40,11 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no CUI profile on RHEL-10+
+      - when: distro == rhel-8
+        require+: [rng-tools]
+        because: >
+            RHEL-8 doesn't have fast /dev/random under OSPP/CUI,
+            compensate with rngd
 
 /e8:
 
@@ -52,6 +57,11 @@ tag:
       - when: distro >= rhel-10
         enabled: false
         because: there is no OSPP profile on RHEL-10+
+      - when: distro == rhel-8
+        require+: [rng-tools]
+        because: >
+            RHEL-8 doesn't have fast /dev/random under OSPP/CUI,
+            compensate with rngd
 
 /pci-dss:
 


### PR DESCRIPTION
This fixes random (mostly non-x86_64) sshd timeouts and session closing:
```
    Warning: Permanently added '<host>' to the list of known hosts.
    Authorized users only. All activity may be monitored and reported.
    Connection closed by <host> port 22
```

We haven't discovered this sooner likely due to heavy re-runs and the fact that this manifests only on some physical systems, eg. not our x86 VMs where a kernel-level `hwrng` daemon forwards entropy from `virtio-rng`.