### PR TITLE
Account for profiles have multiple reference URLs in `rule-identifiers`

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -26,12 +26,9 @@
 /static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
     True
 
-# no STIG ID, but the rule is needed for other authselect rules
-/static-checks/rule-identifiers/stig/enable_authselect
-    rhel == 8
 # no STIG ID for CentOS products
-/static-checks/rule-identifiers/stig/.*
-    rhel.is_centos() and note == 'missing https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux'
+/static-checks/rule-identifiers/stig/stigid/.*
+    rhel.is_centos()
 
 # DISA benchmark allows only released OS versions. Our content is fine with unreleased versions.
 # https://github.com/ComplianceAsCode/content/issues/11649

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -78,18 +78,32 @@
 /scanning/disa-alignment/.+/sysctl_net_ipv4_conf_default_rp_filter
     rhel == 9
 
-# RHEL10 - No official RHEL10 STIG/CIS benchmark yet
-/static-checks/rule-identifiers/(stig|cis.*)/.*
+# RHEL10 - No official RHEL10 STIG benchmark yet
+/static-checks/rule-identifiers/stig/stigid/.*
     rhel == 10
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
-# RHEL9 https://github.com/ComplianceAsCode/content/issues/12425
-/static-checks/rule-identifiers/ospp/.*
-    rhel == 8 or rhel == 9
+/static-checks/rule-identifiers/ospp/ospp/.*
+    rhel == 8
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
 # RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
 # RHEL10 https://github.com/ComplianceAsCode/content/issues/12430
-/static-checks/rule-identifiers/ism_o/.*
-    rhel == 8 or rhel == 9 or rhel == 10
+/static-checks/rule-identifiers/ism_o/ism/.*
+    True
+
+# https://github.com/ComplianceAsCode/content/issues/13856
+/static-checks/rule-identifiers/stig/os-srg/package_sssd_installed
+/static-checks/rule-identifiers/stig/os-srg/service_sssd_enabled
+    rhel == 10
+
+# https://github.com/ComplianceAsCode/content/issues/13857
+/static-checks/rule-identifiers/anssi_bp28_high/anssi/service_chronyd_enabled
+    rhel == 8 or rhel == 10
+/static-checks/rule-identifiers/anssi_bp28_high/anssi/audit_rules_mac_modification_etc_selinux
+    rhel == 10
+/static-checks/rule-identifiers/anssi_bp28_high/anssi/no_nis_in_nsswitch
+/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_tls_cacertpath
+/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_start_tls
+    rhel == 8
 
 # https://github.com/ComplianceAsCode/content/issues/13128
 /hardening/ansible/.+/network_nmcli_permissions

--- a/static-checks/rule-identifiers/test.py
+++ b/static-checks/rule-identifiers/test.py
@@ -9,8 +9,8 @@ from lib import util, results, oscap
 profile_references = {
     # srg, disa, stigid@PRODUCT or controls file
     'stig': {
-        'stigid': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
-        'os-srg': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
+        'stigid': 'https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
+        'os-srg': 'https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
     },
     # ospp
     'ospp': {


### PR DESCRIPTION
This fixes repeated `pass` + `warn` entries for the same result name, ie.
```
2025-09-01 12:11:26 test.py:45: lib.results.report_plain:238: PASS stig/directory_group_ownership_var_log_audit (waived pass)
2025-09-01 12:11:26 test.py:47: lib.results.report_plain:238: WARN stig/directory_group_ownership_var_log_audit ((waived fail) missing https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux)
```
by introducing a reference "name" that is different for each URL.

A potential future improvement has been filed as https://github.com/RHSecurityCompliance/contest/issues/454 .