### PR TITLE
Fix _rule_has_no_remediation traceback on non-rule sub-result names

### DIFF
--- a/lib/waive.py
+++ b/lib/waive.py
@@ -213,7 +213,12 @@ def match_result(status, name, note):
         # extract the rule name from the test name
         # (e.g. '/hardening/kickstart/stig/configure_crypto_policy')
         rule = name.rpartition('/')[2]
-        return not oscap.global_ds().has_remediation(rule, remediation_type)
+        ds = oscap.global_ds()
+        # there can be non-rule sub-result names (e.g. 'playbook: Ensure aide is installed ...')
+        # so just return False if the extracted rule name is not in the datastream
+        if rule not in ds.rules:
+            return False
+        return not ds.has_remediation(rule, remediation_type)
 
     objs = {
         # result related


### PR DESCRIPTION
After f0f8ccb changed the default failure status from `error` to `fail`, ansible playbook task names (e.g. `playbook: Ensure aide is installed`) started reaching the datastream rule lookup in `_rule_has_no_remediation` which raised `ValueError`. Previously the `status == error` check prevented this.

The solution is to skip the `no_remediation` check when the extracted result name is not a name of SCAP rule in the datastream.