### PR TITLE
Fix disa-alignment test

### DIFF
--- a/scanning/disa-alignment/shared.py
+++ b/scanning/disa-alignment/shared.py
@@ -81,7 +81,9 @@ def disa_scan(host, ds, html, arf):
 def get_stigref_uri(xccdf_benchmark):
     for reference in xccdf_benchmark.findall(".//xccdf:reference", nsmap):
         if reference.text == "stigref":
-            return reference.get("href")
+            href = reference.get("href")
+            if href is not None:
+                return href
     raise RuntimeError("STIG reference not found")
 
 


### PR DESCRIPTION
This test doesn't work and everything passes, because it fails to find the STIG references in all rules. The root cause is the recent change of the STIG URL from https://public.cyber.mil to https://www.cyber.mil in our content. The old URL was hardcoded in the test. To prevent problems like this in future, we will parse the URL from the data stream instead of defining it in the test.