### PR TITLE
Remove waivers for RHEL 10 STIG

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -27,12 +27,6 @@
 /scanning/disa-alignment/[^/]+/crypto_policy_not_overridden
     rhel == 9
 
-# RHEL10 - No official RHEL10 STIG benchmark yet
-/static-checks/rule-identifiers/stig/stigid/.*
-/static-checks/rule-identifiers/stig/stigref/.*
-/scanning/disa-stig-viewer-results
-    rhel == 10
-
 # kdump being forcibly enabled somewhere
 # https://github.com/ComplianceAsCode/content/issues/12832
 /hardening/kickstart/.+/service_kdump_disabled


### PR DESCRIPTION
The RHEL 10 STIG profile is now following the official DISA STIG V1R1 benchmark. That has been merged upstream in
https://github.com/ComplianceAsCode/content/pull/14826 Consequently, the rules in the profile now have STIG IDs and references.  In 2026-06-26 daily productization, the tests checking these IDs or references started passing and are displayed as "waived pass".  That means we can remove waivers for these tests.