### PR TITLE
Remove general service_enabled waiver for host-os

### DIFF
--- a/conf/waivers/infrastructure
+++ b/conf/waivers/infrastructure
@@ -12,10 +12,6 @@
 # we don't control partitions on the host OS
 /hardening/host-os/.+/mount_option_(home|opt|srv|var|var_log|var_log_audit|tmp)_(noexec|nosuid|nodev|usrquota|grpquota)
     True
-# Beaker and host-os seem to randomly fail any services enabled
-# TODO: probably worth further investigation, but likely not a content issue
-/hardening/host-os/oscap/[^/]+/service_.+_enabled
-    True
 
 # Remediations are unselected for CentOS, but they might pass outside Testing Farm
 /hardening/.+/ensure_redhat_gpgkey_installed


### PR DESCRIPTION
The waiver is too generic and can hide bugs + it was only applicable to oscap variant and not for Ansible. As there were no issues with Ansible tests and service_enabled rules we can safely remove it.