### PR TITLE
Add waiver for failing rule sysctl_kernel_core_pattern_empty_string

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -192,6 +192,10 @@
 /hardening/image-builder/uefi/ism_o_top_secret
     rhel == 10 and status == 'error'
 
+# https://github.com/ComplianceAsCode/content/issues/14373
+/hardening/(container/)?(anaconda|image-builder|bootc-image-builder|anaconda-ostree)/(ospp|cui)/sysctl_kernel_core_pattern_empty_string
+    rhel == 9
+
 # https://github.com/ComplianceAsCode/content/issues/14213
 /per-rule/oscap/.+/accounts_password_pam_unix_no_remember/remember_present_(password|system)_auth.fail
     rhel == 8 or rhel == 9


### PR DESCRIPTION
This rule doesn't seem to be remediating correctly.

Related to: # https://github.com/ComplianceAsCode/content/issues/14373

Following tests are failing for the RHEL9.8
/hardening/container/anaconda-ostree/ospp|cui
/hardening/container/bootc-image-builder/cui|ospp
/hardening/image-builder/cui|ospp
/hardening/anaconda/ospp|cui