### PR TITLE
skip rule ensure_redhat_gpgkey_installed in Ansible tests

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -45,7 +45,7 @@ def excludes():
 
     # problem described at https://issues.redhat.com/browse/RHEL-126844
     # upstream PR at https://github.com/ansible/ansible/issues/86157
-    if versions.rhel == 10 and "/ansible/" in test_name:
+    if versions.rhel == 10.2 and '/ansible/' in test_name:
         rules += [
             'ensure_redhat_gpgkey_installed',
         ]


### PR DESCRIPTION
Relevant issue: https://issues.redhat.com/browse/RHEL-126844
This needs to be fixed on Ansible side.