### PR TITLE
strip trailing newline for simple variables in per-rule Ansible

### DIFF
--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -91,10 +91,16 @@ if [[ -f $variables_file ]]; then
             # - bash printf can print anything except 0x00 (which is fine)
             while IFS= read -r playbook_line; do
                 if [[ $playbook_line =~ ^([[:space:]]+)$key: ]]; then
+                    # if the value ends with \n, preserve any trailing newlines,
+                    # otherwise strip the \n we add via printf below
+                    [[ ${value: -1} == $'\n' ]] && newlines='|+1' || newlines='|-1'
                     # vars:
-                    #     var_something: |1
+                    #     var_simple_value: |-1        ---> '100'
                     #      100
-                    printf '%s%s: |1\n' "${BASH_REMATCH[1]}" "$key"
+                    #     var_multiline_value: |+1     ---> '1 2\n3 4\n'
+                    #      1 2
+                    #      3 4
+                    printf '%s%s: %s\n' "${BASH_REMATCH[1]}" "$key" "$newlines"
                     while IFS= read -r value_line; do
                         # prefix each value line with the original indent + 1 space
                         printf '%s %s\n' "${BASH_REMATCH[1]}" "$value_line"


### PR DESCRIPTION
The previous code was causing newline-less vars to always get `\n` at the end, because

```yaml
var_something: |1
 100
```
results in `100\n`, not just `100`.

Using
```yaml
var_something: |-1
 100
```
correctly fixes that to `100`.

---

At the same time, values with newlines have to have newlines preserved, even the last one, so that ie.
```yaml
var_something: |-1
 echo foo
 echo bar
```
would be `echo foo\necho bar` without a trailing `\n`, meaning it could break if used in an expression like
```
{{ var_something }}  echo final
```
if the CaC/content code relies on the last `\n` to be inserted as part of the variable expansion, meaning instead of the intended
```
echo foo
echo bar
echo final
```
we would get
```
echo foo
echo bar  echo final
```
Using `|1` (like originally) would fix it, but break the simple `100` case.

Similarly, even `|1` doesn't preserve multiple `\n`, so that
```yaml
var_something: |1
 echo foo
 
 
```
(2 empty lines at the end) should be `echo foo\n\n\n`, but `|1` trims it to just `echo foo\n`. We would need `|+1` to keep all.

...

Therefore we use a split logic - one for `\n`-trailing values that preserve ALL newlines, and one for values without trailing `\n` that strips off the last newline.
```yaml
var_something: |-1
 100

var_something: |+1
 echo foo
 echo bar
```

Note that this also works for strings that have `\n` in the middle, but DO NOT end in `\n` - the `|-1` variant still preserves newlines in the middle (because it is `|` and not `>`), just not at the end.