### PR TITLE
Handle CentOS Stream not having a minor version

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -120,11 +120,11 @@
 /hardening/kickstart(/with-gui|/uefi)?/(hipaa|stig|stig_gui)/service_kdump_disabled
     rhel == 10
 
-# caused by one of:
-# - bz1778661 (abrt)
-# - bz2209266 (RHEL-9 gdm)
+# /run/fapolicyd file mode and groupownership differes from RPM database
+# RHEL 9: https://issues.redhat.com/browse/RHEL-59626
+# RHEL 10: https://issues.redhat.com/browse/RHEL-94536
 /hardening/.+/rpm_verify_(ownership|permissions)
-    True
+    (rhel == 9 and rhel <= 9.6) or rhel == 10.0
 
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587

--- a/lib/versions.py
+++ b/lib/versions.py
@@ -23,7 +23,10 @@ class _Rhel:
         version = str(version)
         major, _, minor = version.partition('.')
         self.major = int(major)
-        self.minor = int(minor) if minor else None
+        # to make version comparison on CentOS Stream possible we assign
+        # it a minor version of 999 as CentOS Stream is always the latest
+        # minor version of RHEL
+        self.minor = int(minor) if minor else 999
 
     @staticmethod
     def is_true_rhel():


### PR DESCRIPTION
Fixes issues on CentOS Stream like https://artifacts.dev.testing-farm.io/a9060e0c-fe03-48b9-bdc8-a7638e92b352/