### PR TITLE
Skip old/new testing if the profile is only in old or new DS

### DIFF
--- a/hardening/oscap/old-new/test.py
+++ b/hardening/oscap/old-new/test.py
@@ -23,11 +23,20 @@ if not g.is_installed():
 g.prepare_for_snapshot()
 atexit.register(g.cleanup_snapshot)
 
-with g.snapshotted(), util.get_old_datastream() as old_xml:
-    # copy old and new datastreams to the guest
+# unselect unwanted rules
+with util.get_old_datastream() as old_xml:
     oscap.unselect_rules(old_xml, 'remediation-old.xml', remediation.excludes())
+oscap.unselect_rules(util.get_datastream(), 'remediation-new.xml', remediation.excludes())
+
+# check whether the profile is in both old and new
+if profile not in oscap.Datastream('remediation-old.xml').profiles:
+    results.report_and_exit('skip', "profile missing the old DS")
+if profile not in oscap.Datastream('remediation-new.xml').profiles:
+    results.report_and_exit('skip', "profile missing the new DS")
+
+with g.snapshotted():
+    # copy old and new datastreams to the guest
     g.copy_to('remediation-old.xml')
-    oscap.unselect_rules(util.get_datastream(), 'remediation-new.xml', remediation.excludes())
     g.copy_to('remediation-new.xml')
 
     def remediate(datastream, arf_results, arf_results2):
@@ -51,7 +60,7 @@ with g.snapshotted(), util.get_old_datastream() as old_xml:
     remediate('remediation-old.xml', 'remediation-arf-old.xml', 'remediation-arf-old2.xml')
     remediate('remediation-new.xml', 'remediation-arf-new.xml', 'remediation-arf-new2.xml')
 
-    # scan using new content
+    # scan using new content (without any modifications)
     g.copy_to(util.get_datastream(), 'scan-new.xml')
     proc, lines = g.ssh_stream(
         f'oscap xccdf eval --profile {profile} --progress --report report.html'


### PR DESCRIPTION
This is useful when a new DS version is adding a new profile, or removing an old one, to avoid errors like
```
OpenSCAP generate fix failed with return code 1.
Output: No profile matching suffix "bsi" was found.
Get available profiles using:
$ oscap info "/root/remediation-old-ds.xml"
```
Note that we don't need an explicit profile name in the reported `note`, we already know it from the test name, ie. `/hardening/oscap/old-new/bsi`.