### PR TITLE
Update waiver of accounts_password_pam_unix_no_remember

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -185,7 +185,7 @@
     rhel == 10
 
 # https://github.com/ComplianceAsCode/content/issues/14213
-/per-rule/oscap/.+/accounts_password_pam_unix_no_remember/remember_present_password_auth.fail
+/per-rule/oscap/.+/accounts_password_pam_unix_no_remember/remember_present_(password|system)_auth.fail
     rhel == 8 or rhel == 9
 
 # vim: syntax=python


### PR DESCRIPTION
Include both password|system test scenarios.

The issue https://github.com/ComplianceAsCode/content/issues/14213 was covering only one of the test scenarios.


`9.8	fail	/per-rule/oscap/2	accounts_password_pam_unix_no_remember/remember_present_system_auth.fail	oscap fixing returned error, expected 'fixed'`