### PR TITLE
Waive configure_crypto_policy in RHEL 8 STIG in Anaconda

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -120,6 +120,7 @@
 # https://github.com/ComplianceAsCode/content/issues/12942
 # https://issues.redhat.com/browse/RHEL-4722
 /hardening/anaconda/ospp/configure_crypto_policy
+/hardening/anaconda/stig/configure_crypto_policy
 /hardening/anaconda/ospp/enable_fips_mode
 /hardening/anaconda/.+/harden_sshd_ciphers_openssh_conf_crypto_policy
     rhel == 8


### PR DESCRIPTION
Starting from version V2R6, the DISA STIG benchmark for Red Hat Enterprise Linux 8 now requires to use a custom crypto sub policy module and set the crypto policy to FIPS:STIG. Therefore, the issue https://issues.redhat.com/browse/RHEL-4722 now started to affect also RHEL 8 STIG.