### PR TITLE
Add waiver for /hardening/image-builder errors on RHEL 8.10

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -277,6 +277,7 @@
 /hardening/kickstart/uefi/ism_o
 /hardening/kickstart/uefi/stig
 /hardening/kickstart/with-gui/stig_gui
+/hardening/kickstart/with-gui/ism_o
     rhel == 10 and status == 'error'
 
 # https://github.com/ComplianceAsCode/content/issues/13877
@@ -288,5 +289,13 @@
 # Image builder issue. Image builder needs to add BSI to its allow list.
 /hardening/image-builder/bsi
     rhel == 9 and status == 'error'
+
+# https://github.com/ComplianceAsCode/content/issues/13906
+/hardening/image-builder/cis
+/hardening/image-builder/cis_workstation_l2
+/hardening/image-builder/cui
+/hardening/image-builder/ospp
+/hardening/image-builder/stig
+    rhel == 8 and status == 'error'
 
 # vim: syntax=python


### PR DESCRIPTION
Related issue:
https://github.com/ComplianceAsCode/content/issues/13906

Also added `/hardening/kickstart/with-gui/ism_o` into the group of waivers for https://github.com/ComplianceAsCode/content/issues/13880