### PR TITLE
Increase VM RAM to 4096 MB

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -18,7 +18,7 @@ require+:
   - createrepo
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -22,7 +22,7 @@ recommend+:
   - rhc-worker-playbook
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -20,7 +20,7 @@ require+:
   - podman
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -20,7 +20,7 @@ require+:
   - podman
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -22,7 +22,7 @@ require+:
   - composer-cli
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -20,7 +20,7 @@ require+:
   - openscap-scanner
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -18,7 +18,7 @@ require+:
   - createrepo
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -104,7 +104,7 @@ NETWORK_EXPIRY = 168
 # installing from HTTP URL leads to Anaconda downloading stage2
 # to RAM, leading to notably higher memory requirements during
 # installation
-INSTALL_TIME_RAM = 3072  # in MBs
+INSTALL_TIME_RAM = 4096  # in MBs
 
 # as byte-strings
 INSTALL_FAILURES = [

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -34,7 +34,7 @@ recommend+:
   - rhc-worker-playbook
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/scanning/disa-alignment/main.fmf
+++ b/scanning/disa-alignment/main.fmf
@@ -12,7 +12,7 @@ require+:
   - createrepo
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false

--- a/scanning/oscap-debug/vm-scan.fmf
+++ b/scanning/oscap-debug/vm-scan.fmf
@@ -15,7 +15,7 @@ require+:
   - createrepo
 extra-hardware: |
     keyvalue = HVM=1
-    hostrequire = memory>=3720
+    hostrequire = memory>=6000
 adjust+:
   - when: arch != x86_64
     enabled: false


### PR DESCRIPTION
Newer Fedoras and RHELs require more than the suggested 3072 MB, per `libosinfo` database for Fedora 41+:

```
$ grep -C2 ram /usr/share/osinfo/os/fedoraproject.org/fedora-41.xml
        <n-cpus>1</n-cpus>
        <cpu>2000000000</cpu>
        <ram>2147483648</ram>
        <storage>16106127360</storage>
      </minimum>
      <recommended>
        <ram>4294967296</ram>
        <storage>21474836480</storage>
      </recommended>
```

Also fix outdated / wrong `main.fmf` requirements - those are for systems that will run nested VMs, so they themselves require more RAM (for the OS itself + nested VM).