### PR TITLE
Reintroduce waiver for issue 14582

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -163,4 +163,8 @@
 /hardening/anaconda/with-gui/stig_gui/configure_crypto_policy
     rhel == 9
 
+# https://github.com/ComplianceAsCode/content/issues/14582
+/scanning/boot-errors/stig/systemd-tmpfiles: Failed to copy files to.*
+    rhel == 9
+
 # vim: syntax=python


### PR DESCRIPTION
The commit 2d2d905 removed waivers for both `stig` and `ccn_advanced` profiles but only issue on `ccn_advanced` has been fixed by https://github.com/ComplianceAsCode/content/pull/14697 and `stig` profile is still affected (reproducible on RHEL 9.0).