### PR TITLE
Don't iterate per-rule playbooks by default

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -136,12 +136,14 @@ def get_playbook(profile, force_ssg=False, content_dir=None):
     return playbook
 
 
-def iter_playbooks(force_ssg=False, content_dir=None):
+def iter_playbooks(force_ssg=False, content_dir=None, per_rule=False):
     for file in find_playbooks(force_ssg, content_dir).iterdir():
         if file.suffix == '.yml':
             yield file
-    per_rule_dir = find_per_rule_playbooks(force_ssg, content_dir)
-    if per_rule_dir.exists():
+    if per_rule:
+        per_rule_dir = find_per_rule_playbooks(force_ssg, content_dir)
+        if not per_rule_dir.exists():
+            raise RuntimeError(f"could not find per-rule playbooks in {content_dir}")
         yield from per_rule_dir.iterdir()
 
 


### PR DESCRIPTION
This impacts
```
/static-checks/ansible/lint
/static-checks/ansible/syntax-check
```
by making them explicitly avoid per-rule playbooks by default.

The reason is predictability - a test processing per-rule playbooks will run many times slower and produce different results, which would show up in results diff.

Using the old logic, whether a test scanned per-rule playbooks or not depended on whether the already-built content included them - e.g. if a per-rule-using test ran before these `/static-check` tests on the same OS, the `/static-check` tests would reuse the built content and run the tests.  
If, OTOH, the playbooks were not pre-built before, they would not be scanned.

When scheduling tests dynamically (like we do via ATEX), this could easily lead to `lint` including them (because it was run on an OS that previously hosted a test that built them) but with `syntax-check` excluding them, because it happened to be run on a clean OS.

I don't think we want this kind of non-determinism in Contest.