### PR TITLE
Adding waivers for DISA misalignment in configure_libreswan_crypto_policy, logind_session_timeout rules

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -50,9 +50,8 @@
 
 # https://github.com/ComplianceAsCode/content/issues/14453
 # The rules are failing on DISA content
-/scanning/disa-alignment/(anaconda|ansible|oscap)/configure_libreswan_crypto_policy
-    rhel == 9
-/scanning/disa-alignment/(anaconda|ansible|oscap)/logind_session_timeout
+/scanning/disa-alignment/.+/configure_libreswan_crypto_policy
+/scanning/disa-alignment/.+/logind_session_timeout
     rhel == 9
 
 # RHEL10 - No official RHEL10 STIG benchmark yet


### PR DESCRIPTION
- Happens only on RHEL 9
- Related to https://github.com/ComplianceAsCode/content/issues/14453