### PR TITLE
Stop `sshd` before reboot (prevent reconnect/reboot race)

### DIFF
--- a/lib/util/environment.py
+++ b/lib/util/environment.py
@@ -16,6 +16,7 @@ def reboot():
     """Reboot the system using whatever means appropriate."""
     # flush buffers to disk, just in case reboot doesn't do it
     os.sync()
+
     if 'ATEX_TEST_CONTROL' in os.environ:
         fd = int(os.environ['ATEX_TEST_CONTROL'])
         with os.fdopen(fd, 'w', closefd=False) as control:
@@ -30,16 +31,24 @@ def reboot():
                 except BrokenPipeError:
                     break
                 time.sleep(0.1)
-        # do reboot without util.log() output as the ssh stdio might be broken
-        # from the above - the DEVNULL also ensures 'reboot' can safely write
-        # to its outputs without getting EPIPE
+        # do these without util.log() output as the ssh stdio might be broken
+        # from the above - the DEVNULL also ensures the commands can safely write
+        # to their outputs without getting EPIPE
+        # - shut down sshd so the test executor doesn't reconnect before reboot
+        subprocess.run(
+            ['systemctl', 'stop', 'sshd'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT,
+        )
+        # - actually reboot the OS
         subprocess.run(['reboot'], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+
     elif shutil.which('tmt-reboot'):
         util.subprocess_run(['tmt-reboot'])
     elif shutil.which('rstrnt-reboot'):
         util.subprocess_run(['rstrnt-reboot'])
     else:
         util.subprocess_run(['reboot'])
+
     while True:
         time.sleep(1000000)
 


### PR DESCRIPTION
The ATEX disconnect method reliably waits for the test to be at a deterministic point, but that doesn't stop another race from happening **after** issuing `reboot`.

For example:

1. `systemd` kills all user sessions first (ahead of system daemons), also killing off the python-based test running over `ssh`
1. ATEX sees ssh disconnect, but that was expected since the control channel was already disconnected safely, so it "waits for reboot" by repeatedly attempting a reconnect
1. The reconnect succeeds, because `sshd` still wasn't shut down, despite user sessions being killed - maybe the OS is blocked for 2-3 minutes on a less important daemon shutting down before `sshd`
1. ATEX restarts the test, assuming the OS has rebooted

This can be easily prevented by shutting off `sshd` and thus preventing new connections while keeping existing sessions alive. That ensures ATEX can never reconnect until something starts `sshd` again, which should happen only after the reboot.

This race was reliably reproducible on ppc64le, perhaps due to some daemons shutting down very slowly.