### PR TITLE
Enable testing of ism_o_secret and ism_o_top_secret profiles on RHEL-10+

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -84,11 +84,6 @@
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
 /static-checks/rule-identifiers/ospp/ospp/.*
     rhel == 8
-# RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
-# RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
-# RHEL10 https://github.com/ComplianceAsCode/content/issues/12430
-/static-checks/rule-identifiers/ism_o/ism/.*
-    True
 
 # https://github.com/ComplianceAsCode/content/issues/13856
 /static-checks/rule-identifiers/stig/os-srg/package_sssd_installed
@@ -273,11 +268,17 @@
 
 # https://github.com/ComplianceAsCode/content/issues/13880
 /hardening/kickstart/ism_o
+/hardening/kickstart/ism_o_secret
+/hardening/kickstart/ism_o_top_secret
 /hardening/kickstart/stig
 /hardening/kickstart/uefi/ism_o
+/hardening/kickstart/uefi/ism_o_secret
+/hardening/kickstart/uefi/ism_o_top_secret
 /hardening/kickstart/uefi/stig
 /hardening/kickstart/with-gui/stig_gui
 /hardening/kickstart/with-gui/ism_o
+/hardening/kickstart/with-gui/ism_o_secret
+/hardening/kickstart/with-gui/ism_o_top_secret
     rhel == 10 and status == 'error'
 
 # https://github.com/ComplianceAsCode/content/issues/13877
@@ -286,9 +287,17 @@
 /scanning/container-rules-applicability/fips_custom_stig_sub_policy
     rhel == 9
 
-# Image builder issue. Image builder needs to add BSI to its allow list.
+# Image builder issue. Image builder needs to add BSI, ISM Official Secret
+# and ISM Official Top Secret to its allow list, tracked under
+# https://issues.redhat.com/browse/HMS-9407
+# https://issues.redhat.com/browse/HMS-9507
 /hardening/image-builder/bsi
     rhel == 9 and status == 'error'
+/hardening/image-builder/ism_o_secret
+/hardening/image-builder/uefi/ism_o_secret
+/hardening/image-builder/ism_o_top_secret
+/hardening/image-builder/uefi/ism_o_top_secret
+    rhel == 10 and status == 'error'
 
 # https://github.com/ComplianceAsCode/content/issues/13906
 /hardening/image-builder/cis

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -78,6 +78,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/ansible/uefi.fmf
+++ b/hardening/ansible/uefi.fmf
@@ -54,6 +54,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -64,6 +64,30 @@ tag+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -77,6 +77,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -73,6 +73,26 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/container/old-new/main.fmf
+++ b/hardening/container/old-new/main.fmf
@@ -74,6 +74,26 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -65,6 +65,26 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -57,6 +57,26 @@ tag:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -75,6 +75,26 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/image-builder/uefi.fmf
+++ b/hardening/image-builder/uefi.fmf
@@ -50,6 +50,26 @@ adjust+:
 /hipaa:
 
 /ism_o:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     adjust+:

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -70,6 +70,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -47,6 +47,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -52,6 +52,30 @@ tag+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -74,6 +74,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -55,6 +55,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/oscap/uefi.fmf
+++ b/hardening/oscap/uefi.fmf
@@ -54,6 +54,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -64,6 +64,30 @@ tag+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:

--- a/scanning/host-os/ansible-check/check-mode/main.fmf
+++ b/scanning/host-os/ansible-check/check-mode/main.fmf
@@ -59,6 +59,30 @@ adjust+:
 /ism_o:
     tag+:
       - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+
+/ism_o_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro >= rhel-10
+        tag+:
+          - subset-profile
+        continue: true
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Secret is only present on RHEL-10+
+
+/ism_o_top_secret:
+    tag+:
+      - fips
+    adjust+:
+      - when: distro < rhel-10
+        enabled: false
+        because: ISM Official Top Secret is only present on RHEL-10+
 
 /ospp:
     tag+:


### PR DESCRIPTION
Based on control file, the hierarchy of ism_o profiles is:
```
levels:
    - id: base
    - id: secret
      inherits_from:
          - base
    - id: top_secret
      inherits_from:
          - secret
```
which means on RHEL-10+ the `ism_o` and `ism_o_secret` are subset profiles of `ism_o_top_secret`.