### PR TITLE
Make `/per-rule` Ansible playbooks support multi-line strings

### DIFF
--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -119,8 +119,20 @@ if [[ -f $variables_file ]]; then
             # - sed would easily mangle it because it can't take a verbatim value
             # - awk also mangles & (gensub) or even \n (substr+print)
             # - bash printf can print anything except 0x00 (which is fine)
+            skip_indent=
             while IFS= read -r playbook_line; do
+                # the original value may span multiple lines (multiline string),
+                # so skip follow-up lines with indent > the initial key: line,
+                # plus fully empty lines
+                #   vars:
+                #     var_something: Foo   # with > or | or without it completely
+                #       Bar
+                if [[ $skip_indent && ( $playbook_line == $skip_indent[[:space:]]* || -z $playbook_line ) ]]; then
+                    continue
+                fi
+                skip_indent=
                 if [[ $playbook_line =~ ^([[:space:]]+)$key: ]]; then
+                    skip_indent=${BASH_REMATCH[1]}
                     # if the value ends with \n, preserve any trailing newlines,
                     # otherwise strip the \n we add via printf below
                     [[ ${value: -1} == $'\n' ]] && newlines='|+1' || newlines='|-1'


### PR DESCRIPTION
This hit a real issue with a source (not yet modified by test) built playbook, which specified

```yaml
- name: Modify the System Login Banner
  hosts: '@@HOSTS@@'
  become: true
  vars:
    login_banner_contents: Authorized users only. All activity may be monitored and
      reported.
  tags:
  - CCE-83557-9
  - DISA-STIG-RHEL-09-211020
```

That's valid YAML, and so would be

```yaml
login_banner_contents: >
  Authorized users only. All activity may be monitored and
  reported.
```
or any variation on it.

The key here is that follow-up lines always have indent greater than the key (since these always contain strings, never lists).

This small addition should remove the original value fully, I hope.