### PR TITLE
Add a temporary waiver for ensure_redhat_gpgkey_installed

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -199,6 +199,7 @@
     rhel == 8 or rhel == 9
 
 # RHEL 10.2 doesn't contain the new post-quantum GPG key yet
+# https://issues.redhat.com/browse/RHELBLD-17165
 /hardening/.+/ensure_redhat_gpgkey_installed
 /per-rule/.+/ensure_redhat_gpgkey_installed
     rhel == 10.2


### PR DESCRIPTION
RHEL 10.2 doesn't contain the new post-quantum GPG key yet which causes many tests in the daily run to fail on 10.2.