### PR TITLE
Remove waivers of issue #13034

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -13,15 +13,6 @@
 # https://github.com/ComplianceAsCode/content/issues/13033
 /scanning/disa-alignment/(oscap|ansible)/file_permission_user_init_files_root
     rhel == 8
-# https://github.com/ComplianceAsCode/content/issues/13034
-/scanning/disa-alignment/.*/grub2_pti_argument
-/scanning/disa-alignment/.*/grub2_vsyscall_argument
-/scanning/disa-alignment/.*/grub2_page_poison_argument
-/scanning/disa-alignment/.*/grub2_audit_argument
-/scanning/disa-alignment/.*/grub2_audit_backlog_limit_argument
-    rhel == 8
-/scanning/disa-alignment/.*/grub2_slub_debug_argument
-    rhel == 8 or rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/11804
 /scanning/disa-alignment/.*/harden_sshd_ciphers_openssh_conf_crypto_policy
 # https://github.com/ComplianceAsCode/content/issues/11692


### PR DESCRIPTION
The issue https://github.com/ComplianceAsCode/content/issues/13034 has been closed because:
- rule grub2_slub_debug_argument isn't part of RHEL 9 stig profile now
- the affected rules on RHEL 8 STIG rules no longer have corresponding rules in DISA SCAP content. See the comments in the issue.