### PR TITLE
Use just 1 VCPU for nested VMs

### DIFF
--- a/lib/virt.py
+++ b/lib/virt.py
@@ -411,7 +411,6 @@ class Guest:
 
         disk_extension = 'qcow2' if disk_format == 'qcow2' else 'img'
         disk_path = Path(f'{GUEST_IMG_DIR}/{self.name}.{disk_extension}')
-        cpus = os.cpu_count() or 1
 
         with kickstart.to_tmpfile() as ksfile:
             virt_install = [
@@ -419,7 +418,7 @@ class Guest:
                 # installing from HTTP URL leads to Anaconda downloading stage2
                 # to RAM, leading to notably higher memory requirements during
                 # installation
-                '--name', self.name, '--vcpus', str(cpus), '--memory', str(INSTALL_TIME_RAM),
+                '--name', self.name, '--vcpus', '1', '--memory', str(INSTALL_TIME_RAM),
                 '--disk', f'path={disk_path},size=20,format={disk_format},io=native,cache=none',
                 '--network', 'network=default', '--location', location,
                 '--graphics', 'none', '--console', 'pty', '--rng', '/dev/urandom',
@@ -527,11 +526,9 @@ class Guest:
 
         util.log(f"importing {disk_path} as {disk_format}")
 
-        cpus = os.cpu_count() or 1
-
         virt_install = [
             'pseudotty', 'virt-install',
-            '--name', self.name, '--vcpus', str(cpus), '--memory', str(INSTALL_TIME_RAM),
+            '--name', self.name, '--vcpus', '1', '--memory', str(INSTALL_TIME_RAM),
             '--disk', f'path={disk_path},format={disk_format},io=native,cache=none',
             '--network', 'network=default',
             '--graphics', 'none', '--console', 'pty', '--rng', '/dev/urandom',


### PR DESCRIPTION
QEMU / KVM has had historical problems with SMP guests and it's possible that this is what's causing kernel lock-ups in rare cases during testing - ssh disconnect and one of
* `TestAbortedError(test duration timeout reached)`
* `TestAbortedError(test wrapper unexpectedly exited with 255 and reconnect was not sent via test control)`

Since we're not performing heavy multi-threaded workloads in nested VMs, have them use 1 VCPU, just to be sure.