### PR TITLE
Prioritize `per-rule` and `image-builder`, to run early

### DIFF
--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -30,6 +30,10 @@ adjust+:
   - when: distro ~< rhel-8.10 or distro ~< rhel-9.4
     enabled: false
     because: there is no OSBuild or Image Builder on old RHEL8/9 contain old OSBuild
+# the OSBuild composer frequently fails on race conditions and needs reruns,
+# slowing down the test run if this happens late, so prioritize it early on,
+# so the re-run can happen in the background
+extra-priority: 1
 
 /anssi_bp28_high:
 

--- a/per-rule/main.fmf
+++ b/per-rule/main.fmf
@@ -34,6 +34,10 @@ adjust+:
   - when: distro == rhel-9.0
     enabled: false
     because: xmlstarlet not available on 9.0
+# /per-rule tests often fail and need re-run, which is then slow
+# (each test takes a long time), so prioritize /per-rule above others
+# so it can re-run in the background
+extra-priority: 1
 
 /oscap:
     environment+:


### PR DESCRIPTION
This uses an ATEX `ContestOrchestrator` feature that allows prioritization when choosing a next test to run after a previously- finished one.

The priority is any positive/negative number, larger means higher priority, with `0` being default for tests that don't specify it.

This is still overriden by the `destructive` tag, which always runs first (to get a clean machine + reprovision it afterwards), and the logic for re-using snapshots (which are preferred over any priority).