### PR TITLE
Add productization-like testing using CentOS Stream via Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,22 @@
+jobs:
+- job: tests
+  trigger: pull_request
+  identifier: productization
+  targets: [fedora-latest-stable]
+  manual_trigger: true
+  skip_build: true
+  fmf_url: https://github.com/RHSecurityCompliance/contest-atex-testingfarm.git
+  fmf_ref: main
+  tf_extra_params:
+    environments:
+      - variables:
+          # tell the test to treat $PACKIT_SOURCE* as Contest and use static
+          # CaC/content, instead of the other way around
+          TEST_CONTEST_INSTEAD: "1"
+          # TODO: remove this after we take care of failures
+          RERUNS: "0"
+    # increase default, per README.md of the above repo
+    # - this includes time spent waiting in queued
+    settings:
+      pipeline:
+        timeout: 1200


### PR DESCRIPTION
This should allow us to trigger expensive 4-6h testing for any PR via `/packit test -i productization`.