### PR TITLE
Add waiver for DISA misalignment to rsyslog_remote_access_monitoring

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -33,6 +33,11 @@
 /scanning/disa-alignment/.+/sysctl_net_ipv4_conf_default_rp_filter
     rhel == 9
 
+# https://github.com/ComplianceAsCode/content/issues/14229
+# maybe it's related to the syntax change in rsyslog configuration files
+/scanning/disa-alignment/[^/]+/rsyslog_remote_access_monitoring
+    rhel == 9
+
 # RHEL10 - No official RHEL10 STIG benchmark yet
 /static-checks/rule-identifiers/stig/stigid/.*
     rhel == 10


### PR DESCRIPTION
happens only on anaconda environment and rhel9, maybe it's related to the possible syntax change in rsyslog configuration files

Related to: https://github.com/ComplianceAsCode/content/issues/14229