### PR TITLE
Extend ntpd waiver, disable ccn_advanced on 9.4 osbuild

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -150,7 +150,7 @@
 
 # https://github.com/ComplianceAsCode/content/issues/14541
 /hardening/host-os/(oscap|ansible)/stig/chronyd_or_ntpd_set_maxpoll
-    rhel == 9 and arch == 'ppc64le'
+    rhel == 9 and arch in ('ppc64le', 's390x')
 
 # https://github.com/ComplianceAsCode/content/issues/14546
 /hardening/image-builder/(uefi/)?cis(_workstation_l2)?/ensure_redhat_gpgkey_installed

--- a/hardening/image-builder/main.fmf
+++ b/hardening/image-builder/main.fmf
@@ -119,6 +119,9 @@ extra-priority: 1
       - when: distro != rhel-9 and distro != centos-stream-9
         enabled: false
         because: CCN profiles are only on RHEL-9
+      - when: distro ~< rhel-9.6
+        enabled: false
+        because: too old osbuild-composer to have the profile added
 
 /ccn_intermediate:
     tag+:
@@ -127,6 +130,9 @@ extra-priority: 1
       - when: distro != rhel-9 and distro != centos-stream-9
         enabled: false
         because: CCN profiles are only on RHEL-9
+      - when: distro ~< rhel-9.6
+        enabled: false
+        because: too old osbuild-composer to have the profile added
 
 /ccn_basic:
     tag+:
@@ -135,3 +141,6 @@ extra-priority: 1
       - when: distro != rhel-9 and distro != centos-stream-9
         enabled: false
         because: CCN profiles are only on RHEL-9
+      - when: distro ~< rhel-9.6
+        enabled: false
+        because: too old osbuild-composer to have the profile added


### PR DESCRIPTION
These are from the last weekly productization, in addition to https://github.com/RHSecurityCompliance/contest/pull/579, which was fixed separately.