### PR TITLE
Keep VM snapshots local to a test

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -132,10 +132,16 @@ This indicates a test that can share virtual machine snapshots with other
 tests, typically via a clause like
 
 ```python
+virt.Host.setup()
 g = virt.Guest(guest_tag)
-if not g.can_be_snapshotted():
+if not g.is_installed():
     g.install(...)
-    g.prepare_for_snapshot()
+
+g.prepare_for_snapshot()
+atexit.register(g.cleanup_snapshot)
+
+with g.snapshotted():
+    ...
 
 with g.snapshotted():
     ...

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import atexit
 import inspect
 import subprocess
 from pathlib import Path
@@ -169,6 +170,7 @@ with util.get_source_content() as content_dir:
         g.ssh('./setup.sh', check=True)
 
     g.prepare_for_snapshot()
+    atexit.register(g.cleanup_snapshot)
 
 guest_logs_template = [
     'initial-report.html', 'initial-results-arf.xml',

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import atexit
 import subprocess
 
 import shared
@@ -14,10 +15,12 @@ virt.Host.setup()
 guest_tag = virt.calculate_guest_tag(metadata.tags())
 g = virt.Guest(guest_tag)
 
-if not g.can_be_snapshotted():
+if not g.is_installed():
     ks = virt.Kickstart(partitions=partitions.partitions)
     g.install(kickstart=ks, kernel_args=['fips=1'])
-    g.prepare_for_snapshot()
+
+g.prepare_for_snapshot()
+atexit.register(g.cleanup_snapshot)
 
 # the VM guest ssh code doesn't use $HOME/.known_hosts, so Ansible blocks
 # on trying to accept its ssh key - tell it to ignore this


### PR DESCRIPTION
Resolves #376

Note: I also tried to setup a persistent ssh connection using `ControlMaster`, but the connection is interrupted after each snapshot revert so we would need to re-establish it every time we revert a snapshot. Therefore, I kept the original ssh implementation without the `ControlMaster`.