### PR TITLE
Enable bsi profile testing for RHEL10

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -44,9 +44,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -18,9 +18,9 @@ tag+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
     adjust+:

--- a/hardening/ansible/main.fmf
+++ b/hardening/ansible/main.fmf
@@ -48,9 +48,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/ansible/uefi.fmf
+++ b/hardening/ansible/uefi.fmf
@@ -23,9 +23,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/ansible/with-gui.fmf
+++ b/hardening/ansible/with-gui.fmf
@@ -18,9 +18,9 @@ tag+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
     adjust+:

--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -46,9 +46,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -46,9 +46,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/container/old-new/main.fmf
+++ b/hardening/container/old-new/main.fmf
@@ -53,9 +53,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/host-os/ansible/main.fmf
+++ b/hardening/host-os/ansible/main.fmf
@@ -34,9 +34,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/host-os/oscap/main.fmf
+++ b/hardening/host-os/oscap/main.fmf
@@ -25,9 +25,9 @@ tag:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -48,9 +48,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/image-builder/uefi.fmf
+++ b/hardening/image-builder/uefi.fmf
@@ -23,9 +23,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -46,9 +46,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -23,9 +23,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -18,9 +18,9 @@ tag+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
     adjust+:

--- a/hardening/oscap/main.fmf
+++ b/hardening/oscap/main.fmf
@@ -43,9 +43,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/oscap/old-new/main.fmf
+++ b/hardening/oscap/old-new/main.fmf
@@ -26,9 +26,9 @@ environment+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/oscap/uefi.fmf
+++ b/hardening/oscap/uefi.fmf
@@ -23,9 +23,9 @@ adjust+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
 

--- a/hardening/oscap/with-gui.fmf
+++ b/hardening/oscap/with-gui.fmf
@@ -18,9 +18,9 @@ tag+:
 
 /bsi:
     adjust+:
-      - when: distro != rhel-9 and distro != centos-stream-9
+      - when: distro == rhel-8 or distro == centos-stream-8
         enabled: false
-        because: BSI profile is currently only on RHEL-9
+        because: The BSI profile is currently not on RHEL-8
 
 /cis:
     adjust+:


### PR DESCRIPTION
- Updated the BSI profile test configuration across all hardening test files to enable testing on RHEL-10 and CentOS Stream 10
- BSI is currently not available only on RHEL 8
- fixes https://issues.redhat.com/browse/OPENSCAP-6525