### PR TITLE
Add waivers for new discovered issues in weekly productization

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -42,6 +42,10 @@
 /hardening/.+/ism_o/rpm_verify_permissions
     rhel == 9
 
+# https://github.com/ComplianceAsCode/content/issues/14933
+/hardening/host-os/ansible/bsi/rpm_verify_ownership
+    rhel == 10 and arch == "ppc64le"
+
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
 # https://issues.redhat.com/browse/RHEL-45706

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -126,4 +126,11 @@
 /per-rule/oscap/.+/accounts_password_all_shadowed_sha512/sha512_password.pass
     rhel == 10
 
+# https://github.com/ComplianceAsCode/content/issues/14934
+/hardening/host-os/(ansible|oscap)/(ospp|cui)/zipl_audit_argument
+/hardening/host-os/(ansible|oscap)/(ospp|cui)/zipl_audit_backlog_limit_argument
+/hardening/host-os/(ansible|oscap)/(ospp|cui)/zipl_page_poison_argument
+/hardening/host-os/(ansible|oscap)/(ospp|cui)/zipl_slub_debug_argument
+    rhel == 8
+
 # vim: syntax=python


### PR DESCRIPTION
1. Rule rpm_verify_ownership fails in BSI profile on ppc64le architecture
https://github.com/ComplianceAsCode/content/issues/14933
2. zIPL rules fail on RHEL 8
https://github.com/ComplianceAsCode/content/issues/14934