### PR TITLE
Report Ansible check-mode failures as `fail`

### DIFF
--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -36,13 +36,17 @@ def install_deps():
             )
 
 
-def report_from_output(lines, to_file=None):
+def report_from_output(lines, to_file=None, failure='error'):
     """
     Process 'ansible-playbook' output, hide useless info, and report important
     info.
 
     If 'to_file' was specified as a file path, redirect ansible-playbook
     outputs to it, instead of leaving them on the console.
+
+    The 'failure' argument dictates what status to use for failing playbook
+    results. The default 'error' is sensible for uses where the playbook is not
+    the test itself. If it is, set it to 'fail'.
 
     Return True whether there was at least one 'failed' module check.
     This can be used by the caller to differentiate between ansible-playbook
@@ -79,7 +83,7 @@ def report_from_output(lines, to_file=None):
             if m:
                 status, _, _, data = m.groups()
                 if status in ['failed', 'fatal']:
-                    results.report('error', f'playbook: {task}', data)
+                    results.report(failure, f'playbook: {task}', data)
                     failed = True
                 continue
 

--- a/scanning/host-os/ansible-check/check-mode/test.py
+++ b/scanning/host-os/ansible-check/check-mode/test.py
@@ -23,7 +23,7 @@ ansible_cmd = [
 ]
 proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
 ansible.report_from_output(lines, to_file='ansible-playbook.log')
-results.add_log('ansible-playbook.log')
-if proc.returncode != 0:
-    raise RuntimeError(f"ansible-playbook failed with {proc.returncode}")
-results.report_and_exit()
+results.report_and_exit(
+    'pass' if proc.returncode == 0 else 'fail',
+    logs=['ansible-playbook.log'],
+)

--- a/scanning/host-os/ansible-check/check-mode/test.py
+++ b/scanning/host-os/ansible-check/check-mode/test.py
@@ -22,7 +22,7 @@ ansible_cmd = [
     *skip_tags_arg, playbook,
 ]
 proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
-ansible.report_from_output(lines, to_file='ansible-playbook.log')
+ansible.report_from_output(lines, to_file='ansible-playbook.log', failure='fail')
 results.report_and_exit(
     'pass' if proc.returncode == 0 else 'fail',
     logs=['ansible-playbook.log'],


### PR DESCRIPTION
The issues being reported as errors (exceptions) trips up Oculus (Testing Farm results viewer) as infra issues.

https://artifacts.dev.testing-farm.io/2d03354c-b95b-4e17-8f1b-29deee8c88c2/

And `fail` makes more sense here - the **intent** of the test is to check for issues. And `ansible-playbook --check` failing means issues were found (the tested functionality failed).

Nothing unexpected (`error`) happened.

Related (but maybe not fully fixed): https://github.com/RHSecurityCompliance/contest/issues/518