### PR TITLE
Resolve crypto policy rules alignment with DISA

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -26,11 +26,6 @@
 # https://github.com/ComplianceAsCode/content/issues/11802
 /scanning/disa-alignment/[^/]+/auditd_audispd_configure_sufficiently_large_partition
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13108
-/scanning/disa-alignment/.*/configure_crypto_policy
-/scanning/disa-alignment/.*/configure_kerberos_crypto_policy
-/scanning/disa-alignment/.*/configure_libreswan_crypto_policy
-    rhel == 9 or rhel == 8
 # https://github.com/ComplianceAsCode/content/issues/13109
 /scanning/disa-alignment/.+/file_permissions_sshd_config
 /scanning/disa-alignment/.+/file_permissions_sshd_drop_in_config

--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -26,7 +26,7 @@ with util.BackgroundHTTPServer(virt.NETWORK_HOST, 0) as srv:
     }
     ks.add_oscap_addon(oscap_conf)
 
-    g.install(kickstart=ks)
+    g.install(kickstart=ks, kernel_args=['fips=1'])
 
 with g.booted(), util.get_source_content() as content_dir:
     g.copy_to(util.get_datastream(), 'ssg-ds.xml')

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -16,7 +16,7 @@ g = virt.Guest(guest_tag)
 
 if not g.can_be_snapshotted():
     ks = virt.Kickstart(partitions=partitions.partitions)
-    g.install(kickstart=ks)
+    g.install(kickstart=ks, kernel_args=['fips=1'])
     g.prepare_for_snapshot()
 
 # the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -12,7 +12,7 @@ g = virt.Guest(guest_tag)
 
 if not g.can_be_snapshotted():
     ks = virt.Kickstart(partitions=partitions.partitions)
-    g.install(kickstart=ks)
+    g.install(kickstart=ks, kernel_args=['fips=1'])
     g.prepare_for_snapshot()
 
 with g.snapshotted():


### PR DESCRIPTION
This change will resolve https://github.com/ComplianceAsCode/content/issues/13108.

In the current upstream content, the only rule reported by disa-alignment test as misaligned with DISA is configure_crypto_policy on RHEL 9. But, the misalignment is reported because the testing VM doesn't run in FIPS mode. (See the
https://github.com/ComplianceAsCode/content/issues/13108 for more explanation.)

The STIG profiles require the system to be run in FIPS mode. We think that to get more natural results in the disa-alignment test we should install the VM on which the test runs in FIPS mode as well.

Running the testing VM in FIPS mode will cause that the misalignment on configure_crypto_policy won't be reported by the test.