### PR TITLE
Remove outdated waivers

### DIFF
--- a/conf/waivers/infrastructure
+++ b/conf/waivers/infrastructure
@@ -22,7 +22,6 @@
 # Testing farm RHEL 10.2 systems on s390x don't configure server pool in /etc/chrony.conf.
 # Consequently, remediations in these rules can't add the server pool settings.
 # See: https://issues.redhat.com/browse/TFT-4206
-/hardening/host-os/.+/chrony_set_nts
 /hardening/host-os/.+/chronyd_or_ntpd_set_maxpoll
     rhel == 10.2 and arch == 's390x'
 

--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -145,11 +145,6 @@
 /hardening/host-os/.+/service_rngd_enabled
     rhel == 8
 
-# DISA says that the rule checking for libreswan cryptopolicy should be not applicable when libreswan not installed
-# we decide to show "pass" instead
-/scanning/disa-alignment/.+/configure_libreswan_crypto_policy
-    rhel == 8
-
 # https://github.com/ComplianceAsCode/content/issues/14389
 # DISA content evaluates this as not applicable once package is removed
 /scanning/disa-alignment/.+/package_tftp-server_removed

--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -154,11 +154,6 @@
 /scanning/boot-errors/.+/rsyslogd.+(certificate.*is not set|key.*is not set|cannot resolve hostname).*
     True
 
-# These rules fail in the default Hummingbird container images,
-# hardening needs to be done on the Hummingbird project side.
-/scanning/hummingbird/.+/accounts_umask_etc_(bashrc|profile)
-    True
-
 # File /boot/grub2/grub2.cfg is created with lenient permissions by
 # bootupd during the installation of a bootable container image.
 # Tests still fail on RHEL 10.0

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -112,11 +112,6 @@
 /scanning/boot-errors/(stig|anssi_bp28_intermediary|anssi_bp28_enhanced|anssi_bp28_high)/sssd.*No domain is enabled.*
 /scanning/boot-errors/(stig|anssi_bp28_high)/sssd: SSSD couldn't load the configuration database.*
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/14560
-/scanning/boot-errors/(cis|cis_workstation_l2|pci-dss|stig|hipaa)/auditd.*Email option is specified but /usr/lib/sendmail doesn't seem executable.*
-    rhel == 10
-/scanning/boot-errors/(cis|cis_workstation_l2|pci-dss)/auditd.*Email option is specified but /usr/lib/sendmail doesn't seem executable.*
-    rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/14563
 /scanning/boot-errors/stig/chronyd.*(Could not connect|certificate verification|TLS handshake|no selectable sources|timed out).*
     True

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -9,9 +9,6 @@
 # https://github.com/ComplianceAsCode/content/issues/13236
 /scanning/disa-alignment/ansible/networkmanager_dns_mode
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/13676
-/scanning/disa-alignment/.*/coredump_disable_.+
-    True
 # https://github.com/ComplianceAsCode/content/issues/14229
 # maybe it's related to the syntax change in rsyslog configuration files
 /scanning/disa-alignment/[^/]+/rsyslog_remote_access_monitoring

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -116,25 +116,4 @@
 /hardening/host-os/oscap/.+/rsyslog_files_permissions
     rhel.is_centos() and rhel in [9, 10]
 
-# https://github.com/ComplianceAsCode/content/issues/14669
-/scanning/boot-errors/stig
-/hardening/oscap/stig
-/hardening/oscap/with-gui/stig_gui
-/scanning/disa-alignment/ansible
-/hardening/ansible/stig
-/hardening/ansible/with-gui/stig_gui
-    rhel == 9 and status == 'error'
-
-# I think it is also connected with following failures
-# https://github.com/ComplianceAsCode/content/issues/14669
-/hardening/container/bootc-image-builder/stig/configure_crypto_policy
-/hardening/container/anaconda-ostree/stig/configure_crypto_policy
-/hardening/anaconda/stig/configure_crypto_policy
-/hardening/anaconda/with-gui/stig_gui/configure_crypto_policy
-    rhel == 9
-
-# https://github.com/ComplianceAsCode/content/issues/14582
-/scanning/boot-errors/stig/systemd-tmpfiles: Failed to copy files to.*
-    rhel == 9
-
 # vim: syntax=python

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -104,10 +104,6 @@
 /hardening/image-builder/uefi/ism_o_top_secret
     rhel == 10 and status == 'error'
 
-# https://github.com/ComplianceAsCode/content/issues/14558
-/scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*kdump.service.*
-/scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*Failed to start Crash recovery kernel arming.*
-    True
 # https://github.com/ComplianceAsCode/content/issues/14559
 /scanning/boot-errors/(stig|ism_o|ism_o_secret|ism_o_top_secret)/.*sssd.service.*
     rhel == 10

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -112,9 +112,6 @@
 /scanning/boot-errors/(stig|anssi_bp28_intermediary|anssi_bp28_enhanced|anssi_bp28_high)/sssd.*No domain is enabled.*
 /scanning/boot-errors/(stig|anssi_bp28_high)/sssd: SSSD couldn't load the configuration database.*
     rhel == 9
-# https://github.com/ComplianceAsCode/content/issues/14563
-/scanning/boot-errors/stig/chronyd.*(Could not connect|certificate verification|TLS handshake|no selectable sources|timed out).*
-    True
 # https://github.com/ComplianceAsCode/content/issues/14570
 /hardening/host-os/oscap/.+/rsyslog_files_permissions
     rhel.is_centos() and rhel in [9, 10]


### PR DESCRIPTION
During the 0.1.81 release stabilization multiple outdated waivers were found. The waived tests no longer manifest.

For more details, please read commit messages of every commit.

```
jcerny@fedora:~/work/git/contest/scripts (main)$ ./find_invalid_waivers.py new_results.json.gz 
2026-05-21 11:52:08 find_invalid_waivers.py:191: lib.waive.collect_waivers:150: using /home/jcerny/work/git/contest/conf/waivers for waiving
===============================================================
The following waivers are no longer valid, they either did not
match any test results or only matched the 'pass' test results:
===============================================================

/hardening/host-os/.+/chrony_set_nts
    rhel == 10.2 and arch == 's390x'

/static-checks/html-links/https://www.iso.org/contents/data/standard/05/45/54534.html
/static-checks/html-links/https://fossies.org/linux/Linux-PAM-docs/doc/sag/Linux-PAM_SAG.pdf
    "URL returned error: 403" in note

/static-checks/html-links/https://www.cyber.mil/stigs/downloads/.*
    "Connection reset by peer" in note

/hardening/host-os/.+/service_rngd_enabled
    rhel == 8

/scanning/disa-alignment/.+/configure_libreswan_crypto_policy
    rhel == 8

/scanning/hummingbird/.+/accounts_umask_etc_(bashrc|profile)
    True

/scanning/disa-alignment/.*/coredump_disable_.+
    True

/scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*Failed to start Crash recovery kernel arming.*
/scanning/boot-errors/(e8|ism_o|ism_o_secret|ism_o_top_secret)/.*kdump.service.*
    True

/scanning/boot-errors/(cis|cis_workstation_l2|pci-dss|stig|hipaa)/auditd.*Email option is specified but /usr/lib/sendmail doesn't seem executable.*
    rhel == 10

/scanning/boot-errors/(cis|cis_workstation_l2|pci-dss)/auditd.*Email option is specified but /usr/lib/sendmail doesn't seem executable.*
    rhel == 9

/scanning/boot-errors/stig/chronyd.*(Could not connect|certificate verification|TLS handshake|no selectable sources|timed out).*
    True

/hardening/ansible/with-gui/stig_gui
/scanning/boot-errors/stig
/scanning/disa-alignment/ansible
/hardening/oscap/with-gui/stig_gui
/hardening/ansible/stig
/hardening/oscap/stig
    rhel == 9 and status == 'error'

/hardening/container/bootc-image-builder/stig/configure_crypto_policy
/hardening/container/anaconda-ostree/stig/configure_crypto_policy
/hardening/anaconda/stig/configure_crypto_policy
/hardening/anaconda/with-gui/stig_gui/configure_crypto_policy
    rhel == 9

/scanning/boot-errors/stig/systemd-tmpfiles: Failed to copy files to.*
    rhel == 9

```