### PR TITLE
Rule fips_crypto_subpolicy should be notapplicable also on RHEL10

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -281,7 +281,7 @@
 
 # https://github.com/ComplianceAsCode/content/issues/13877
 /scanning/container-rules-applicability/fips_crypto_subpolicy
-    rhel == 8 or rhel == 9
+    True
 /scanning/container-rules-applicability/fips_custom_stig_sub_policy
     rhel == 9
 


### PR DESCRIPTION
Issue: https://github.com/ComplianceAsCode/content/issues/13877

The failing `/scanning/container-rules-applicability/fips_crypto_subpolicy` is also present on RHEL 10.