### PR TITLE
Fix ansible-galaxy locale error in per-rule %post

### DIFF
--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -142,12 +142,12 @@ with util.get_source_content() as content_dir:
             EOF
         '''))
     else:
-        # OPENSCAP-6756: Fixes "Ansible requires the locale encoding to be UTF-8; Detected None."
-        # has to be in the %post as it is a sibling process to the installer, not a child
+        # Set the locale to fix the error:
+        #   Ansible requires the locale encoding to be UTF-8; Detected None.
+        # The locale has to be set in the %post as it is running in a separate sibling process to the installer, not in its child process.
         ks.add_post(util.dedent('''
             export LC_ALL=en_US.UTF-8
-            ansible-galaxy collection install community.general
-            ansible-galaxy collection install ansible.posix
+            ansible-galaxy collection install community.general ansible.posix
         '''))
 
     # install the VM

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -144,7 +144,8 @@ with util.get_source_content() as content_dir:
     else:
         # Set the locale to fix the error:
         #   Ansible requires the locale encoding to be UTF-8; Detected None.
-        # The locale has to be set in the %post as it is running in a separate sibling process to the installer, not in its child process.
+        # The locale has to be set in the %post because it is running in a separate
+        # sibling process to the installer, not in its child process.
         ks.add_post(util.dedent('''
             export LC_ALL=en_US.UTF-8
             ansible-galaxy collection install community.general ansible.posix

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -142,7 +142,10 @@ with util.get_source_content() as content_dir:
             EOF
         '''))
     else:
+        # OPENSCAP-6756: Fixes "Ansible requires the locale encoding to be UTF-8; Detected None."
+        # has to be in the %post as it is a sibling process to the installer, not a child
         ks.add_post(util.dedent('''
+            export LC_ALL=en_US.UTF-8
             ansible-galaxy collection install community.general
             ansible-galaxy collection install ansible.posix
         '''))


### PR DESCRIPTION
#### Description:

- Export `LC_ALL=en_US.UTF-8` in the per-rule `%post` kickstart script before running `ansible-galaxy`, fixing the "Ansible requires the locale encoding to be UTF-8; Detected None" error on CentOS.

#### Rationale:

- Anaconda's `%post` chroot does not inherit locale settings from the kickstart `lang` directive — each `%post` block is a sibling process spawned by Anaconda, not a child of the installed system. Without an explicit locale, `ansible-galaxy` refuses to run.

#### Review Hints:

- The only file changed is `per-rule/test.py`. The kickstart `lang` directive was intentionally **not** added to the base template in `lib/virt.py` since it doesn't help inside `%post`.
- To verify: run e.g. `/per-rule/oscap/4` on CentOS Stream — the VM installation should succeed without the locale error.