### PR TITLE
Extend waiver for service_kdump_disabled

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -34,7 +34,7 @@
 
 # kdump being forcibly enabled somewhere
 # https://github.com/ComplianceAsCode/content/issues/12832
-/hardening/kickstart(/with-gui|/uefi)?/(hipaa|stig|stig_gui|ism_o|ism_o_secret|ism_o_top_secret|e8)/service_kdump_disabled
+/hardening/kickstart/.+/service_kdump_disabled
     rhel == 10
 
 # /run/fapolicyd file mode and groupownership differes from RPM database

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -34,7 +34,7 @@
 
 # kdump being forcibly enabled somewhere
 # https://github.com/ComplianceAsCode/content/issues/12832
-/hardening/kickstart(/with-gui|/uefi)?/(hipaa|stig|stig_gui|ism_o_top_secret|e8)/service_kdump_disabled
+/hardening/kickstart(/with-gui|/uefi)?/(hipaa|stig|stig_gui|ism_o|ism_o_secret|ism_o_top_secret|e8)/service_kdump_disabled
     rhel == 10
 
 # /run/fapolicyd file mode and groupownership differes from RPM database


### PR DESCRIPTION
The pre-release stabilization of the 0.1.81 release has revealed that the issue about service_kdump_disabled affects all 3 ISM profiles, not only the top secret profile, therefore we will extend the waiver to all 3 ISM profiles.