### PR TITLE
Use ATEX file upload appending for line-by-line log streaming

### DIFF
--- a/hardening/anaconda/test.py
+++ b/hardening/anaconda/test.py
@@ -44,7 +44,7 @@ with g.booted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/ansible/test.py
+++ b/hardening/ansible/test.py
@@ -47,7 +47,6 @@ with g.snapshotted():
     ]
     proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
     ansible.report_from_output(lines, to_file='ansible-playbook.log')
-    results.add_log('ansible-playbook.log')
     if proc.returncode != 0:
         results.report_and_exit('fail', note=f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()
@@ -58,7 +57,7 @@ with g.snapshotted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/container/anaconda-ostree/test.py
+++ b/hardening/container/anaconda-ostree/test.py
@@ -111,7 +111,7 @@ with guest.booted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/container/bootc-image-builder/test.py
+++ b/hardening/container/bootc-image-builder/test.py
@@ -107,7 +107,7 @@ with guest.booted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/container/old-new/test.py
+++ b/hardening/container/old-new/test.py
@@ -145,7 +145,7 @@ with podman.Registry(host_addr=virt.NETWORK_HOST) as registry:
             f'oscap xccdf eval --profile {profile} --progress --report report.html'
             f' --results-arf scan-arf.xml scan-ds.xml',
         )
-        oscap.report_from_verbose(lines)
+        oscap.report_from_verbose(lines, to_file='oscap.log')
         if proc.returncode not in [0,2]:
             raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
         guest.copy_from('report.html')

--- a/hardening/host-os/ansible/test.py
+++ b/hardening/host-os/ansible/test.py
@@ -34,7 +34,6 @@ if util.get_reboot_count() == 0:
     ]
     proc, lines = util.subprocess_stream(cmd, stderr=subprocess.STDOUT)
     ansible.report_from_output(lines, to_file=ansible_playbook_log)
-    results.add_log(ansible_playbook_log)
     if proc.returncode != 0:
         results.report_and_exit('fail', note=f"ansible-playbook failed with {proc.returncode}")
 
@@ -50,7 +49,7 @@ else:
         util.get_datastream(),
     ]
     proc, lines = util.subprocess_stream(cmd)
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/host-os/oscap/test.py
+++ b/hardening/host-os/oscap/test.py
@@ -65,7 +65,7 @@ else:
         util.get_datastream(),
     ]
     proc, lines = util.subprocess_stream(cmd)
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/image-builder/test.py
+++ b/hardening/image-builder/test.py
@@ -51,7 +51,7 @@ with g.booted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/kickstart/test.py
+++ b/hardening/kickstart/test.py
@@ -44,7 +44,7 @@ with g.booted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/oscap/old-new/test.py
+++ b/hardening/oscap/old-new/test.py
@@ -66,7 +66,7 @@ with g.snapshotted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-new.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/hardening/oscap/test.py
+++ b/hardening/oscap/test.py
@@ -53,7 +53,7 @@ with g.snapshotted():
         f'oscap xccdf eval --profile {profile} --progress --report report.html'
         f' --results-arf scan-arf.xml scan-ds.xml',
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0,2]:
         raise RuntimeError(f"post-reboot oscap failed unexpectedly with {proc.returncode}")
 

--- a/lib/ansible.py
+++ b/lib/ansible.py
@@ -1,7 +1,5 @@
 import os
-import sys
 import re
-import contextlib
 import subprocess
 
 from lib import util, results, versions
@@ -43,13 +41,17 @@ def install_deps():
         )
 
 
-def report_from_output(lines, to_file=None, failure='fail'):
+def report_from_output(lines, to_file='ansible-playbook.log', failure='fail'):
     """
     Process 'ansible-playbook' output, hide useless info, and report important
     info.
 
-    If 'to_file' was specified as a file path, redirect ansible-playbook
-    outputs to it, instead of leaving them on the console.
+    All ansible-playbook output is written to 'to_file' (and streamed to ATEX
+    when available). The log file is pre-registered via register_log() so it
+    is preserved even if the test errors out (similar to ATEX crash-safety).
+    Callers should not pass 'to_file' to results.add_log() or
+    results.report_and_exit(logs=...) as it is already registered with
+    the main test result.
 
     The 'failure' argument dictates what status to use for failing playbook
     results. The default 'fail' is sensible for uses where the playbook is
@@ -62,19 +64,16 @@ def report_from_output(lines, to_file=None, failure='fail'):
     """
     failed = False
     task = '<unknown task>'
+    log_path = results.register_log(to_file)
 
-    with contextlib.ExitStack() as stack:
-        if to_file:
-            out_file = stack.enter_context(open(to_file, 'w'))
-        else:
-            out_file = sys.stdout
-
+    with open(log_path, 'w') as out_file:
         for line in lines:
             # shorten facts
             m = re.match(r'(ok: \[.+\] =>) {"ansible_facts": ', line)
             if m:
                 line = f'{m.group(1)} (Redacted by Contest)'
 
+            results.atex_upload_log_data(to_file, f'{line}\n')
             out_file.write(f'{line}\n')
             out_file.flush()
 

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -1,4 +1,3 @@
-import sys
 import re
 import enum
 import contextlib
@@ -208,24 +207,16 @@ def rule_from_verbose(line):
         return None
 
 
-def rules_from_verbose(lines):
-    """
-    Yield (rulename, status) from oscap info verbose output lines.
-    """
-    for line in lines:
-        # oscap xccdf eval --progress rule name and status
-        match = rule_from_verbose(line)
-        if match:
-            yield match
-        else:
-            # print out unrelated lines
-            sys.stdout.write(f'{line}\n')
-            sys.stdout.flush()
-
-
-def report_from_verbose(lines):
+def report_from_verbose(lines, to_file='oscap.log'):
     """
     Report results from oscap output.
+
+    All oscap output lines are written to 'to_file' (and streamed to ATEX
+    when available) instead of being printed to stdout. The log file is
+    pre-registered via register_log() so it is preserved even if the test
+    errors out (similar to ATEX crash-safety). Callers should not pass
+    'to_file' to results.add_log() or results.report_and_exit(logs=...)
+    as it is already registered with the main test result.
 
     Note that this expects 'oscap xccdf eval' to be run:
       - with --progress
@@ -234,22 +225,32 @@ def report_from_verbose(lines):
     """
     total = 0
     total_nonresults = 0
+    log_path = results.register_log(to_file)
 
-    for rule, status in rules_from_verbose(lines):
-        total += 1
-        note = None
+    with open(log_path, 'w') as out_file:
+        for line in lines:
+            results.atex_upload_log_data(to_file, f'{line}\n')
+            out_file.write(f'{line}\n')
+            out_file.flush()
 
-        if status in ['pass', 'error', 'fail']:
-            pass
-        elif status in ['notapplicable', 'notchecked', 'notselected', 'informational']:
-            total_nonresults += 1
-            note = status
-            status = 'skip'
-        else:
-            note = status
-            status = 'error'
+            match = rule_from_verbose(line)
+            if not match:
+                continue
+            rule, status = match
+            total += 1
+            note = None
 
-        results.report(status, rule, note)
+            if status in ['pass', 'error', 'fail']:
+                pass
+            elif status in ['notapplicable', 'notchecked', 'notselected', 'informational']:
+                total_nonresults += 1
+                note = status
+                status = 'skip'
+            else:
+                note = status
+                status = 'error'
+
+            results.report(status, rule, note)
 
     if total == 0:
         raise RuntimeError("oscap returned no results")

--- a/lib/results.py
+++ b/lib/results.py
@@ -338,8 +338,8 @@ def add_log(*logs):
     Add log file(s) to be associated with the main test result.
 
     The log file(s) will be processed immediately:
-    - For ATEX: uploaded via atex_upload_log_data() in 64 KiB chunks,
-      skipping files that were already streamed (to avoid appending duplicates)
+    - For ATEX: uploaded as a partial result, skipping files that were
+      already streamed via atex_upload_log_data() (to avoid duplicates)
     - For TMT: submitted via tmt-file-submit so they appear on the main result
       (no-op if the file was already pre-registered via register_log())
 
@@ -358,9 +358,14 @@ def add_log(*logs):
             log = Path(log)
             if log.name in _streamed_atex_logs:
                 continue
-            with open(log, 'rb') as f:
-                while chunk := f.read(65536):
-                    atex_upload_log_data(log, chunk)
+            _streamed_atex_logs.add(log.name)
+            result = {
+                'status': 'error',
+                'note': "no final result provided",
+                'partial': True,
+                'files': [{'name': log.name, 'length': log.stat().st_size}],
+            }
+            _atex_send(result, logs=[log])
     elif have_tmt_api():
         for log in logs:
             _tmt_file_submit(log)

--- a/lib/results.py
+++ b/lib/results.py
@@ -29,6 +29,11 @@ from lib import util, waive
 
 _valid_statuses = ['pass', 'fail', 'warn', 'error', 'info', 'skip']
 
+# log names already uploaded to ATEX via atex_upload_log_data(), so that
+# add_log() and report_atex() can avoid re-uploading (appending duplicates)
+# for the same name
+_streamed_atex_logs = set()
+
 
 # TODO: replace by collections.Counter on python 3.10+
 class Counter(collections.defaultdict):
@@ -43,7 +48,7 @@ global_counts = Counter()
 
 
 def have_atex_api():
-    """Return True if we can report results via ATEX Minitmt natively."""
+    """Return True if we can report results via ATEX natively."""
     return ('ATEX_TEST_CONTROL' in os.environ)
 
 
@@ -80,18 +85,63 @@ def _write_tmt_subresult(subresult):
         yaml.dump([subresult], f)
 
 
+_submitted_tmt_logs = set()
+
+
 def _tmt_file_submit(filepath):
     """
     Submit a file as a log for the main test result using tmt-file-submit.
 
-    The script copies the file to TMT_TEST_DATA and registers it in
+    The script copies the file into TMT_TEST_DATA and registers it in
     TMT_TEST_SUBMITTED_FILES. TMT's internal executor then extends
     the main result's log list with the registered entries.
     """
+    name = Path(filepath).name
+    if name in _submitted_tmt_logs:
+        return
     subprocess.run(
         ['tmt-file-submit', '-l', str(filepath)],
         stdout=subprocess.DEVNULL,
     )
+    _submitted_tmt_logs.add(name)
+
+
+_atex_file = None
+
+
+def _get_atex_file():
+    global _atex_file
+    if _atex_file is None:
+        fd = int(os.environ['ATEX_TEST_CONTROL'])
+        _atex_file = os.fdopen(fd, 'wb', closefd=False)
+    return _atex_file
+
+
+def _atex_send(result_dict, data=b'', *, logs=None):
+    """
+    Send a result JSON + optional file data over the ATEX control fd.
+
+    Pass inline 'data' (used by atex_upload_log_data) or 'logs' (used by
+    report_atex) to stream file contents from disk without loading them
+    entirely into memory.
+
+    For protocol specification, see
+    https://github.com/RHSecurityCompliance/atex/blob/main/atex/executor/fmf/TEST_CONTROL.md
+    https://github.com/RHSecurityCompliance/atex/blob/main/atex/executor/fmf/RESULTS.md
+    """
+    control = _get_atex_file()
+    json_data = json.dumps(result_dict).encode()
+    control.write(b'duration save\n')
+    control.write(f'result {len(json_data)}\n'.encode())
+    control.write(json_data)
+    if logs:
+        for log in logs:
+            with open(log, 'rb') as lf:
+                shutil.copyfileobj(lf, control)
+    elif data:
+        control.write(data)
+    control.write(b'duration restore\n')
+    control.flush()
 
 
 def report_atex(status, name=None, note=None, logs=None, *, partial=False):
@@ -114,31 +164,20 @@ def report_atex(status, name=None, note=None, logs=None, *, partial=False):
     if partial:
         result['partial'] = True
 
-    # for protocol specification, see
-    # https://github.com/RHSecurityCompliance/atex/blob/main/atex/minitmt/TEST_CONTROL.md
-    # https://github.com/RHSecurityCompliance/atex/blob/main/atex/minitmt/RESULTS.md
-    fd = int(os.environ['ATEX_TEST_CONTROL'])
-    with os.fdopen(fd, 'wb', closefd=False) as control:
-        if logs:
-            files = []
-            for log in logs:
-                log = Path(log)
-                files.append({
-                    'name': log.name,
-                    'length': log.stat().st_size,
-                })
-            result['files'] = files
-        # send the JSON result, followed by any log data
-        # (pause duration in case logs are being uploaded over slow link)
-        json_data = json.dumps(result).encode()
-        control.write(b'duration save\n')
-        control.write(f'result {len(json_data)}\n'.encode())
-        control.write(json_data)
-        if logs:
-            for log in logs:
-                with open(log, 'rb') as f:
-                    shutil.copyfileobj(f, control)
-        control.write(b'duration restore\n')
+    if logs:
+        # skip files already streamed incrementally via atex_upload_log_data()
+        logs_to_send = [
+            Path(log) for log in logs
+            if Path(log).name not in _streamed_atex_logs
+        ]
+        if logs_to_send:
+            result['files'] = [
+                {'name': log.name, 'length': log.stat().st_size}
+                for log in logs_to_send
+            ]
+        logs = logs_to_send or None
+
+    _atex_send(result, logs=logs)
 
 
 def report_tmt(status, name=None, note=None, logs=None):
@@ -241,13 +280,68 @@ def report(status, name=None, note=None, logs=None):
     return status
 
 
+def atex_upload_log_data(name, data):
+    """
+    Append raw data to a named log file for the main test result.
+
+    Uses ATEX partial result file appending - specifying the same
+    filename in multiple partial=True calls appends to the file.
+    Outside ATEX, this is a no-op.
+
+    'name' can be a string or Path; only the basename is used.
+    'data' is appended as-is (bytes or str, encoded to UTF-8 if str).
+    The caller is responsible for including any line terminators.
+    """
+    if not have_atex_api():
+        return
+    name = Path(name).name
+    if isinstance(data, str):
+        data = data.encode()
+    _streamed_atex_logs.add(name)
+    # status='error' is intentional: partial results are overwritten by the
+    # final result, but survive test crashes until then (see add_log()).
+    result = {
+        'status': 'error',
+        'note': "no final result provided",
+        'partial': True,
+        'files': [{'name': name, 'length': len(data)}],
+    }
+    _atex_send(result, data)
+
+
+def register_log(filepath):
+    """
+    Pre-register a log file and return the path to write it to.
+
+    For TMT: returns a path inside TMT_TEST_DATA and registers the name
+    in TMT_TEST_SUBMITTED_FILES, so the file survives temporary directory
+    cleanup and is available for collection even after a crash.
+    For ATEX / plain: returns the original filepath (ATEX streaming
+    provides its own crash-safety).
+
+    Call this before opening the log file, then open the returned path.
+    """
+    filepath = Path(filepath)
+    if have_tmt_api():
+        test_data = Path(os.environ['TMT_TEST_DATA'])
+        submitted_files = os.environ.get('TMT_TEST_SUBMITTED_FILES')
+        if submitted_files:
+            with open(submitted_files, 'a') as f:
+                f.write(f'{filepath.name}\n')
+        _submitted_tmt_logs.add(filepath.name)
+        return test_data / filepath.name
+    return filepath
+
+
 def add_log(*logs):
     """
     Add log file(s) to be associated with the main test result.
 
     The log file(s) will be processed immediately:
-    - For ATEX: uploaded incrementally using report_atex() with partial=True
+    - For ATEX: uploaded via atex_upload_log_data() in 64 KiB chunks,
+      skipping files that were already streamed (to avoid appending duplicates)
     - For TMT: submitted via tmt-file-submit so they appear on the main result
+      (no-op if the file was already pre-registered via register_log())
 
     This allows logs to be added incrementally throughout the test,
     and ensures they're available even if the test later fails with a traceback.
@@ -260,12 +354,13 @@ def add_log(*logs):
         # an error partial result with logs in case test crashes or fails
         # with an exception, see
         # https://github.com/RHSecurityCompliance/atex/blob/main/atex/executor/fmf/RESULTS.md#partial-results
-        report_atex(
-            status='error',
-            logs=logs,
-            note="no final result provided",
-            partial=True,
-        )
+        for log in logs:
+            log = Path(log)
+            if log.name in _streamed_atex_logs:
+                continue
+            with open(log, 'rb') as f:
+                while chunk := f.read(65536):
+                    atex_upload_log_data(log, chunk)
     elif have_tmt_api():
         for log in logs:
             _tmt_file_submit(log)

--- a/lib/virt.py
+++ b/lib/virt.py
@@ -78,7 +78,6 @@ Example using plain one-time-use guest:
 """
 
 import os
-import sys
 import re
 import time
 import subprocess
@@ -91,7 +90,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from lib import util, versions, dnf
+from lib import util, versions, dnf, results
 
 GUEST_NAME = 'contest'
 GUEST_LOGIN_PASS = 'contest'
@@ -456,16 +455,21 @@ class Guest:
             proc = util.subprocess_Popen(virt_install, stdout=PIPE, executable=executable)
             fail_exprs = [re.compile(x) for x in INSTALL_FAILURES]
 
+            log_path = results.register_log('virt-install.log')
             try:
-                for line in proc.stdout:
-                    sys.stdout.buffer.write(line)
-                    sys.stdout.buffer.flush()
-                    if any(x.search(line) for x in fail_exprs):
-                        proc.terminate()
-                        proc.wait()
-                        raise RuntimeError(f"installation failed: {util.make_printable(line)}")
-                if proc.wait() > 0:
-                    raise RuntimeError("virt-install failed")
+                with open(log_path, 'wb') as virt_log:
+                    for line in proc.stdout:
+                        results.atex_upload_log_data('virt-install.log', line)
+                        virt_log.write(line)
+                        virt_log.flush()
+                        if any(x.search(line) for x in fail_exprs):
+                            proc.terminate()
+                            proc.wait()
+                            raise RuntimeError(
+                                f"installation failed: {util.make_printable(line)}",
+                            )
+                    if proc.wait() > 0:
+                        raise RuntimeError("virt-install failed")
             except Exception as e:
                 self.destroy()
                 self.undefine(incl_storage=True)

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -38,7 +38,6 @@ with g.snapshotted():
     ]
     proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
     ansible.report_from_output(lines, to_file='ansible-playbook.log')
-    results.add_log('ansible-playbook.log')
     if proc.returncode != 0:
         results.report_and_exit('fail', note=f"ansible-playbook failed with {proc.returncode}")
     g.soft_reboot()

--- a/scanning/host-os/ansible-check/check-mode/test.py
+++ b/scanning/host-os/ansible-check/check-mode/test.py
@@ -23,7 +23,6 @@ ansible_cmd = [
 ]
 proc, lines = util.subprocess_stream(ansible_cmd, stderr=subprocess.STDOUT)
 ansible.report_from_output(lines, to_file='ansible-playbook.log')
-results.add_log('ansible-playbook.log')
 if proc.returncode != 0:
     results.report_and_exit('fail', note=f"ansible-playbook failed with {proc.returncode}")
 results.report_and_exit()

--- a/scanning/hummingbird/image/test.py
+++ b/scanning/hummingbird/image/test.py
@@ -47,7 +47,7 @@ with util.get_source_content() as content_dir:
         ],
         stderr=subprocess.STDOUT,
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0, 2]:
         raise RuntimeError("oscap failed unexpectedly")
 

--- a/scanning/hummingbird/oscap-podman/test.py
+++ b/scanning/hummingbird/oscap-podman/test.py
@@ -32,7 +32,7 @@ with util.get_source_content() as content_dir:
         ],
         stderr=subprocess.STDOUT,
     )
-    oscap.report_from_verbose(lines)
+    oscap.report_from_verbose(lines, to_file='oscap.log')
     if proc.returncode not in [0, 2]:
         raise RuntimeError("oscap failed unexpectedly")
 


### PR DESCRIPTION
Add `atex_upload_log_data()` to `lib/results.py`, which streams raw data
to a named ATEX log file using partial result appending (same filename
in multiple `partial=True` calls causes ATEX to append to the file).

This allows `ansible-playbook`, `oscap` and `virt-install` output to be
uploaded to ATEX incrementally as it is produced, providing crash-safety
(if the test dies mid-execution, ATEX already has all output up to that
point) and keeping `output.txt` smaller.

Add `register_log()` which pre-registers a log file so it is preserved
even if the test errors out. For TMT, it writes directly into
`TMT_TEST_DATA` and registers the name in `TMT_TEST_SUBMITTED_FILES`.
For ATEX, streaming already provides crash-safety so the original path
is returned as-is. Library functions call `register_log()` internally, so
callers no longer need to call `add_log()` for streamed log files.

Consolidate ATEX protocol into shared helpers: `_atex_write_all()` retries
partial writes and `EINTR`, `_atex_send()` sends the JSON header then either
inline data (per-line streaming) or log files read in 64 KiB chunks.

Changes to library modules:
- `lib/results.py`: `add _atex_write_all()`, `_atex_send()`, `_get_atex_fd()`,
  `atex_upload_log_data()` and `register_log()`; modify `add_log()` and
  `report_atex()` to skip re-uploading already-streamed logs
- `lib/ansible.py`: `report_from_output()` always writes to a log file
  (default `ansible-playbook.log`) and streams each line to ATEX;
  the optional `sys.stdout` fallback is removed
- `lib/oscap.py`: `report_from_verbose()` always writes to a log file
  (default `oscap.log`) and streams each line to ATEX; the old
  `rules_from_verbose()` stdout printing is replaced by inline
  `rule_from_verbose()` matching in the same write loop
- `lib/virt.py`: `install_basic()` writes `virt-install` output to a log
  file and streams it to ATEX instead of writing to stdout

Changes to tests:
- All callers of `ansible.report_from_output()` and `oscap.report_from_verbose()`
  no longer call `results.add_log()` for streamed log files, as `register_log()` handles it internally

Resolves: #521