### PR TITLE
Update osbuild.py to use 30 GiB disk size

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -134,10 +134,6 @@
 /hardening/image-builder/uefi/ism_o_top_secret
     rhel == 10 and status == 'error'
 
-# https://github.com/ComplianceAsCode/content/issues/14551
-/hardening/image-builder/stig
-    rhel == 8 and status == 'error'
-
 # File /boot/grub2/grub2.cfg is created with lenient permissions by
 # bootupd during the installation of a bootable container image.
 # Tests still fail on RHEL 10.0

--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -38,6 +38,11 @@ from pathlib import Path
 
 from lib import util, dnf, virt
 
+# composer-cli compose start --size: disk image size in MiB.
+# 30 GiB should be enough for all profiles, e.g. STIG which uses 10 GiB
+# /var/log/audit partition because of DISA requirements.
+QCOW2_IMAGE_SIZE_MIB = 30 * 1024
+
 
 class Host:
     @staticmethod
@@ -150,7 +155,10 @@ class Compose:
                 composer_cli('compose', 'cancel', entry.id)
             composer_cli('compose', 'delete', entry.id)
         # start and wait
-        composer_cli('compose', 'start', blueprint_name, 'qcow2')
+        composer_cli(
+            'compose', 'start', blueprint_name, 'qcow2',
+            '--size', str(QCOW2_IMAGE_SIZE_MIB),
+        )
         entry = cls._wait_for_finished(blueprint_name)
         # check & yield
         if entry.status != 'FINISHED':
@@ -378,6 +386,38 @@ def translate_oscap_blueprint(lines, datastream):
         f'name = "{Blueprint.NAME}"',
         bp_text, count=1, flags=re.M,
     )
+
+    # Partitioning mode defaults to auto-lvm which uses lvm because we use
+    # filesystem customizations in blueprints; root LV then stays near the
+    # 1 GiB / + 2 GiB /usr hard-coded minimum size with free space left in the VG.
+    # Switch to raw layout which grows the / partition to fill the disk, see
+    # https://osbuild.org/docs/user-guide/partitioning/
+    # https://osbuild.org/docs/user-guide/blueprint-reference/#partitioning-mode
+    bp_new = re.sub(
+        r'^partitioning_mode\s*=\s*"[^"]*"\s*$',
+        'partitioning_mode = "raw"',
+        bp_text,
+        count=1,
+        flags=re.M,
+    )
+    if bp_new != bp_text:
+        bp_text = bp_new
+    elif not re.search(r'^partitioning_mode\s*=\s*"raw"\s*$', bp_text, flags=re.M):
+        bp_text, inserted = re.subn(
+            r'^(\[customizations\]\s*\n)',
+            r'\1partitioning_mode = "raw"\n',
+            bp_text,
+            count=1,
+            flags=re.M,
+        )
+        if not inserted:
+            bp_text = re.sub(
+                r'^(version = .*\n)',
+                r'\1\n[customizations]\npartitioning_mode = "raw"\n',
+                bp_text,
+                count=1,
+                flags=re.M,
+            )
 
     blueprint = Blueprint(template=bp_text)
 


### PR DESCRIPTION
Switch to `partitioning_mode = "raw"` to make sure that `/`
filesystem is grown to fill any left over space on the partition
table which is not the default behavior with `auto-lvm` and filesystem
customizations in blueprint, see
https://osbuild.org/docs/user-guide/partitioning/
https://osbuild.org/docs/user-guide/blueprint-reference/#partitioning-mode
    
Before this update the disk for imported VM could have been smaller
based on filesystem customizations in blueprint and with `auto-lvm`
partitioning mode it only allocated 1 GiB for `/` and 2 GiB for `/usr`,
if `/usr` was not on a separate partition `/` filesystem was configured
to have 3 GiB. This was not enough for some profiles like STIG.
    
Additionally, STIG also uses 10 GiB for `/var/log/audit`. To make sure
there is enough space on VM disk update `composer-cli compose start`
to always allocate 30 GiB disk which should be enough for all profiles.
Note: `virt.Guest.import_image` doesn't specify disk size, it only imports
the disk created by `composer-cli`.

Resolves https://github.com/ComplianceAsCode/content/issues/14551