### PR TITLE
Waive accounts_password_all_shadowed_sha512/sha512_password.pass on RHEL 10

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -115,5 +115,8 @@
 # https://github.com/ComplianceAsCode/content/issues/14570
 /hardening/host-os/oscap/.+/rsyslog_files_permissions
     rhel.is_centos() and rhel in [9, 10]
+# https://github.com/ComplianceAsCode/content/issues/14832
+/per-rule/oscap/.+/accounts_password_all_shadowed_sha512/sha512_password.pass
+    rhel == 10
 
 # vim: syntax=python


### PR DESCRIPTION
Even in FIPS mode RHEL 10 uses yescrypt. This might be more of a test environment issue than anything else but for now add this waiver.