### PR TITLE
Support adding logs on the fly

### DIFF
--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -45,8 +45,12 @@ with g.snapshotted():
         *skip_tags_arg,
         playbook,
     ]
-    _, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT, check=True)
+    proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
     ansible.report_from_output(lines, to_file='ansible-playbook.log')
+    util.subprocess_run(['gzip', '-9', 'ansible-playbook.log'], check=True, stderr=subprocess.PIPE)
+    results.add_log('ansible-playbook.log.gz')
+    if proc.returncode != 0:
+        raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()
 
     # scan the remediated system
@@ -63,6 +67,5 @@ with g.snapshotted():
     g.copy_from('scan-arf.xml')
 
 util.subprocess_run(['gzip', '-9', 'scan-arf.xml'], check=True, stderr=subprocess.PIPE)
-util.subprocess_run(['gzip', '-9', 'ansible-playbook.log'], check=True, stderr=subprocess.PIPE)
 
-results.report_and_exit(logs=['report.html', 'scan-arf.xml.gz', 'ansible-playbook.log.gz'])
+results.report_and_exit(logs=['report.html', 'scan-arf.xml.gz'])

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -81,8 +81,4 @@ else:
     ]
     util.subprocess_run(tar, check=True, stderr=subprocess.PIPE)
 
-    logs = [
-        'report.html',
-        'results-arf.tar.xz',
-    ]
-    results.report_and_exit(logs=logs)
+    results.report_and_exit(logs=['report.html', 'results-arf.tar.xz'])

--- a/scanning/audit-rules-syscalls-grouping/test.py
+++ b/scanning/audit-rules-syscalls-grouping/test.py
@@ -77,6 +77,7 @@ try:
         '--results-arf', 'remediation-arf.xml', 'remediation-ds.xml',
     ]
     util.subprocess_run(cmd, check=True, stderr=subprocess.PIPE)
+    results.add_log('remediation-arf.xml', 'report.html')
 
     util.subprocess_run(['augenrules', '--load'], check=True, stderr=subprocess.PIPE)
 
@@ -84,6 +85,7 @@ try:
         util.subprocess_run(
             ['auditctl', '-l'], stdout=f, text=True, check=True, stderr=subprocess.PIPE,
         )
+    results.add_log('audit_rules.txt')
 finally:
     util.restore('/etc/audit')
     util.subprocess_run(['augenrules', '--load'], check=True, stderr=subprocess.PIPE)
@@ -94,4 +96,4 @@ for group in syscalls_groups:
     else:
         results.report('fail', syscalls_pretty_print(group))
 
-results.report_and_exit(logs=['report.html', 'remediation-arf.xml', 'audit_rules.txt'])
+results.report_and_exit()

--- a/scanning/host-os/ansible-check/check-mode/test.py
+++ b/scanning/host-os/ansible-check/check-mode/test.py
@@ -18,7 +18,10 @@ ansible_cmd = [
     'ansible-playbook', '-v', '-c', 'local', '-i', 'localhost,', '--check',
     playbook,
 ]
-_, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT, check=True)
+proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
 ansible.report_from_output(lines, to_file='ansible-playbook.log')
 util.subprocess_run(['gzip', '-9', 'ansible-playbook.log'], check=True, stderr=subprocess.PIPE)
-results.report_and_exit(logs=['ansible-playbook.log.gz'])
+results.add_log('ansible-playbook.log.gz')
+if proc.returncode != 0:
+    raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
+results.report_and_exit()


### PR DESCRIPTION
Add `results.add_log()` function which can be used anywhere in a test to add existing file(s) to logs which will then be all uploaded within the `results.report_and_exit()`.

Also use the `results.add_log()` in tests where it's convenient.

Resolves https://github.com/RHSecurityCompliance/contest/issues/365 and https://github.com/RHSecurityCompliance/contest/issues/466