### PR TITLE
Extend disa-alignment/.+/sysctl_kernel_core_pattern to RHEL9

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -27,7 +27,7 @@
     True
 # https://github.com/ComplianceAsCode/content/issues/13799
 /scanning/disa-alignment/.+/sysctl_kernel_core_pattern
-    rhel == 8
+    rhel == 8 or rhel == 9
 
 # https://github.com/ComplianceAsCode/content/issues/13828
 /scanning/disa-alignment/.+/sysctl_net_ipv4_conf_default_rp_filter


### PR DESCRIPTION
With the release of a new STIG for RHEL9, DISA SCAP content is now included and behaves the same way as RHEL8. In this case our approach OVAL is correct.

Related to: https://github.com/ComplianceAsCode/content/issues/13799