### PR TITLE
Disable all automatic runs of the /static-checks/audit-sample-rules test

### DIFF
--- a/plans/daily.fmf
+++ b/plans/daily.fmf
@@ -39,5 +39,7 @@ discover:
       - /static-checks/html-links
       # not useful in automated runs that are not manually reviewed
       - /static-checks/diff
+      # we want to run this test only manually when needed
+      - /static-checks/audit-sample-rules
 
 # vim: syntax=yaml

--- a/plans/errata.fmf
+++ b/plans/errata.fmf
@@ -15,6 +15,8 @@ discover:
       - /static-checks/removed-rules
       # not useful in automated runs that are not manually reviewed
       - /static-checks/diff
+      # we want to run this test only manually when needed
+      - /static-checks/audit-sample-rules
 adjust:
   - when: newa_batch is defined
     report:

--- a/plans/stabilization.fmf
+++ b/plans/stabilization.fmf
@@ -5,5 +5,8 @@ discover:
     filter:
       - tag:-needs-param
       - tag:-broken
+    exclude:
+      # we want to run this test only manually when needed
+      - /static-checks/audit-sample-rules
 
 # vim: syntax=yaml

--- a/plans/upstream-parallel.fmf
+++ b/plans/upstream-parallel.fmf
@@ -115,6 +115,8 @@ environment:
               - /static-checks/html-links
               # not useful in automated runs that are not manually reviewed
               - /static-checks/diff
+              # we want to run this test only manually when needed
+              - /static-checks/audit-sample-rules
     /scanning:
         discover+:
             test:

--- a/plans/upstream.fmf
+++ b/plans/upstream.fmf
@@ -15,5 +15,7 @@ discover:
       - /static-checks/html-links
       # not useful in automated runs that are not manually reviewed
       - /static-checks/diff
+      # we want to run this test only manually when needed
+      - /static-checks/audit-sample-rules
 
 # vim: syntax=yaml

--- a/plans/weekly.fmf
+++ b/plans/weekly.fmf
@@ -10,5 +10,7 @@ discover:
       - /static-checks/html-links
       # not useful in automated runs that are not manually reviewed
       - /static-checks/diff
+      # we want to run this test only manually when needed
+      - /static-checks/audit-sample-rules
 
 # vim: syntax=yaml


### PR DESCRIPTION
We want to keep this test, but we want to be able to run it only when needed.