### PR TITLE
Move no CCN identifiers to permanent waivers

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -35,6 +35,11 @@
 /scanning/disa-alignment/.*/installed_OS_is_vendor_supported
     True
 
+# No CCN identifiers for CentOS products
+# https://github.com/ComplianceAsCode/content/issues/14033
+/static-checks/rule-identifiers/ccn_advanced/ccn/.*
+    rhel == 9 and rhel.is_centos()
+
 # Rules checking if OS is FIPS certified
 /hardening/host-os/.+/sshd_use_approved_.+
 /hardening/host-os/.+/package_dracut-fips_installed

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -55,10 +55,6 @@
 /static-checks/rule-identifiers/anssi_bp28_high/anssi/ldap_client_start_tls
     rhel == 8
 
-# https://github.com/ComplianceAsCode/content/issues/14033
-/static-checks/rule-identifiers/ccn_advanced/ccn/.*
-    rhel == 9 and rhel.is_centos()
-
 # bz1825810 or maybe bz1929805
 # can be reproduced mostly reliably (95%) both via anaconda and oscap CLI,
 # but apparently we don't really care about old releases


### PR DESCRIPTION
This is expected as CCN is only for RHEL