### PR TITLE
Extend waiver for sshd_include_crypto_policy

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -179,7 +179,7 @@
     rhel in [8, 9]
 
 # https://github.com/ComplianceAsCode/content/issues/14668
-/scanning/disa-alignment/oscap/sshd_include_crypto_policy
+/scanning/disa-alignment/(ansible|oscap)/sshd_include_crypto_policy
     rhel == 9
 
 # https://github.com/ComplianceAsCode/content/issues/14669


### PR DESCRIPTION
The DISA alignment issue in rule sshd_include_crypto_policy on RHEL 9 affects both oscap and ansible variants of the test. https://github.com/ComplianceAsCode/content/issues/14668