### PR TITLE
Update HTML links waivers

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -56,9 +56,11 @@
     rhel == 8
 
 # Inaccessible until form is filled:
-/static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
 /static-checks/html-links/https://fossies.org/linux/Linux-PAM-docs/doc/sag/Linux-PAM_SAG.pdf
+    "URL returned error: 401" in note
+/static-checks/html-links/https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
 /static-checks/html-links/https://www.iso.org/contents/data/standard/05/45/54534.html
+/static-checks/html-links/https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
     "URL returned error: 403" in note
 # likely has bot detection
 /static-checks/html-links/https://www.cyber.mil/stigs/downloads/.*


### PR DESCRIPTION
Based on the stabilization test results for the 0.1.81 release, we will do these changes in HTML links waivers:

https://fossies.org/linux/Linux-PAM-docs/doc/sag/Linux-PAM_SAG.pdf
- now returns 401 instead of previous 403, but is accesible by Firefox

https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
- now returns 403, but is accesible by Firefox