### PR TITLE
_rule_has_no_remediation: don't check error results

### DIFF
--- a/lib/waive.py
+++ b/lib/waive.py
@@ -207,6 +207,9 @@ def match_result(status, name, note):
         # cases we want `no_remediation` function to return False
         if not subresult:
             return False
+        # similarly, if we got an error status we are not processing a sub-result with rule
+        if status == 'error':
+            return False
         # extract the rule name from the test name
         # (e.g. '/hardening/kickstart/stig/configure_crypto_policy')
         rule = name.rpartition('/')[2]


### PR DESCRIPTION
Error results might contain arbitrary strings in the test name that might not be SCAP rules. This would make
`oscap.global_ds().has_remediation` to error out becase it tries to extract a SCAP rule name from the test name and it also checks if the extracted SCAP rule is present in the tested datastream.