### PR TITLE
Remove rpm_verify_ownership waiver for ppc64le.

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -42,10 +42,6 @@
 /hardening/.+/ism_o/rpm_verify_permissions
     rhel == 9
 
-# https://github.com/ComplianceAsCode/content/issues/14933
-/hardening/host-os/ansible/bsi/rpm_verify_ownership
-    rhel == 10 and arch == "ppc64le"
-
 # RHEL-8: https://bugzilla.redhat.com/show_bug.cgi?id=1834716
 # RHEL-9: https://bugzilla.redhat.com/show_bug.cgi?id=1999587
 # https://issues.redhat.com/browse/RHEL-45706


### PR DESCRIPTION
The issue is being fixed upstream in the ppc64le platform.

Related: ComplianceAsCode/content#14933