### PR TITLE
per-rule tests: detect and test rules with SCE content

### DIFF
--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -14,6 +14,15 @@ FixType = enum.Flag(
     ['bash', 'ansible', 'anaconda', 'kickstart', 'blueprint', 'bootc'],
 )
 
+_FIX_SYSTEM_MAP = {
+    'urn:xccdf:fix:script:sh': FixType.bash,
+    'urn:xccdf:fix:script:ansible': FixType.ansible,
+    'urn:redhat:anaconda:pre': FixType.anaconda,
+    'urn:xccdf:fix:script:kickstart': FixType.kickstart,
+    'urn:redhat:osbuild:blueprint': FixType.blueprint,
+    'urn:xccdf:fix:script:bootc': FixType.bootc,
+}
+
 
 def parse_xml(path):
     """
@@ -133,20 +142,10 @@ class Datastream:
 
             # fixes / remediations
             elif frames[-2:] == ['Rule', 'fix']:
-                system = elements[-1].get('system')
-                for_rule = elements[-1].get('id')
-                if system == 'urn:xccdf:fix:script:sh':
-                    self.rules[for_rule].fixes |= FixType.bash
-                elif system == 'urn:xccdf:fix:script:ansible':
-                    self.rules[for_rule].fixes |= FixType.ansible
-                elif system == 'urn:redhat:anaconda:pre':
-                    self.rules[for_rule].fixes |= FixType.anaconda
-                elif system == 'urn:xccdf:fix:script:kickstart':
-                    self.rules[for_rule].fixes |= FixType.kickstart
-                elif system == 'urn:redhat:osbuild:blueprint':
-                    self.rules[for_rule].fixes |= FixType.blueprint
-                elif system == 'urn:xccdf:fix:script:bootc':
-                    self.rules[for_rule].fixes |= FixType.bootc
+                fix_type = _FIX_SYSTEM_MAP.get(elements[-1].get('system'))
+                if fix_type:
+                    for_rule = elements[-1].get('id')
+                    self.rules[for_rule].fixes |= fix_type
 
         # "convert" to regular dict, make external logic get KeyError
         # on bad profile or rule name

--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -14,6 +14,8 @@ FixType = enum.Flag(
     ['bash', 'ansible', 'anaconda', 'kickstart', 'blueprint', 'bootc'],
 )
 
+_OVAL_SYSTEM = 'http://oval.mitre.org/XMLSchema/oval-definitions-5'
+
 _FIX_SYSTEM_MAP = {
     'urn:xccdf:fix:script:sh': FixType.bash,
     'urn:xccdf:fix:script:ansible': FixType.ansible,
@@ -93,7 +95,7 @@ class Datastream:
             return types.SimpleNamespace(title=None, rules=set(), values=set())
 
         def make_rule():
-            return types.SimpleNamespace(fixes=FixType(0))
+            return types.SimpleNamespace(fixes=FixType(0), has_sce=False, has_oval=False)
 
         self.profiles.default_factory = make_profile
         self.rules.default_factory = make_rule
@@ -140,12 +142,23 @@ class Datastream:
                 rule_id = rule_id.removeprefix('xccdf_org.ssgproject.content_rule_')
                 self.rules[rule_id]  # let defaultdict fill in the values
 
-            # fixes / remediations
-            elif frames[-2:] == ['Rule', 'fix']:
-                fix_type = _FIX_SYSTEM_MAP.get(elements[-1].get('system'))
-                if fix_type:
-                    for_rule = elements[-1].get('id')
-                    self.rules[for_rule].fixes |= fix_type
+            # fixes / remediations and check engines
+            elif frames[-2] == 'Rule':
+                system = elements[-1].get('system')
+                if frames[-1] == 'fix':
+                    fix_type = _FIX_SYSTEM_MAP.get(system)
+                    if fix_type:
+                        for_rule = elements[-1].get('id')
+                        self.rules[for_rule].fixes |= fix_type
+                elif frames[-1] == 'check':
+                    rule_id = elements[-2].get('id')
+                    rule_id = rule_id.removeprefix(
+                        'xccdf_org.ssgproject.content_rule_',
+                    )
+                    if system == 'http://open-scap.org/page/SCE':
+                        self.rules[rule_id].has_sce = True
+                    elif system == _OVAL_SYSTEM:
+                        self.rules[rule_id].has_oval = True
 
         # "convert" to regular dict, make external logic get KeyError
         # on bad profile or rule name

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -26,8 +26,13 @@ test_name=$2        # some_test_name
 test_type=$3        # pass or fail
 remediation=$4      # oscap or ansible or none
 debug_arg=$5        # debug or nodebug
+check=$6            # oval or sce
 
 function debug { [[ $debug_arg == debug ]]; }
+
+if [[ "$check" == "sce" ]]; then
+    export OSCAP_PREFERRED_ENGINE=SCE
+fi
 
 # Retry wrapper for oscap scans
 # Args: max_attempts oscap_args...

--- a/per-rule/setup.sh
+++ b/per-rule/setup.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+dnf install -y openscap-engine-sce
+
 thin_ds_dir=thin_ds
 playbooks_dir=playbooks
 tests_dir=tests

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -30,11 +30,12 @@ remediation_excludes = set(remediation.excludes())
 
 
 def format_test(test):
+    rule_name = f'{test.rule}_sce' if test.check == 'sce' else test.rule
     pass_fail = 'pass' if test.is_pass else 'fail'
-    return f'{test.rule}/{test.test}.{pass_fail}'
+    return f'{rule_name}/{test.test}.{pass_fail}'
 
 
-def unit_tests_from_rules(built_tests_dir, rules):
+def unit_tests_from_rules(built_tests_dir, rules, ds):
     for rule in sorted(rules):
         rule_dir = built_tests_dir / rule
         # rule without tests
@@ -62,6 +63,8 @@ def unit_tests_from_rules(built_tests_dir, rules):
                 if full.rule in remediation_excludes:
                     continue
             yield full
+            if rule in ds.rules and ds.rules[rule].has_sce:
+                yield full._replace(check='sce')
 
 
 with util.get_source_content() as content_dir:
@@ -101,7 +104,7 @@ with util.get_source_content() as content_dir:
 
     util.log(f"will be testing {len(our_rules)} rules")
 
-    tests = unit_tests_from_rules(built_tests, our_rules)
+    tests = unit_tests_from_rules(built_tests, our_rules, ds)
     # if remediating via ansible, filter out any tests without playbooks
     if fix_type == 'ansible':
         tests = (t for t in tests if (playbooks_dir / f'{t.rule}.yml').exists())
@@ -194,6 +197,13 @@ for test in tests:
     if test.remediation == 'ansible' and fix_type != 'ansible':
         continue
 
+    # SCE-only rule with no OVAL check - skip the non-SCE test
+    if test.check != 'sce' and test.rule in ds.rules:
+        rule_info = ds.rules[test.rule]
+        if rule_info.has_sce and not rule_info.has_oval:
+            results.report('skip', format_test(test), 'rule has no OVAL check')
+            continue
+
     # if unspecified by test, default to test type from fmf metadata
     if test.remediation == 'bash':
         remediation_type = 'oscap'
@@ -205,7 +215,8 @@ for test in tests:
     # try a first run, if it passes, report it without extra overhead
     with g.snapshotted():
         proc = g.ssh(
-            './runner.sh', test.rule, test.test, pass_fail, remediation_type, 'nodebug',
+            './runner.sh', test.rule, test.test, pass_fail,
+            remediation_type, 'nodebug', test.check or 'oval',
             stdout=subprocess.PIPE, text=True,
         )
         if proc.returncode == 0:
@@ -220,7 +231,8 @@ for test in tests:
     #   may still pass
     with g.snapshotted():
         proc = g.ssh(
-            './runner.sh', test.rule, test.test, pass_fail, remediation_type, 'debug',
+            './runner.sh', test.rule, test.test, pass_fail,
+            remediation_type, 'debug', test.check or 'oval',
             stdout=subprocess.PIPE, text=True,
         )
 


### PR DESCRIPTION
Heavily based on recommendations from https://github.com/ComplianceAsCode/content/pull/13758#issuecomment-3155084027

Test results of OVAL rules do not change.
If the rule has SCE, the test result appends "_sce" to the rule name.
In case the rule has ONLY SCE, the OVAL test is marked as skipped.