### PR TITLE
Add retry wrapper for oscap per-rule scans

### DIFF
--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -57,7 +57,6 @@ function oscap_scan_retry {
     fi
 
     echo "$output"
-    return $rc
 }
 
 datastream=$thin_ds_dir/$rule.xml

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -29,6 +29,31 @@ debug_arg=$5        # debug or nodebug
 
 function debug { [[ $debug_arg == debug ]]; }
 
+# Retry wrapper for oscap scans
+# Args: max_attempts oscap_args...
+# Retries on unexpected exit codes (errors, segfaults, crashes, etc.)
+# Only exit codes 0 and 2 are considered successful
+function oscap_scan_retry {
+    local max_attempts=$1
+    shift
+    local attempt rc output
+
+    for ((attempt=1; attempt<=max_attempts; attempt++)); do
+        output=$(oscap "$@"); rc=$?
+
+        # exit codes 0 and 2 are expected (success and rule failure)
+        if [[ $rc == 0 || $rc == 2 ]]; then
+            break
+        fi
+
+        # log the failure
+        echo "oscap attempt $attempt/$max_attempts failed with exit code $rc" >&2
+    done
+
+    echo "$output"
+    return $rc
+}
+
 datastream=$thin_ds_dir/$rule.xml
 playbook=$playbooks_dir/$rule.yml
 variables_file=$variables_dir/$rule/$test_name.$test_type
@@ -125,7 +150,7 @@ rule_full=xccdf_org.ssgproject.content_rule_$rule
 if debug; then
     rc=0
     out=$(
-        oscap xccdf eval --profile '(all)' --rule "$rule_full" --progress \
+        oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" --progress \
         --report initial-report.html --results-arf initial-results-arf.xml \
         "$datastream"
     ) || rc=$?
@@ -164,7 +189,7 @@ fi
 if [[ $test_type == pass ]]; then
     rc=0
     out=$(
-        oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+        oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
         --progress "${oscap_reports[@]}" "$datastream"
     ) || rc=$?
     if [[ $rc != 0 && $rc != 2 ]]; then
@@ -187,7 +212,7 @@ elif [[ $test_type == fail ]]; then
     if [[ $remediation == none ]]; then
         rc=0
         out=$(
-            oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+            oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
             --progress "${oscap_reports[@]}" "$datastream"
         ) || rc=$?
 
@@ -262,7 +287,7 @@ elif [[ $test_type == fail ]]; then
 
         rc=0
         out=$(
-            oscap xccdf eval --profile '(all)' --rule "$rule_full" \
+            oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
             --progress "${oscap_reports[@]}" "$datastream"
         ) || rc=$?
 

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -51,6 +51,11 @@ function oscap_scan_retry {
         echo "oscap attempt $attempt/$max_attempts failed with exit code $rc" >&2
     done
 
+    # if all retries failed, exit with error
+    if [[ $rc != 0 && $rc != 2 ]]; then
+        exit_err "oscap exited unexpectedly with $rc after $max_attempts attempts"
+    fi
+
     echo "$output"
     return $rc
 }
@@ -149,15 +154,11 @@ rule_full=xccdf_org.ssgproject.content_rule_$rule
 
 # do a scan prior to running the test script
 if debug; then
-    rc=0
     out=$(
         oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" --progress \
         --report initial-report.html --results-arf initial-results-arf.xml \
         "$datastream"
-    ) || rc=$?
-    if [[ $rc != 0 && $rc != 2 ]]; then
-        exit_err "oscap exited unexpectedly with $rc"
-    fi
+    )
 fi
 
 # run test script
@@ -188,14 +189,10 @@ fi
 
 # just do an oscap scan, expect it to pass
 if [[ $test_type == pass ]]; then
-    rc=0
     out=$(
         oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
         --progress "${oscap_reports[@]}" "$datastream"
-    ) || rc=$?
-    if [[ $rc != 0 && $rc != 2 ]]; then
-        exit_err "oscap exited unexpectedly with $rc"
-    fi
+    )
 
     IFS=: read -r oscap_rule oscap_status <<<"$out"
     if [[ $oscap_rule != $rule_full ]]; then
@@ -211,15 +208,10 @@ if [[ $test_type == pass ]]; then
 elif [[ $test_type == fail ]]; then
     # just do an oscap scan, expect it to fail
     if [[ $remediation == none ]]; then
-        rc=0
         out=$(
             oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
             --progress "${oscap_reports[@]}" "$datastream"
-        ) || rc=$?
-
-        if [[ $rc != 0 && $rc != 2 ]]; then
-            exit_err "oscap exited unexpectedly with $rc"
-        fi
+        )
 
         IFS=: read -r oscap_rule oscap_status <<<"$out"
         if [[ $oscap_rule != $rule_full ]]; then
@@ -286,15 +278,10 @@ elif [[ $test_type == fail ]]; then
             exit_err "ansible-playbook exited unexpectedly with $rc"
         fi
 
-        rc=0
         out=$(
             oscap_scan_retry 5 xccdf eval --profile '(all)' --rule "$rule_full" \
             --progress "${oscap_reports[@]}" "$datastream"
-        ) || rc=$?
-
-        if [[ $rc != 0 && $rc != 2 ]]; then
-            exit_err "oscap exited unexpectedly with $rc"
-        fi
+        )
 
         IFS=: read -r oscap_rule oscap_status <<<"$out"
         if [[ $oscap_rule != $rule_full ]]; then

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -34,12 +34,12 @@ function debug { [[ $debug_arg == debug ]]; }
 # Retries on unexpected exit codes (errors, segfaults, crashes, etc.)
 # Only exit codes 0 and 2 are considered successful
 function oscap_scan_retry {
-    local max_attempts=$1
+    local max_attempts=$1 attempt rc output
     shift
-    local attempt rc output
 
     for ((attempt=1; attempt<=max_attempts; attempt++)); do
-        output=$(oscap "$@"); rc=$?
+        rc=0
+        output=$(oscap "$@") || rc=$?
 
         # exit codes 0 and 2 are expected (success and rule failure)
         if [[ $rc == 0 || $rc == 2 ]]; then
@@ -47,6 +47,7 @@ function oscap_scan_retry {
         fi
 
         # log the failure
+        echo "$output" >&2
         echo "oscap attempt $attempt/$max_attempts failed with exit code $rc" >&2
     done
 


### PR DESCRIPTION
#### Description

- Add `oscap_scan_retry` function to repeat `per-rule` scan in case of unexpected exit codes (errors, segfaults, crashes, etc.)
- Function accepts a configurable `max_attempts` parameter (currently set to 5)

#### Rationale

- Fix #548
