### PR TITLE
Remove waiver for 14570

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -133,9 +133,6 @@
 # https://github.com/ComplianceAsCode/content/issues/14563
 /scanning/boot-errors/stig/chronyd.*(Could not connect|certificate verification|TLS handshake|no selectable sources|timed out).*
     True
-# https://github.com/ComplianceAsCode/content/issues/14570
-/hardening/host-os/oscap/.+/rsyslog_files_permissions
-    rhel.is_centos() and rhel in [9, 10]
 
 # https://github.com/ComplianceAsCode/content/issues/14669
 /scanning/boot-errors/stig


### PR DESCRIPTION
Tests appear to be passing now on RHEL and C9S and C10S.