### PR TITLE
Revert "Remove waiver for 14570"

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -127,6 +127,9 @@
 # https://github.com/ComplianceAsCode/content/issues/14563
 /scanning/boot-errors/stig/chronyd.*(Could not connect|certificate verification|TLS handshake|no selectable sources|timed out).*
     True
+# https://github.com/ComplianceAsCode/content/issues/14570
+/hardening/host-os/oscap/.+/rsyslog_files_permissions
+    rhel.is_centos() and rhel in [9, 10]
 
 # https://github.com/ComplianceAsCode/content/issues/14669
 /scanning/boot-errors/stig


### PR DESCRIPTION
This reverts commit ef2c21b018b295cb71780d7f85fbb83ad7e50d36.

Adding this back as this happens only in the public Testing farm ranch and upstream CI is now red.