### PR TITLE
Update ansible.posix to 1.4.0 to be compatible with CentOS 10

### DIFF
--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -6,16 +6,18 @@ import subprocess
 
 from lib import util, results, versions
 
-# Versions pinned to match what rhc-worker-playbook bundles on RHEL, so that
-# CentOS/Fedora test results stay close to what customers run.
-#
+# Versions pinned to match what rhc-worker-playbook bundles on RHEL for the
+# given RHEL version, so that CentOS/Fedora test environments are as close
+# as possible to RHEL.
 # RHEL 8/9 (rhc-worker-playbook 0.1.x):
 #   https://gitlab.com/redhat/centos-stream/rpms/rhc-worker-playbook/-/blob/c9s/rhc-worker-playbook.spec
 # RHEL 10  (rhc-worker-playbook 0.2.x):
 #   https://github.com/RedHatInsights/rhc-worker-playbook/blob/main/ansible/meson.build
 ANSIBLE_GALAXY_COLLECTIONS = {
+    8: ['ansible.posix:1.3.0', 'community.general:4.4.0'],
+    9: ['ansible.posix:1.3.0', 'community.general:4.4.0'],
     10: ['ansible.posix:1.5.4', 'community.general:9.2.0'],
-    'default': ['ansible.posix:1.3.0', 'community.general:4.4.0'],
+    'default': ['ansible.posix', 'community.general'],
 }
 
 
@@ -29,14 +31,13 @@ def install_deps():
         os.environ['ANSIBLE_COLLECTIONS_PATH'] = \
             '/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/'
     else:
-        # On Fedora, CentOS, etc., fetch from Galaxy pinned to RHEL versions
-        # Default to RHEL 8/9 collections if no specific version is available
         collections = ANSIBLE_GALAXY_COLLECTIONS.get(
             versions.rhel.major, ANSIBLE_GALAXY_COLLECTIONS['default'],
         )
         util.subprocess_run(
-            ['ansible-galaxy', '-vvv', 'collection', 'install', '--force',
-             *collections],
+            (
+                'ansible-galaxy', '-vvv', 'collection', 'install', '--force', *collections,
+            ),
             check=True,
             stderr=subprocess.PIPE,
         )

--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -26,11 +26,19 @@ def install_deps():
     # Use ansible-galaxy when rhc-worker-playbook not available (Fedora, CentOS, etc.)
     else:
         for collection, version in RHC_WORKER_PLAYBOOK_COLLECTIONS.items():
+            # For CentOS Stream 10+, use ansible.posix 1.4.0 and newer,
+            # as it ships with Python 3.12 and it doesn't contain the distutils package,
+            # on which the ansible.posix 1.3.0 depends.
             if versions.rhel.is_centos():
-                # install the specific version to match rhc-worker-playbook versions
-                collection = f"{collection}:{version}"
+                if versions.rhel.major >= 10 and collection == 'ansible.posix':
+                    version = '1.4.0'
+
             util.subprocess_run(
-                ['ansible-galaxy', '-vvv', 'collection', 'install', collection],
+                ['ansible-galaxy',
+                '-vvv',
+                'collection', 'install',
+                f"{collection}:{version}",
+                '--force'],
                 check=True,
                 stderr=subprocess.PIPE,
             )

--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -6,10 +6,16 @@ import subprocess
 
 from lib import util, results, versions
 
-# collections present in the rhc-worker-playbook package and their versions
-RHC_WORKER_PLAYBOOK_COLLECTIONS = {
-    "community.general": "4.4.0",
-    "ansible.posix": "1.3.0",
+# Versions pinned to match what rhc-worker-playbook bundles on RHEL, so that
+# CentOS/Fedora test results stay close to what customers run.
+#
+# RHEL 8/9 (rhc-worker-playbook 0.1.x):
+#   https://gitlab.com/redhat/centos-stream/rpms/rhc-worker-playbook/-/blob/c9s/rhc-worker-playbook.spec
+# RHEL 10  (rhc-worker-playbook 0.2.x):
+#   https://github.com/RedHatInsights/rhc-worker-playbook/blob/main/ansible/meson.build
+ANSIBLE_GALAXY_COLLECTIONS = {
+    10: ['ansible.posix:1.5.4', 'community.general:9.2.0'],
+    'default': ['ansible.posix:1.3.0', 'community.general:4.4.0'],
 }
 
 
@@ -17,31 +23,23 @@ def install_deps():
     """
     Download and install any external dependencies required for Ansible to run.
     """
-    # On RHEL, rhc-worker-playbook package should be available
     if versions.rhel.is_true_rhel():
-        # export per official instructions on
+        # On RHEL, use collections bundled in rhc-worker-playbook
         # https://access.redhat.com/articles/remediation
         os.environ['ANSIBLE_COLLECTIONS_PATH'] = \
             '/usr/share/rhc-worker-playbook/ansible/collections/ansible_collections/'
-    # Use ansible-galaxy when rhc-worker-playbook not available (Fedora, CentOS, etc.)
     else:
-        for collection, version in RHC_WORKER_PLAYBOOK_COLLECTIONS.items():
-            # For CentOS Stream 10+, use ansible.posix 1.4.0 and newer,
-            # as it ships with Python 3.12 and it doesn't contain the distutils package,
-            # on which the ansible.posix 1.3.0 depends.
-            if versions.rhel.is_centos():
-                if versions.rhel.major >= 10 and collection == 'ansible.posix':
-                    version = '1.4.0'
-
-            util.subprocess_run(
-                ['ansible-galaxy',
-                '-vvv',
-                'collection', 'install',
-                f"{collection}:{version}",
-                '--force'],
-                check=True,
-                stderr=subprocess.PIPE,
-            )
+        # On Fedora, CentOS, etc., fetch from Galaxy pinned to RHEL versions
+        # Default to RHEL 8/9 collections if no specific version is available
+        collections = ANSIBLE_GALAXY_COLLECTIONS.get(
+            versions.rhel.major, ANSIBLE_GALAXY_COLLECTIONS['default'],
+        )
+        util.subprocess_run(
+            ['ansible-galaxy', '-vvv', 'collection', 'install', '--force',
+             *collections],
+            check=True,
+            stderr=subprocess.PIPE,
+        )
 
 
 def report_from_output(lines, to_file=None, failure='fail'):


### PR DESCRIPTION
- CentOS 10 ships with Python 3.12.
- `ansible.posix` 1.3.0 depends on `distutils` which was deprecated in Python 3.12.
- Use the same ansible collections as equivalent RHEL versions (see which are included in the `rhc-worker-playbook`)

Tested locally with /static-checks/ansible/syntax-check - pass.
Tested in https://github.com/ComplianceAsCode/content/pull/14692 - pass.