### PR TITLE
Waive chronyd_or_ntpd_set_maxpoll on Beaker systems

### DIFF
--- a/conf/waivers/infrastructure
+++ b/conf/waivers/infrastructure
@@ -19,10 +19,9 @@
 /hardening/.+/enable_gpgcheck_for_all_repositories
     rhel.is_centos()
 
-# Testing farm RHEL 10.2 systems on s390x don't configure server pool in /etc/chrony.conf.
-# Consequently, remediations in these rules can't add the server pool settings.
-# See: https://issues.redhat.com/browse/TFT-4206
+# Beaker systems don't configure server pool in /etc/chrony.conf.
+# Consequently, remediations in this rule can't add the server pool settings.
 /hardening/host-os/.+/chronyd_or_ntpd_set_maxpoll
-    rhel == 10.2 and arch == 's390x'
+    True
 
 # vim: syntax=python


### PR DESCRIPTION
Beaker systems don't configure server pool in /etc/chrony.conf. Consequently, remediations in this rule can't add the server pool settings.