### PR TITLE
Clean waivers after 0.1.78 stabilization

### DIFF
--- a/conf/waivers/infrastructure
+++ b/conf/waivers/infrastructure
@@ -11,7 +11,6 @@
 /(hardening|scanning)/.+/ensure_gpgcheck_never_disabled
 # we don't control partitions on the host OS
 /hardening/host-os/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit|tmp)_(noexec|nosuid|nodev|usrquota|grpquota)
-/hardening/host-os/.+/mount_option_boot_efi_nosuid
     True
 # Beaker and host-os seem to randomly fail any services enabled
 # TODO: probably worth further investigation, but likely not a content issue

--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -34,10 +34,6 @@
 # https://github.com/ComplianceAsCode/content/issues/11649
 /scanning/disa-alignment/.*/installed_OS_is_vendor_supported
     True
-# This sysctl setting breaks some services and according to STIG it can be skipped if there is a need
-# https://github.com/ComplianceAsCode/content/pull/12824
-/scanning/disa-alignment/.*/sysctl_user_max_user_namespaces
-    rhel >= 9
 
 # Rules checking if OS is FIPS certified
 /hardening/host-os/.+/sshd_use_approved_.+
@@ -48,7 +44,7 @@
 # Presumably not valid for CentOS, see also conf/remediation.py
 /hardening/.+/ospp/enable_fips_mode
 /hardening/.*/ospp/configure_crypto_policy
-    rhel.is_centos() and (rhel == 9 or rhel == 10)
+    rhel.is_centos()
 
 # Caused by SCE content being built by default, enabled
 # in https://github.com/ComplianceAsCode/content/pull/12488

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -4,68 +4,23 @@
 # https://github.com/ComplianceAsCode/content/issues/12561
 /scanning/disa-alignment/.*/logind_session_timeout
     rhel == 8
-# https://github.com/ComplianceAsCode/content/issues/13033
-/scanning/disa-alignment/(oscap|ansible)/file_permission_user_init_files_root
-    rhel == 8
-# https://github.com/ComplianceAsCode/content/issues/11804
-/scanning/disa-alignment/.*/harden_sshd_ciphers_openssh_conf_crypto_policy
-# https://github.com/ComplianceAsCode/content/issues/11692
-/scanning/disa-alignment/.*/accounts_password_pam_pwhistory_remember_system_auth
-# https://github.com/ComplianceAsCode/content/issues/11695
-/scanning/disa-alignment/.*/service_pcscd_enabled
 # https://github.com/ComplianceAsCode/content/issues/11698
 /scanning/disa-alignment/.*/no_shelllogin_for_systemaccounts
-# https://github.com/ComplianceAsCode/content/issues/11802
-/scanning/disa-alignment/.*/CCE-88173-0
-# https://github.com/ComplianceAsCode/content/issues/11703
-/scanning/disa-alignment/.*/file_permissions_library_dirs
 # https://github.com/ComplianceAsCode/content/issues/12573
 /scanning/disa-alignment/.*/sshd_set_keepalive
-# https://github.com/ComplianceAsCode/content/issues/11693
-/scanning/disa-alignment/(oscap|ansible)/accounts_password_pam_retry
 # https://github.com/ComplianceAsCode/content/issues/11802
 /scanning/disa-alignment/[^/]+/auditd_audispd_configure_sufficiently_large_partition
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13109
-/scanning/disa-alignment/.+/file_permissions_sshd_config
-/scanning/disa-alignment/.+/file_permissions_sshd_drop_in_config
-    rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13110
-/scanning/disa-alignment/anaconda/ensure_gpgcheck_globally_activated
-    rhel == 8
 # https://github.com/ComplianceAsCode/content/issues/9307 (DISA issue)
 /scanning/disa-alignment/.*/sysctl_kernel_yama_ptrace_scope
-# https://github.com/ComplianceAsCode/content/issues/10044 (DISA issue)
-/scanning/disa-alignment/.*/accounts_password_pam_pwhistory_remember_password_auth
 # https://github.com/ComplianceAsCode/content/issues/11197 (DISA issue)
 /scanning/disa-alignment/.*/display_login_attempts
-    rhel == 8 or rhel == 9
-# the feature used in this stigid is not ported to 9.0
-/scanning/disa-alignment/.*/CCE-90785-7
-    rhel == 9.0
-# https://github.com/ComplianceAsCode/content/issues/11778 (issue on DISA side)
-/scanning/disa-alignment/.*/file_permission_user_init_files_root
-    rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13006 (issues on both sides)
-/scanning/disa-alignment/.*/mount_option_boot_efi_nosuid
     rhel == 8 or rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/13011
 /scanning/disa-alignment/.*/accounts_password_pam_pwquality_retry
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13021
-/scanning/disa-alignment/.*/directory_permissions_sshd_config_d
-    rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13160
-/scanning/disa-alignment/.+/rootfiles_configured
-    rhel == 8 or rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/13236
 /scanning/disa-alignment/ansible/networkmanager_dns_mode
-    rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13272
-/scanning/disa-alignment/.*/audit_rules_.+
-    True
-# https://github.com/ComplianceAsCode/content/issues/13391
-/scanning/disa-alignment/.+/logind_session_timeout
     rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/13676
 /scanning/disa-alignment/.*/coredump_disable_.+
@@ -76,37 +31,6 @@
 
 # https://github.com/ComplianceAsCode/content/issues/13828
 /scanning/disa-alignment/.+/sysctl_net_ipv4_conf_default_rp_filter
-    rhel == 9
-
-# RHEL10 - No official RHEL10 STIG benchmark yet
-/static-checks/rule-identifiers/stig/stigid/.*
-    rhel == 10
-# RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
-/static-checks/rule-identifiers/ospp/ospp/.*
-    rhel == 8
-# RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
-# RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
-# RHEL10 https://github.com/ComplianceAsCode/content/issues/12430
-/static-checks/rule-identifiers/ism_o/ism/.*
-    True
-
-# https://github.com/ComplianceAsCode/content/issues/13856
-/static-checks/rule-identifiers/stig/os-srg/package_sssd_installed
-/static-checks/rule-identifiers/stig/os-srg/service_sssd_enabled
-    rhel == 10
-
-# https://github.com/ComplianceAsCode/content/issues/13857
-/static-checks/rule-identifiers/anssi_bp28_high/anssi/service_chronyd_enabled
-    rhel == 8 or rhel == 10
-/static-checks/rule-identifiers/anssi_bp28_high/anssi/audit_rules_mac_modification_etc_selinux
-    rhel == 10
-/static-checks/rule-identifiers/anssi_bp28_high/anssi/no_nis_in_nsswitch
-/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_tls_cacertpath
-/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_start_tls
-    rhel == 8
-
-# https://github.com/ComplianceAsCode/content/issues/13128
-/hardening/ansible/.+/network_nmcli_permissions
     rhel == 9
 
 # bz1825810 or maybe bz1929805
@@ -131,10 +55,6 @@
 # https://github.com/ComplianceAsCode/content/issues/13175
 /hardening/anaconda/.+/enable_gpgcheck_for_all_repositories
     rhel == 8
-
-# https://github.com/ComplianceAsCode/content/issues/13100
-/hardening/.*/file_permission_user_init_files_root
-    True
 
 # kdump being forcibly enabled somewhere
 # https://github.com/ComplianceAsCode/content/issues/12832
@@ -167,13 +87,8 @@
 /hardening/kickstart/.+/service_avahi-daemon_disabled
 /hardening/kickstart/.+/socket_systemd-journal-remote_disabled
 /hardening/kickstart/.+/service_bluetooth_disabled
-/hardening/kickstart/.+/service_nftables_disabled
 /hardening/kickstart/.+/systemd_tmp_mount_enabled
     True
-
-# RHEL 9 and 10 are not FIPS certified yet
-/hardening/.+/aide_use_fips_hashes
-    rhel >= 9
 
 # https://github.com/ComplianceAsCode/content/issues/12942
 # https://issues.redhat.com/browse/RHEL-4722
@@ -181,21 +96,10 @@
 /hardening/anaconda/ospp/enable_fips_mode
 /hardening/anaconda/.+/configure_gnutls_tls_crypto_policy
 /hardening/anaconda/.+/harden_sshd_ciphers_openssh_conf_crypto_policy
-/hardening/anaconda/.+/harden_sshd_ciphers_opensshserver_conf_crypto_policy
-/hardening/anaconda/.+/harden_sshd_macs_openssh_conf_crypto_policy
-/hardening/anaconda/.+/harden_sshd_macs_opensshserver_conf_crypto_policy
     rhel == 8
-
-# OAA just failed without an error, as usual
-# https://issues.redhat.com/browse/OPENSCAP-3321
-# seems to be happening much more reliably with GUI
-/hardening/anaconda/with-gui/cis_workstation_l[12]
-    status == 'error'
 
 # https://github.com/ComplianceAsCode/content/issues/11565
 /hardening/image-builder/.*/audit_rules_privileged_commands
-# https://github.com/ComplianceAsCode/content/issues/11566
-/hardening/image-builder/.+/sebool_selinuxuser_execstack
 # https://github.com/ComplianceAsCode/content/issues/11567
 /hardening/image-builder/.*/enable_dracut_fips_module
 /hardening/image-builder/.*/enable_fips_mode
@@ -205,13 +109,6 @@
 /hardening/image-builder/ccn_[^/]+
     rhel == 9 and status == 'error'
 
-# rule accounts_password_pam_retry passes during initial scan but it is then
-# broken by the enable_authselect rule remediation (as on RHEL9 bootc container
-# image there is no default authselect profile selected); there is a documentation
-# informing users to select default authselect profile in a Containerfile
-# until https://issues.redhat.com/browse/RHEL-82079 is fixed (9.7+)
-/hardening/container/[^/]+/[^/]+/accounts_password_pam_retry
-    rhel == 9
 # https://issues.redhat.com/browse/RHEL-77158
 # (we unselect max_age in conf/remediations.py)
 /hardening/container/anaconda-ostree/.+/accounts_password_set_min_life_existing
@@ -219,10 +116,6 @@
 # https://github.com/ComplianceAsCode/content/issues/13214
 /hardening/container/(anaconda-ostree|bootc-image-builder|old-new)/.+/dir_perms_world_writable_sticky_bits
     True
-# https://github.com/ComplianceAsCode/content/issues/13296
-/scanning/disa-alignment/.+/audit_privileged_commands_.+
-    rhel == 9
-
 # File /boot/grub2/grub2.cfg is created with lenient permissions by
 # bootupd during the installation of a bootable container image.
 # https://github.com/coreos/bootupd/issues/952
@@ -237,11 +130,8 @@
 # processing negative numbers by textfilecontent54_probe which is fixed by
 # https://github.com/OpenSCAP/openscap/pull/2210
 # https://github.com/ComplianceAsCode/content/issues/13412
-/hardening/.+/configure_gnutls_tls_crypto_policy
 /hardening/.+/harden_sshd_ciphers_(openssh|opensshserver)_conf_crypto_policy
 /hardening/.+/harden_sshd_macs_(openssh|opensshserver)_conf_crypto_policy
-/per-rule/.+/harden_sshd_ciphers_(openssh|opensshserver)_conf_crypto_policy
-/per-rule/.+/harden_sshd_macs_(openssh|opensshserver)_conf_crypto_policy
     rhel == 8
 
 # https://github.com/ComplianceAsCode/content/issues/13690
@@ -254,19 +144,7 @@
 /per-rule/.+/file_permissions_unauthorized_world_writable/world_writable_tmp.fail
     True
 
-# https://github.com/ComplianceAsCode/content/issues/13737
-/hardening/kickstart/with-gui/stig_gui/dconf_gnome_login_banner_text
-/hardening/oscap/with-gui/stig_gui/dconf_gnome_login_banner_text
-/hardening/anaconda/with-gui/stig_gui/dconf_gnome_login_banner_text
-    True
-
-# https://github.com/ComplianceAsCode/content/issues/13743
-/hardening/host-os/ansible/cis/file_permission_user_init_files
-/hardening/host-os/ansible/cis_workstation_l2/file_permission_user_init_files
-    rhel  == 10
-
 # https://github.com/ComplianceAsCode/content/issues/13844
-/hardening/.+/bsi/rpm_verify_permissions
 /hardening/.+/bsi/file_permissions_cron.*
 /hardening/container/.+/bsi/file_permissions_efi_grub2_cfg
     rhel == 9

--- a/scripts/find_invalid_waivers.py
+++ b/scripts/find_invalid_waivers.py
@@ -106,7 +106,6 @@ def match_result_mark_waiver(regexes_matched_list, version, arch, status, name, 
 def load_and_process_results(file, regexes_matched_list):
     with gzip.open(file, 'rt') as f:
         for line in f:
-            line = line.strip()
             version, arch, status, name, note = line.split('\t')
 
             if version == 'rhel':  # skip the header


### PR DESCRIPTION
Here is the file which I created by the appropriate script.
I had to apply a small fix before I was able to use it, it is in a separate commit in this PR.

```
2025-09-05 13:54:27 find_invalid_waivers.py:179: lib.waive.collect_waivers:150: using /home/vojta/repos/upstream/test_contest/conf/waivers for waiving
===============================================================
The following waivers are no longer valid, they either did not
match any test results or only matched the 'pass' test results:
===============================================================

/hardening/host-os/.+/mount_option_boot_efi_nosuid
    True

/static-checks/html-links/.+
    "failed: certificate has expired" in note

/scanning/disa-alignment/.*/sysctl_user_max_user_namespaces
    rhel >= 9

/hardening/.+/ospp/enable_fips_mode
/hardening/.*/ospp/configure_crypto_policy
    rhel.is_centos() and (rhel == 9 or rhel == 10)

/hardening/container/.+/file_groupownership_sshd_private_key
    True

/scanning/disa-alignment/(oscap|ansible)/file_permission_user_init_files_root
    rhel == 8

/scanning/disa-alignment/(oscap|ansible)/accounts_password_pam_retry
/scanning/disa-alignment/.*/harden_sshd_ciphers_openssh_conf_crypto_policy
/scanning/disa-alignment/.*/accounts_password_pam_pwhistory_remember_system_auth
/scanning/disa-alignment/.*/CCE-88173-0
/scanning/disa-alignment/.*/file_permissions_library_dirs
/scanning/disa-alignment/.*/service_pcscd_enabled
    rhel == 9

/scanning/disa-alignment/.+/file_permissions_sshd_config
/scanning/disa-alignment/.+/file_permissions_sshd_drop_in_config
    rhel == 9

/scanning/disa-alignment/anaconda/ensure_gpgcheck_globally_activated
    rhel == 8

/scanning/disa-alignment/.*/accounts_password_pam_pwhistory_remember_password_auth
    rhel == 8 or rhel == 9

/scanning/disa-alignment/.*/CCE-90785-7
    rhel == 9.0

/scanning/disa-alignment/.*/file_permission_user_init_files_root
    rhel == 9

/scanning/disa-alignment/.*/mount_option_boot_efi_nosuid
    rhel == 8 or rhel == 9

/scanning/disa-alignment/.*/directory_permissions_sshd_config_d
    rhel == 9

/scanning/disa-alignment/.+/rootfiles_configured
    rhel == 8 or rhel == 9

/scanning/disa-alignment/.*/audit_rules_.+
    True

/scanning/disa-alignment/.+/logind_session_timeout
    rhel == 9

/static-checks/rule-identifiers/stig/stigid/.*
    rhel == 10

/static-checks/rule-identifiers/ospp/ospp/.*
    rhel == 8

/static-checks/rule-identifiers/ism_o/ism/.*
    True

/static-checks/rule-identifiers/stig/os-srg/service_sssd_enabled
/static-checks/rule-identifiers/stig/os-srg/package_sssd_installed
    rhel == 10

/static-checks/rule-identifiers/anssi_bp28_high/anssi/service_chronyd_enabled
    rhel == 8 or rhel == 10

/static-checks/rule-identifiers/anssi_bp28_high/anssi/audit_rules_mac_modification_etc_selinux
    rhel == 10

/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_tls_cacertpath
/static-checks/rule-identifiers/anssi_bp28_high/anssi/no_nis_in_nsswitch
/static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_start_tls
    rhel == 8

/hardening/ansible/.+/network_nmcli_permissions
    rhel == 9

/hardening/.*/file_permission_user_init_files_root
    True

/hardening/kickstart/.+/service_nftables_disabled
    True

/hardening/.+/aide_use_fips_hashes
    rhel >= 9

/hardening/anaconda/.+/harden_sshd_ciphers_opensshserver_conf_crypto_policy
/hardening/anaconda/.+/harden_sshd_macs_opensshserver_conf_crypto_policy
/hardening/anaconda/.+/configure_gnutls_tls_crypto_policy
    rhel == 8

/hardening/anaconda/with-gui/cis_workstation_l[12]
    status == 'error'

/hardening/image-builder/.+/sebool_selinuxuser_execstack
    True

/hardening/container/[^/]+/[^/]+/accounts_password_pam_retry
    rhel == 9

/scanning/disa-alignment/.+/audit_privileged_commands_.+
    rhel == 9

/per-rule/.+/harden_sshd_macs_(openssh|opensshserver)_conf_crypto_policy
/per-rule/.+/harden_sshd_ciphers_(openssh|opensshserver)_conf_crypto_policy
/hardening/.+/configure_gnutls_tls_crypto_policy
    rhel == 8

/hardening/oscap/with-gui/stig_gui/dconf_gnome_login_banner_text
/hardening/kickstart/with-gui/stig_gui/dconf_gnome_login_banner_text
/hardening/anaconda/with-gui/stig_gui/dconf_gnome_login_banner_text
    True

/hardening/host-os/ansible/cis/file_permission_user_init_files
/hardening/host-os/ansible/cis_workstation_l2/file_permission_user_init_files
    rhel  == 10

/hardening/.+/bsi/rpm_verify_permissions
    rhel == 9
```
