### PR TITLE
/scanning/container-rules-applicability: check for enable_authselect

### DIFF
--- a/scanning/container-rules-applicability/test.py
+++ b/scanning/container-rules-applicability/test.py
@@ -23,6 +23,7 @@ NA_RULE_PATTERNS = [
     r"dconf_",
     r"fapolicy[d]?_",
     r"usbguard_",
+    r"enable_authselect",
 ]
 NA_RULES_REGEX = re.compile("|".join(NA_RULE_PATTERNS))
 


### PR DESCRIPTION
Update the test `NA_RULE_PATTERNS` with the `enable_authselect` rule which should be `notapplicable` when evaluated inside a container.

Related issue:
https://issues.redhat.com/browse/RHEL-84439