### PR TITLE
Add more testing to `plans-upstream`

### DIFF
--- a/plans/upstream-parallel.fmf
+++ b/plans/upstream-parallel.fmf
@@ -103,14 +103,66 @@ environment:
 /ansible/ccn_basic:
     discover+: {test: /hardening/host-os/ansible/ccn_basic$}
 
-/static-checks:
-    discover+:
-        test:
-          - /static-checks
-        exclude:
-          # frequently fails on transient issues, run it only in stabilization
-          - /static-checks/html-links
-          # not useful in automated runs that are not manually reviewed
-          - /static-checks/diff
+/other:
+    /static-checks:
+        discover+:
+            test:
+              - /static-checks
+            exclude:
+              # frequently fails on transient issues, run it only in stabilization
+              - /static-checks/html-links
+              # not useful in automated runs that are not manually reviewed
+              - /static-checks/diff
+    /scanning:
+        discover+:
+            test:
+              # others are too time-consuming or fail due to external factors
+              - /scanning/audit-rules-syscalls-grouping
+              - /scanning/container-rules-applicability
+    /ansible-check-mode:
+        /anssi_bp28_high:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/anssi_bp28_high$}
+        /anssi_bp28_enhanced:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/anssi_bp28_enhanced$}
+        /anssi_bp28_intermediary:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/anssi_bp28_intermediary$}
+        /anssi_bp28_minimal:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/anssi_bp28_minimal$}
+        /bsi:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/bsi$}
+        /cis:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/cis$}
+        /cis_server_l1:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/cis_server_l1$}
+        /cis_workstation_l2:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/cis_workstation_l2$}
+        /cis_workstation_l1:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/cis_workstation_l1$}
+        /cui:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/cui$}
+        /e8:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/e8$}
+        /hipaa:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/hipaa$}
+        /ism_o:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ism_o$}
+        /ism_o_secret:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ism_o_secret$}
+        /ism_o_top_secret:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ism_o_top_secret$}
+        /ospp:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ospp$}
+        /pci-dss:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/pci-dss$}
+        /stig:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/stig$}
+        /stig_gui:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/stig_gui$}
+        /ccn_advanced:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ccn_advanced$}
+        /ccn_intermediate:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ccn_intermediate$}
+        /ccn_basic:
+            discover+: {test: /scanning/host-os/ansible-check/check-mode/ccn_basic$}
 
 # vim: syntax=yaml

--- a/plans/upstream-parallel.fmf
+++ b/plans/upstream-parallel.fmf
@@ -13,95 +13,97 @@ environment:
 # (if test is not relevant) are silently SKIPPED for any given RHEL or
 # CentOS Stream combination
 
-/oscap/anssi_bp28_high:
-    discover+: {test: /hardening/host-os/oscap/anssi_bp28_high$}
-/oscap/anssi_bp28_enhanced:
-    discover+: {test: /hardening/host-os/oscap/anssi_bp28_enhanced$}
-/oscap/anssi_bp28_intermediary:
-    discover+: {test: /hardening/host-os/oscap/anssi_bp28_intermediary$}
-/oscap/anssi_bp28_minimal:
-    discover+: {test: /hardening/host-os/oscap/anssi_bp28_minimal$}
-/oscap/bsi:
-    discover+: {test: /hardening/host-os/oscap/bsi$}
-/oscap/cis:
-    discover+: {test: /hardening/host-os/oscap/cis$}
-/oscap/cis_server_l1:
-    discover+: {test: /hardening/host-os/oscap/cis_server_l1$}
-/oscap/cis_workstation_l2:
-    discover+: {test: /hardening/host-os/oscap/cis_workstation_l2$}
-/oscap/cis_workstation_l1:
-    discover+: {test: /hardening/host-os/oscap/cis_workstation_l1$}
-/oscap/cui:
-    discover+: {test: /hardening/host-os/oscap/cui$}
-/oscap/e8:
-    discover+: {test: /hardening/host-os/oscap/e8$}
-/oscap/hipaa:
-    discover+: {test: /hardening/host-os/oscap/hipaa$}
-/oscap/ism_o:
-    discover+: {test: /hardening/host-os/oscap/ism_o$}
-/oscap/ism_o_secret:
-    discover+: {test: /hardening/host-os/oscap/ism_o_secret$}
-/oscap/ism_o_top_secret:
-    discover+: {test: /hardening/host-os/oscap/ism_o_top_secret$}
-/oscap/ospp:
-    discover+: {test: /hardening/host-os/oscap/ospp$}
-/oscap/pci-dss:
-    discover+: {test: /hardening/host-os/oscap/pci-dss$}
-/oscap/stig:
-    discover+: {test: /hardening/host-os/oscap/stig$}
-/oscap/stig_gui:
-    discover+: {test: /hardening/host-os/oscap/stig_gui$}
-/oscap/ccn_advanced:
-    discover+: {test: /hardening/host-os/oscap/ccn_advanced$}
-/oscap/ccn_intermediate:
-    discover+: {test: /hardening/host-os/oscap/ccn_intermediate$}
-/oscap/ccn_basic:
-    discover+: {test: /hardening/host-os/oscap/ccn_basic$}
+/oscap:
+    /anssi_bp28_high:
+        discover+: {test: /hardening/host-os/oscap/anssi_bp28_high$}
+    /anssi_bp28_enhanced:
+        discover+: {test: /hardening/host-os/oscap/anssi_bp28_enhanced$}
+    /anssi_bp28_intermediary:
+        discover+: {test: /hardening/host-os/oscap/anssi_bp28_intermediary$}
+    /anssi_bp28_minimal:
+        discover+: {test: /hardening/host-os/oscap/anssi_bp28_minimal$}
+    /bsi:
+        discover+: {test: /hardening/host-os/oscap/bsi$}
+    /cis:
+        discover+: {test: /hardening/host-os/oscap/cis$}
+    /cis_server_l1:
+        discover+: {test: /hardening/host-os/oscap/cis_server_l1$}
+    /cis_workstation_l2:
+        discover+: {test: /hardening/host-os/oscap/cis_workstation_l2$}
+    /cis_workstation_l1:
+        discover+: {test: /hardening/host-os/oscap/cis_workstation_l1$}
+    /cui:
+        discover+: {test: /hardening/host-os/oscap/cui$}
+    /e8:
+        discover+: {test: /hardening/host-os/oscap/e8$}
+    /hipaa:
+        discover+: {test: /hardening/host-os/oscap/hipaa$}
+    /ism_o:
+        discover+: {test: /hardening/host-os/oscap/ism_o$}
+    /ism_o_secret:
+        discover+: {test: /hardening/host-os/oscap/ism_o_secret$}
+    /ism_o_top_secret:
+        discover+: {test: /hardening/host-os/oscap/ism_o_top_secret$}
+    /ospp:
+        discover+: {test: /hardening/host-os/oscap/ospp$}
+    /pci-dss:
+        discover+: {test: /hardening/host-os/oscap/pci-dss$}
+    /stig:
+        discover+: {test: /hardening/host-os/oscap/stig$}
+    /stig_gui:
+        discover+: {test: /hardening/host-os/oscap/stig_gui$}
+    /ccn_advanced:
+        discover+: {test: /hardening/host-os/oscap/ccn_advanced$}
+    /ccn_intermediate:
+        discover+: {test: /hardening/host-os/oscap/ccn_intermediate$}
+    /ccn_basic:
+        discover+: {test: /hardening/host-os/oscap/ccn_basic$}
 
-/ansible/anssi_bp28_high:
-    discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
-/ansible/anssi_bp28_enhanced:
-    discover+: {test: /hardening/host-os/ansible/anssi_bp28_enhanced$}
-/ansible/anssi_bp28_intermediary:
-    discover+: {test: /hardening/host-os/ansible/anssi_bp28_intermediary$}
-/ansible/anssi_bp28_minimal:
-    discover+: {test: /hardening/host-os/ansible/anssi_bp28_minimal$}
-/ansible/bsi:
-    discover+: {test: /hardening/host-os/ansible/bsi$}
-/ansible/cis:
-    discover+: {test: /hardening/host-os/ansible/cis$}
-/ansible/cis_server_l1:
-    discover+: {test: /hardening/host-os/ansible/cis_server_l1$}
-/ansible/cis_workstation_l2:
-    discover+: {test: /hardening/host-os/ansible/cis_workstation_l2$}
-/ansible/cis_workstation_l1:
-    discover+: {test: /hardening/host-os/ansible/cis_workstation_l1$}
-/ansible/cui:
-    discover+: {test: /hardening/host-os/ansible/cui$}
-/ansible/e8:
-    discover+: {test: /hardening/host-os/ansible/e8$}
-/ansible/hipaa:
-    discover+: {test: /hardening/host-os/ansible/hipaa$}
-/ansible/ism_o:
-    discover+: {test: /hardening/host-os/ansible/ism_o$}
-/ansible/ism_o_secret:
-    discover+: {test: /hardening/host-os/ansible/ism_o_secret$}
-/ansible/ism_o_top_secret:
-    discover+: {test: /hardening/host-os/ansible/ism_o_top_secret$}
-/ansible/ospp:
-    discover+: {test: /hardening/host-os/ansible/ospp$}
-/ansible/pci-dss:
-    discover+: {test: /hardening/host-os/ansible/pci-dss$}
-/ansible/stig:
-    discover+: {test: /hardening/host-os/ansible/stig$}
-/ansible/stig_gui:
-    discover+: {test: /hardening/host-os/ansible/stig_gui$}
-/ansible/ccn_advanced:
-    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
-/ansible/ccn_intermediate:
-    discover+: {test: /hardening/host-os/ansible/ccn_intermediate$}
-/ansible/ccn_basic:
-    discover+: {test: /hardening/host-os/ansible/ccn_basic$}
+/ansible:
+    /anssi_bp28_high:
+        discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
+    /anssi_bp28_enhanced:
+        discover+: {test: /hardening/host-os/ansible/anssi_bp28_enhanced$}
+    /anssi_bp28_intermediary:
+        discover+: {test: /hardening/host-os/ansible/anssi_bp28_intermediary$}
+    /anssi_bp28_minimal:
+        discover+: {test: /hardening/host-os/ansible/anssi_bp28_minimal$}
+    /bsi:
+        discover+: {test: /hardening/host-os/ansible/bsi$}
+    /cis:
+        discover+: {test: /hardening/host-os/ansible/cis$}
+    /cis_server_l1:
+        discover+: {test: /hardening/host-os/ansible/cis_server_l1$}
+    /cis_workstation_l2:
+        discover+: {test: /hardening/host-os/ansible/cis_workstation_l2$}
+    /cis_workstation_l1:
+        discover+: {test: /hardening/host-os/ansible/cis_workstation_l1$}
+    /cui:
+        discover+: {test: /hardening/host-os/ansible/cui$}
+    /e8:
+        discover+: {test: /hardening/host-os/ansible/e8$}
+    /hipaa:
+        discover+: {test: /hardening/host-os/ansible/hipaa$}
+    /ism_o:
+        discover+: {test: /hardening/host-os/ansible/ism_o$}
+    /ism_o_secret:
+        discover+: {test: /hardening/host-os/ansible/ism_o_secret$}
+    /ism_o_top_secret:
+        discover+: {test: /hardening/host-os/ansible/ism_o_top_secret$}
+    /ospp:
+        discover+: {test: /hardening/host-os/ansible/ospp$}
+    /pci-dss:
+        discover+: {test: /hardening/host-os/ansible/pci-dss$}
+    /stig:
+        discover+: {test: /hardening/host-os/ansible/stig$}
+    /stig_gui:
+        discover+: {test: /hardening/host-os/ansible/stig_gui$}
+    /ccn_advanced:
+        discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
+    /ccn_intermediate:
+        discover+: {test: /hardening/host-os/ansible/ccn_intermediate$}
+    /ccn_basic:
+        discover+: {test: /hardening/host-os/ansible/ccn_basic$}
 
 /other:
     /static-checks:


### PR DESCRIPTION
It turns out we never configured the `/static-checks` to run in https://github.com/ComplianceAsCode/content/blob/07c4c5ac26ede5e3c132952209f50c074588f1bb/.packit.yaml#L26-L44 so that section of `plans/upstream-parallel.fmf` is dead.

So, instead of enabling it, I refactored it into `/other` and included `/static-checks` and some safe-enough `/scanning` tests too, as parallel plans.

The idea is that we only add a third `-other` Packit job (so we get `contest-oscap`, `contest-ansible`, `contest-other` for EACH CentOS Stream in CaC/content), but run multiple parallel plans within each Packit job.

In this case, each Ansible check-mode runs in parallel, and is a copy/paste of the above.

A second commit also refactors the original hardening oscap/ansible sections to reduce visual clutter - no behavior change, only syntax change.

---

~Do not merge yet, this uncovered some ansible playbook syntax issues that likely should be fixed first.~