### PR TITLE
Extend exclude for Ansible

### DIFF
--- a/conf/remediation.py
+++ b/conf/remediation.py
@@ -45,7 +45,7 @@ def excludes():
 
     # problem described at https://issues.redhat.com/browse/RHEL-126844
     # upstream PR at https://github.com/ansible/ansible/issues/86157
-    if versions.rhel == 10.2 and ('/ansible/' in test_name or '/ansible-check/' in test_name):
+    if versions.rhel >= 10.1 and ('/ansible/' in test_name or '/ansible-check/' in test_name):
         rules += [
             'ensure_redhat_gpgkey_installed',
         ]


### PR DESCRIPTION
The linked bug in Ansible affects also our Playbooks running on RHEL 10.1, because the postquantum GPG key has been introduced to RHEL in RHEL 10.1.