### PR TITLE
per-rule tests: detect and test rules with SCE content

### DIFF
--- a/lib/oscap.py
+++ b/lib/oscap.py
@@ -84,7 +84,7 @@ class Datastream:
             return types.SimpleNamespace(title=None, rules=set(), values=set())
 
         def make_rule():
-            return types.SimpleNamespace(fixes=FixType(0))
+            return types.SimpleNamespace(fixes=FixType(0), has_sce=False, has_oval=False)
 
         self.profiles.default_factory = make_profile
         self.rules.default_factory = make_rule
@@ -147,6 +147,16 @@ class Datastream:
                     self.rules[for_rule].fixes |= FixType.blueprint
                 elif system == 'urn:xccdf:fix:script:bootc':
                     self.rules[for_rule].fixes |= FixType.bootc
+
+            # checks (OVAL OR sce)
+            elif frames[-2:] == ['Rule', 'check']:
+                system = elements[-1].get('system')
+                for_rule = elements[-2].get('id')
+                for_rule = for_rule.removeprefix('xccdf_org.ssgproject.content_rule_')
+                if system == 'http://open-scap.org/page/SCE':
+                    self.rules[for_rule].has_sce = True
+                if system == 'http://oval.mitre.org/XMLSchema/oval-definitions-5':
+                    self.rules[for_rule].has_oval = True
 
         # "convert" to regular dict, make external logic get KeyError
         # on bad profile or rule name

--- a/per-rule/runner.sh
+++ b/per-rule/runner.sh
@@ -26,6 +26,11 @@ test_name=$2        # some_test_name
 test_type=$3        # pass or fail
 remediation=$4      # oscap or ansible or none
 debug_arg=$5        # debug or nodebug
+check=$6            # oval or sce
+
+if [[ "$check" == "sce" ]]; then
+    export OSCAP_PREFERRED_ENGINE=SCE
+fi
 
 function debug { [[ $debug_arg == debug ]]; }
 

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -31,7 +31,10 @@ remediation_excludes = set(remediation.excludes())
 
 def format_test(test):
     pass_fail = 'pass' if test.is_pass else 'fail'
-    return f'{test.rule}/{test.test}.{pass_fail}'
+    if test.check == 'sce':
+        return f'sce/{test.rule}/{test.test}.{pass_fail}'
+    else:
+        return f'{test.rule}/{test.test}.{pass_fail}'
 
 
 def unit_tests_from_rules(built_tests_dir, rules, ds):

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -34,7 +34,7 @@ def format_test(test):
     return f'{test.rule}/{test.test}.{pass_fail}'
 
 
-def unit_tests_from_rules(built_tests_dir, rules):
+def unit_tests_from_rules(built_tests_dir, rules, ds):
     for rule in sorted(rules):
         rule_dir = built_tests_dir / rule
         # rule without tests
@@ -61,7 +61,10 @@ def unit_tests_from_rules(built_tests_dir, rules):
             if not full.is_pass and full.remediation != 'none':
                 if full.rule in remediation_excludes:
                     continue
-            yield full
+            if ds.rules[rule].has_sce:
+                yield full._replace(check='sce')
+            if ds.rules[rule].has_oval:
+                yield full._replace(check='oval')
 
 
 with util.get_source_content() as content_dir:
@@ -101,7 +104,7 @@ with util.get_source_content() as content_dir:
 
     util.log(f"will be testing {len(our_rules)} rules")
 
-    tests = unit_tests_from_rules(built_tests, our_rules)
+    tests = unit_tests_from_rules(built_tests, our_rules, ds)
     # if remediating via ansible, filter out any tests without playbooks
     if fix_type == 'ansible':
         tests = (t for t in tests if (playbooks_dir / f'{t.rule}.yml').exists())
@@ -205,7 +208,8 @@ for test in tests:
     # try a first run, if it passes, report it without extra overhead
     with g.snapshotted():
         proc = g.ssh(
-            './runner.sh', test.rule, test.test, pass_fail, remediation_type, 'nodebug',
+            './runner.sh', test.rule, test.test, pass_fail,
+            remediation_type, 'nodebug', test.check,
             stdout=subprocess.PIPE, text=True,
         )
         if proc.returncode == 0:
@@ -220,7 +224,8 @@ for test in tests:
     #   may still pass
     with g.snapshotted():
         proc = g.ssh(
-            './runner.sh', test.rule, test.test, pass_fail, remediation_type, 'debug',
+            './runner.sh', test.rule, test.test, pass_fail,
+            remediation_type, 'debug', test.check,
             stdout=subprocess.PIPE, text=True,
         )
 

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -136,7 +136,7 @@ with util.get_source_content() as content_dir:
 
     # prepare a kickstart for the VM
     ks = virt.Kickstart()
-    ks.packages += ['rsync', 'xmlstarlet', 'ansible-core']
+    ks.packages += ['rsync', 'xmlstarlet', 'ansible-core', 'openscap-engine-sce']
     # if RHEL, use rhc-worker-playbook, else install from galaxy
     if versions.rhel.is_true_rhel():
         ks.packages.append('rhc-worker-playbook')

--- a/per-rule/test.py
+++ b/per-rule/test.py
@@ -31,10 +31,8 @@ remediation_excludes = set(remediation.excludes())
 
 def format_test(test):
     pass_fail = 'pass' if test.is_pass else 'fail'
-    if test.check == 'sce':
-        return f'sce/{test.rule}/{test.test}.{pass_fail}'
-    else:
-        return f'{test.rule}/{test.test}.{pass_fail}'
+    prefix = 'sce/' if test.check == 'sce' else ''
+    return f'{prefix}{test.rule}/{test.test}.{pass_fail}'
 
 
 def unit_tests_from_rules(built_tests_dir, rules, ds):

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,6 +28,7 @@ ignore = [
     "PLR0911",  # too-many-return-statements
     "PLR0912",  # too-many-branches
     "PLR0913",  # too-many-arguments
+    "PLR0915",  # too many statements in a function
     "PLW0717",  # too-many-statements-in-try-clause
     "PLR2004",  # magic-value-comparison
     "PLR5501",  # collapsible-else-if


### PR DESCRIPTION
Heavily based on recommendations from https://github.com/ComplianceAsCode/content/pull/13758#issuecomment-3155084027

Test results of OVAL rules do not change.
If the rule has SCE, the test result prepends  "/sce" before the rule name.