### PR TITLE
Remove outdated waiver for ensure_redhat_gpgkey_installed

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -153,10 +153,6 @@
 /hardening/kickstart/(uefi/)?cis(_workstation_l2)?/ensure_redhat_gpgkey_installed
     rhel == 10
 
-# https://github.com/ComplianceAsCode/content/issues/14594
-/hardening/container/[^/]+/(cis|cis_workstation_l2)/ensure_redhat_gpgkey_installed
-    rhel == 10.0
-
 # https://github.com/ComplianceAsCode/content/issues/14558
 /scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*kdump.service.*
 /scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*Failed to start Crash recovery kernel arming.*


### PR DESCRIPTION
ComplianceAsCode/content#14594 has been resolved and closed.

Productization output:

```
The following waiver sections reference ComplianceAsCode issues that have
been closed for more than 14 days. Consider removing these waivers
or updating them if the underlying issues are truly resolved.
Waiver section: contest/conf/waivers/productization:156
Section content:
  # https://github.com/ComplianceAsCode/content/issues/14594
  /hardening/container/[^/]+/(cis|cis_workstation_l2)/ensure_redhat_gpgkey_installed
GitHub issues (all closed):
 - Issue #14594: Remediations of `ensure_redhat_gpgkey_installed` incorrectly call `sq` on RHEL 10.0
    Closed 14 days ago'
++ echo '
OUTDATED WAIVER SECTIONS found: 1
The following waiver sections reference ComplianceAsCode issues that have
been closed for more than 14 days. Consider removing these waivers
or updating them if the underlying issues are truly resolved.
Waiver section: contest/conf/waivers/productization:156
Section content:
  # https://github.com/ComplianceAsCode/content/issues/14594
  /hardening/container/[^/]+/(cis|cis_workstation_l2)/ensure_redhat_gpgkey_installed
GitHub issues (all closed):
 - Issue #14594: Remediations of `ensure_redhat_gpgkey_installed` incorrectly call `sq` on RHEL 10.0
    Closed 14 days ago'
```