### PR TITLE
Guard yields with `try`/`finally`, adjust `ruff` warnings

### DIFF
--- a/lib/osbuild.py
+++ b/lib/osbuild.py
@@ -105,12 +105,14 @@ class ComposerRepos:
             ['systemctl', 'restart', 'osbuild-composer.service'],
             check=True, stderr=subprocess.PIPE,
         )
-        yield
-        shutil.rmtree(self.ETC_REPOS)
-        util.subprocess_run(
-            ['systemctl', 'restart', 'osbuild-composer.service'],
-            check=True, stderr=subprocess.PIPE,
-        )
+        try:
+            yield
+        finally:
+            shutil.rmtree(self.ETC_REPOS)
+            util.subprocess_run(
+                ['systemctl', 'restart', 'osbuild-composer.service'],
+                check=True, stderr=subprocess.PIPE,
+            )
 
 
 class Compose:
@@ -165,9 +167,11 @@ class Compose:
         if entry.status != 'FINISHED':
             composer_cli('compose', 'log', entry.id)
             raise RuntimeError(f"failed to build: {entry}")
-        yield entry.id
-        # clean up
-        composer_cli('compose', 'delete', entry.id)
+        try:
+            yield entry.id
+        finally:
+            # clean up
+            composer_cli('compose', 'delete', entry.id)
 
 
 # this is using a different approach to class Kickstart or class RpmPack
@@ -245,8 +249,10 @@ class Blueprint:
             composer_cli('blueprints', 'delete', self.NAME)
         with self.to_tmpfile() as f:
             composer_cli('blueprints', 'push', f)
-        yield self.NAME
-        composer_cli('blueprints', 'delete', self.NAME)
+        try:
+            yield self.NAME
+        finally:
+            composer_cli('blueprints', 'delete', self.NAME)
 
 
 class Guest(virt.Guest):

--- a/lib/util/backup.py
+++ b/lib/util/backup.py
@@ -41,5 +41,7 @@ def backed_up(path):
             # do destructive stuff to it
     """
     backup(path)
-    yield
-    restore(path)
+    try:
+        yield
+    finally:
+        restore(path)

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,6 +28,7 @@ ignore = [
     "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
+    "PLW0717",  # too-many-statements-in-try-clause
     "PLR2004",  # magic-value-comparison
     "PLR5501",  # collapsible-else-if
     "PLW0603",  # global-statement


### PR DESCRIPTION
The `try`/`finally` is needed because if an exception happens in the parent (during `yield`), the code is never returned back to do the cleaning.