### PR TITLE
Remove waiver for productization issue #13550

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -9,12 +9,6 @@
 /hardening/container/.+/ensure_pam_wheel_group_empty
     rhel == 9 or rhel == 10
 
-# https://github.com/ComplianceAsCode/content/issues/13550
-/hardening/container/.+/sebool_polyinstantiation_enabled
-/hardening/container/.+/sebool_selinuxuser_execstack
-/hardening/container/.+/sebool_selinuxuser_execmod
-    rhel == 9 or rhel == 10
-
 # https://github.com/ComplianceAsCode/content/issues/13287
 # The old-new test for enable_fips_mode rules is failing
 /hardening/oscap/old-new/.*/enable_fips_mode


### PR DESCRIPTION
The issue https://github.com/ComplianceAsCode/content/issues/13550 is closed. It has been fixed or worked around by
https://github.com/ComplianceAsCode/content/pull/13645. As of 2025-07-14, the issue doesn't appear in daily productization. Also, I can't reproduce it locally using autocontest. I used current upstream master as of HEAD f78aeca. In the HTML report, all 3 rules listed in the description are passing. They pass both on RHEL 9 and 10.