### PR TITLE
Fix `/hardening/(anaconda|kickstart)` test applicability on CentOS Stream

### DIFF
--- a/hardening/anaconda/main.fmf
+++ b/hardening/anaconda/main.fmf
@@ -23,7 +23,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro >= rhel-10
+  - when: distro >= rhel-10 or distro >= centos-stream-10
     enabled: false
     because: content doesn't have pre-made kickstarts for RHEL-10+
 

--- a/hardening/anaconda/with-gui.fmf
+++ b/hardening/anaconda/with-gui.fmf
@@ -93,14 +93,8 @@ tag+:
     tag+:
       - fips
     adjust+:
-      - when: distro == rhel-8 or distro == centos-stream-8
-        enabled: false
-        because: >
-            not supported on RHEL-8 according to RHEL documentation,
-            the "Profiles not compatible with Server with GUI" table
-      - when: distro >= rhel-10
-        enabled: false
-        because: there is no OSPP profile on RHEL-10+
+      - enabled: false
+        because: OSPP profile is not supported with GUI
 
 /pci-dss:
 

--- a/hardening/kickstart/main.fmf
+++ b/hardening/kickstart/main.fmf
@@ -25,7 +25,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-10
+  - when: distro < rhel-10 or distro < centos-stream-10
     enabled: false
     because: on RHEL <= 9 oscap-anaconda-addon is used instead
 
@@ -105,6 +105,7 @@ adjust+:
     tag+:
       - fips
     adjust+:
+      # keep enabled on centos-stream-10+ for upstream testing
       - when: distro >= rhel-10
         enabled: false
         because: there is no OSPP profile on RHEL-10+

--- a/hardening/kickstart/uefi.fmf
+++ b/hardening/kickstart/uefi.fmf
@@ -1,7 +1,7 @@
 tag+:
   - uefi
 adjust+:
-  - when: distro < rhel-10
+  - when: distro < rhel-10 or distro < centos-stream-10
     enabled: false
     because: >
         we don't have capacity to test this everywhere, but RHEL-10 is UEFI
@@ -83,6 +83,7 @@ adjust+:
     tag+:
       - fips
     adjust+:
+      # keep enabled on centos-stream-10+ for upstream testing
       - when: distro >= rhel-10
         enabled: false
         because: there is no OSPP profile on RHEL-10+

--- a/hardening/kickstart/with-gui.fmf
+++ b/hardening/kickstart/with-gui.fmf
@@ -93,14 +93,8 @@ tag+:
     tag+:
       - fips
     adjust+:
-      - when: distro == rhel-8 or distro == centos-stream-8
-        enabled: false
-        because: >
-            not supported on RHEL-8 according to RHEL documentation,
-            the "Profiles not compatible with Server with GUI" table
-      - when: distro >= rhel-10
-        enabled: false
-        because: there is no OSPP profile on RHEL-10+
+      - enabled: false
+        because: OSPP profile is not supported with GUI
 
 /pci-dss:
 


### PR DESCRIPTION
Resolves [OPENSCAP-6753](https://redhat.atlassian.net/browse/OPENSCAP-6753).