### PR TITLE
Remove waiver for productization issue #13551 and #13552

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -1,14 +1,6 @@
 # waivers for content issues found during productization (stabilization) testing
 # approximately sorted by test categories and history
 
-# https://github.com/ComplianceAsCode/content/issues/13552
-/hardening/container/.+/account_password_selinux_faillock_dir
-    rhel == 9 or rhel == 10
-
-# https://github.com/ComplianceAsCode/content/issues/13551
-/hardening/container/.+/ensure_pam_wheel_group_empty
-    rhel == 9 or rhel == 10
-
 # https://github.com/ComplianceAsCode/content/issues/13287
 # The old-new test for enable_fips_mode rules is failing
 /hardening/oscap/old-new/.*/enable_fips_mode


### PR DESCRIPTION
Issues https://github.com/ComplianceAsCode/content/issues/13551 and https://github.com/ComplianceAsCode/content/issues/13551 have been closed. They have been fixed or worked around by
https://github.com/ComplianceAsCode/content/pull/13645. As of 2025-07-14, these issues don't appear in daily productization. Also, I can't reproduce them locally using autocontest. I used current upstream master as of HEAD f78aeca. In the HTML reports they pass on both RHEL 9 and RHEL 10.