### PR TITLE
Revert waivers for /static-checks/rule-identifiers/ism_o

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -39,6 +39,11 @@
 # RHEL8 https://github.com/ComplianceAsCode/content/issues/12422
 /static-checks/rule-identifiers/ospp/ospp/.*
     rhel == 8
+# RHEL8 https://github.com/ComplianceAsCode/content/issues/12423
+# RHEL9 https://github.com/ComplianceAsCode/content/issues/12427
+# RHEL10 https://github.com/ComplianceAsCode/content/issues/12430
+/static-checks/rule-identifiers/ism_o/ism/.*
+    True
 
 # https://github.com/ComplianceAsCode/content/issues/13856
 /static-checks/rule-identifiers/stig/os-srg/package_sssd_installed


### PR DESCRIPTION
There are still many rules missing ism identifiers.