### PR TITLE
Extend Hummingbird scanning test

### DIFF
--- a/scanning/hummingbird/image/main.fmf
+++ b/scanning/hummingbird/image/main.fmf
@@ -1,10 +1,10 @@
-summary: Scan hummingbird containers
+summary: Scan hummingbird containers using openscap image
 description: |
   Build Hummingbird product content and scan Hummingbird container images
-  using oscap-podman.
+  using the "quay.io/hummingbird/openscap" container image.
 test: $CONTEST_PYTHON -m lib.runtest ./test.py
 environment+:
-    PYTHONPATH: ../..
+    PYTHONPATH: ../../..
 duration: 30m
 require+:
   - openscap-utils
@@ -17,6 +17,12 @@ adjust+:
     enabled: false
     because: sufficient to run only on RHEL 10
 
-/stig:
-
 /cis:
+
+/fips/cis:
+    tag+:
+      - fips
+
+/fips/stig:
+    tag+:
+      - fips

--- a/scanning/hummingbird/image/test.py
+++ b/scanning/hummingbird/image/test.py
@@ -4,8 +4,12 @@ import shutil
 import subprocess
 import tempfile
 
-from lib import results, metadata, oscap, podman, util
 from pathlib import Path
+
+from lib import results, metadata, oscap, podman, util
+
+SCANNER_IMAGE = 'quay.io/hummingbird/openscap:latest'
+podman.podman('pull', SCANNER_IMAGE)
 
 IMAGE = 'openjdk'
 profile = util.get_test_name().rpartition('/')[2]
@@ -31,12 +35,16 @@ with util.get_source_content() as content_dir:
         shutil.copy(ds_path, tempdir)
         proc, lines = util.subprocess_stream(
             [
-                'podman', 'run', '--rm', '--cap-add', 'SYS_CHROOT', '--mount',
-                f'type=image,source={image_id},destination=/target', '-e',
-                'OSCAP_PROBE_ROOT=/target', '-v', f'{tempdir}:/ssg:z,U',
-                'quay.io/hummingbird/openscap:latest', 'xccdf', 'eval',
-                '--progress', '--profile', profile, '--results-arf',
-                '/ssg/scan-arf.xml', '--report', '/ssg/report.html',
+                'podman', 'run', '--rm',
+                '--cap-add', 'SYS_CHROOT',
+                '--mount', f'type=image,source={image_id},destination=/target',
+                '-e', 'OSCAP_PROBE_ROOT=/target',
+                '-v', f'{tempdir}:/ssg:z,U',
+                SCANNER_IMAGE,
+                'xccdf', 'eval', '--progress',
+                '--profile', profile,
+                '--results-arf', '/ssg/scan-arf.xml',
+                '--report', '/ssg/report.html',
                 '/ssg/ssg-hummingbird-ds.xml',
             ],
             stderr=subprocess.STDOUT,
@@ -44,7 +52,9 @@ with util.get_source_content() as content_dir:
         oscap.report_from_verbose(lines)
         if proc.returncode not in [0, 2]:
             raise RuntimeError("oscap failed unexpectedly")
-        shutil.copy(tempdir + '/scan-arf.xml', Path.cwd())
-        shutil.copy(tempdir + '/report.html', Path.cwd())
+        artifacts = ['report.html', 'scan-arf.xml']
+        tempdir_path = Path(tempdir)
+        for artifact in artifacts:
+            shutil.copy(tempdir_path / artifact, Path.cwd())
 
-results.report_and_exit(logs=['report.html', 'scan-arf.xml'])
+results.report_and_exit(logs=artifacts)

--- a/scanning/hummingbird/image/test.py
+++ b/scanning/hummingbird/image/test.py
@@ -2,7 +2,6 @@
 
 import shutil
 import subprocess
-import tempfile
 
 from pathlib import Path
 
@@ -31,30 +30,26 @@ with util.get_source_content() as content_dir:
     ds_path = content_dir / util.CONTENT_BUILD_DIR / 'ssg-hummingbird-ds.xml'
     if not ds_path.exists():
         raise RuntimeError(f"Datastream not found: {ds_path}")
-    with tempfile.TemporaryDirectory() as tempdir:
-        shutil.copy(ds_path, tempdir)
-        proc, lines = util.subprocess_stream(
-            [
-                'podman', 'run', '--rm',
-                '--cap-add', 'SYS_CHROOT',
-                '--mount', f'type=image,source={image_id},destination=/target',
-                '-e', 'OSCAP_PROBE_ROOT=/target',
-                '-v', f'{tempdir}:/ssg:z,U',
-                SCANNER_IMAGE,
-                'xccdf', 'eval', '--progress',
-                '--profile', profile,
-                '--results-arf', '/ssg/scan-arf.xml',
-                '--report', '/ssg/report.html',
-                '/ssg/ssg-hummingbird-ds.xml',
-            ],
-            stderr=subprocess.STDOUT,
-        )
-        oscap.report_from_verbose(lines)
-        if proc.returncode not in [0, 2]:
-            raise RuntimeError("oscap failed unexpectedly")
-        artifacts = ['report.html', 'scan-arf.xml']
-        tempdir_path = Path(tempdir)
-        for artifact in artifacts:
-            shutil.copy(tempdir_path / artifact, Path.cwd())
+    shutil.copy(ds_path, Path.cwd())
+    proc, lines = util.subprocess_stream(
+        [
+            'podman', 'run', '--rm',
+            '--cap-add', 'SYS_CHROOT',
+            '--mount', f'type=image,source={image_id},destination=/target',
+            '-e', 'OSCAP_PROBE_ROOT=/target',
+            '-v', f'{Path.cwd()}:/ssg:z,U',
+            SCANNER_IMAGE,
+            'xccdf', 'eval', '--progress',
+            '--profile', profile,
+            '--results-arf', '/ssg/scan-arf.xml',
+            '--report', '/ssg/report.html',
+            '/ssg/ssg-hummingbird-ds.xml',
+        ],
+        stderr=subprocess.STDOUT,
+    )
+    oscap.report_from_verbose(lines)
+    if proc.returncode not in [0, 2]:
+        raise RuntimeError("oscap failed unexpectedly")
 
-results.report_and_exit(logs=artifacts)
+results.add_log('report.html', 'scan-arf.xml')
+results.report_and_exit()

--- a/scanning/hummingbird/image/test.py
+++ b/scanning/hummingbird/image/test.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import shutil
+import subprocess
+import tempfile
+
+from lib import results, metadata, oscap, podman, util
+from pathlib import Path
+
+IMAGE = 'openjdk'
+profile = util.get_test_name().rpartition('/')[2]
+if 'fips' in metadata.tags():
+    image_variant = 'latest-fips'
+else:
+    image_variant = 'latest'
+image_id = f'quay.io/hummingbird/{IMAGE}:{image_variant}'
+podman.podman('pull', image_id)
+
+with util.get_source_content() as content_dir:
+    # Hummingbird is a separate product in ComplianceAsCode/content
+    util.build_content(
+        content_dir,
+        {
+            'SSG_PRODUCT_HUMMINGBIRD:BOOL': 'ON',
+        },
+    )
+    ds_path = content_dir / util.CONTENT_BUILD_DIR / 'ssg-hummingbird-ds.xml'
+    if not ds_path.exists():
+        raise RuntimeError(f"Datastream not found: {ds_path}")
+    with tempfile.TemporaryDirectory() as tempdir:
+        shutil.copy(ds_path, tempdir)
+        proc, lines = util.subprocess_stream(
+            [
+                'podman', 'run', '--rm', '--cap-add', 'SYS_CHROOT', '--mount',
+                f'type=image,source={image_id},destination=/target', '-e',
+                'OSCAP_PROBE_ROOT=/target', '-v', f'{tempdir}:/ssg:z,U',
+                'quay.io/hummingbird/openscap:latest', 'xccdf', 'eval',
+                '--progress', '--profile', profile, '--results-arf',
+                '/ssg/scan-arf.xml', '--report', '/ssg/report.html',
+                '/ssg/ssg-hummingbird-ds.xml',
+            ],
+            stderr=subprocess.STDOUT,
+        )
+        oscap.report_from_verbose(lines)
+        if proc.returncode not in [0, 2]:
+            raise RuntimeError("oscap failed unexpectedly")
+        shutil.copy(tempdir + '/scan-arf.xml', Path.cwd())
+        shutil.copy(tempdir + '/report.html', Path.cwd())
+
+results.report_and_exit(logs=['report.html', 'scan-arf.xml'])

--- a/scanning/hummingbird/image/test.py
+++ b/scanning/hummingbird/image/test.py
@@ -51,5 +51,4 @@ with util.get_source_content() as content_dir:
     if proc.returncode not in [0, 2]:
         raise RuntimeError("oscap failed unexpectedly")
 
-results.add_log('report.html', 'scan-arf.xml')
-results.report_and_exit()
+results.report_and_exit(logs=['report.html', 'scan-arf.xml'])

--- a/scanning/hummingbird/oscap-podman/main.fmf
+++ b/scanning/hummingbird/oscap-podman/main.fmf
@@ -1,0 +1,28 @@
+summary: Scan hummingbird containers using oscap-podman
+description: |
+  Build Hummingbird product content and scan Hummingbird container images
+  using oscap-podman.
+test: $CONTEST_PYTHON -m lib.runtest ./test.py
+environment+:
+    PYTHONPATH: ../../..
+duration: 30m
+require+:
+  - openscap-utils
+  - podman
+adjust+:
+  - when: arch != x86_64
+    enabled: false
+    because: sufficient to check only on x86_64
+  - when: distro < rhel-10
+    enabled: false
+    because: sufficient to run only on RHEL 10
+
+/cis:
+
+/fips/cis:
+    tag+:
+      - fips
+
+/fips/stig:
+    tag+:
+      - fips

--- a/scanning/hummingbird/oscap-podman/test.py
+++ b/scanning/hummingbird/oscap-podman/test.py
@@ -2,18 +2,15 @@
 
 import subprocess
 
-from lib import results, oscap, podman, util
+from lib import results, metadata, oscap, podman, util
 
 IMAGE = 'openjdk'
 profile = util.get_test_name().rpartition('/')[2]
-# Some profiles are expected to be applicable only to the FIPS variant of the
-# container image. Some profiles are expected to be applicable only on default
-# variants of container images.
-if profile in ('stig',):
-    variant = 'latest-fips'
+if 'fips' in metadata.tags():
+    image_variant = 'latest-fips'
 else:
-    variant = 'latest'
-image_id = f'quay.io/hummingbird/{IMAGE}:{variant}'
+    image_variant = 'latest'
+image_id = f'quay.io/hummingbird/{IMAGE}:{image_variant}'
 podman.podman('pull', image_id)
 
 with util.get_source_content() as content_dir:


### PR DESCRIPTION
This commit changes the `/scanning/hummingbird` tests with these 2 major improvements:

1. The test has been split into 2 tests:
   1. scanning using oscap-podman
   2. scanning using the openscap hummingbird container image
2. The test now tests more profile and image variants:
   1. normal images are scanned with CIS profiles
   2. FIPS images are scanned with both CIS and STIG profiles

The reason for the improvement 1 is that while users can use oscap-podman for scanning, the hummingbird users will be guided by documentation to use the scanner and content shipped in the `quay.io/hummingbird/openscap` container image.

The reason for the improvement 2 CIS profile should be applicable also on FIPS variants of images. Remember that hummingbird provides images in 2 basic variants:
1. normal (eg. `:latest`) - compliant only with CIS
2. FIPS (eg. `:latest-fips`) - compliant with CIS and STIG

Related to: https://github.com/ComplianceAsCode/content/pull/14683