### PR TITLE
Waive crypto_policy_not_overridden DISA alignment on RHEL 9

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -23,6 +23,10 @@
 /scanning/disa-alignment/.+/logind_session_timeout
     rhel == 9
 
+# https://github.com/ComplianceAsCode/content/issues/14745
+/scanning/disa-alignment/[^/]+/crypto_policy_not_overridden
+    rhel == 9
+
 # RHEL10 - No official RHEL10 STIG benchmark yet
 /static-checks/rule-identifiers/stig/stigid/.*
 /static-checks/rule-identifiers/stig/stigref/.*


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/issues/14745

From issue above: The testing environment does not contain the openscap-engine-sce package therefore it doesn't check the rule that only contains SCE content. We might want to introduce the openscap-engine-sce package to the testing environment, which would align with the SCE testing strategy we are still in need.