### PR TITLE
Add a test scanning hummingbird images

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -130,4 +130,9 @@
 /scanning/boot-errors/.+/rsyslogd.+(certificate.*is not set|key.*is not set|cannot resolve hostname).*
     True
 
+# These rules fail in the default Hummingbird container images,
+# hardening needs to be done on the Hummingbird project side.
+/scanning/hummingbird/.+/accounts_umask_etc_(bashrc|profile)
+    True
+
 # vim: syntax=python

--- a/scanning/hummingbird/main.fmf
+++ b/scanning/hummingbird/main.fmf
@@ -1,0 +1,22 @@
+summary: Scan hummingbird containers
+description: |
+  Build Hummingbird product content and scan Hummingbird container images
+  using oscap-podman.
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
+environment+:
+    PYTHONPATH: ../..
+duration: 30m
+require+:
+  - openscap-utils
+  - podman
+adjust+:
+  - when: arch != x86_64
+    enabled: false
+    because: sufficient to check only on x86_64
+  - when: distro < rhel-10
+    enabled: false
+    because: sufficient to run only on RHEL 10
+
+/stig:
+
+/cis:

--- a/scanning/hummingbird/test.py
+++ b/scanning/hummingbird/test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import subprocess
+
+from lib import results, oscap, podman, util
+
+IMAGE = 'openjdk'
+profile = util.get_test_name().rpartition('/')[2]
+# Some profiles are expected to be applicable only to the FIPS variant of the
+# container image. Some profiles are expected to be applicable only on default
+# variants of container images.
+if profile in ('stig',):
+    variant = 'latest-fips'
+else:
+    variant = 'latest'
+image_id = f'quay.io/hummingbird-hatchling/{IMAGE}:{variant}'
+podman.podman('pull', image_id)
+
+with util.get_source_content() as content_dir:
+    # Hummingbird is a separate product in ComplianceAsCode/content
+    util.build_content(
+        content_dir,
+        {
+            'SSG_PRODUCT_HUMMINGBIRD:BOOL': 'ON',
+        },
+    )
+    ds_path = content_dir / util.CONTENT_BUILD_DIR / 'ssg-hummingbird-ds.xml'
+    if not ds_path.exists():
+        raise RuntimeError(f"Datastream not found: {ds_path}")
+
+    proc, lines = util.subprocess_stream(
+        [
+            'oscap-podman', image_id, 'xccdf', 'eval', '--profile', profile, '--progress',
+            '--report', 'report.html', '--results-arf', 'scan-arf.xml', ds_path,
+        ],
+        stderr=subprocess.STDOUT,
+    )
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0, 2]:
+        raise RuntimeError("oscap failed unexpectedly")
+
+results.report_and_exit(logs=['report.html', 'scan-arf.xml'])


### PR DESCRIPTION
The new test `/scanning/hummingbird` will build Hummingbird product content and scan Hummingbird container image using `oscap-podman`.

The test consists of 2 tests `cis` and `stig` so that both existing profiles in the data stream are covered.