### PR TITLE
Remove waiver for 13287

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -1,12 +1,6 @@
 # waivers for content issues found during productization (stabilization) testing
 # approximately sorted by test categories and history
 
-# https://github.com/ComplianceAsCode/content/issues/13287
-# The old-new test for enable_fips_mode rules is failing
-/hardening/oscap/old-new/.*/enable_fips_mode
-    rhel == 8 or rhel == 9
-
-
 # https://github.com/ComplianceAsCode/content/issues/12561
 /scanning/disa-alignment/.*/logind_session_timeout
     rhel == 8


### PR DESCRIPTION
Using custom GitLab pipeline I have discovered that this issue isn't reproducible any more. I use current upstream master as as of 2025-07-16 as of HEAD 2738622. In contest report, all occurences of enable_fips_mode in old-new are shown as "waived pass" on both RHEL 8.10 and RHEL 9.6.