### PR TITLE
Always test per-rule playbooks in user content

### DIFF
--- a/lib/util/content.py
+++ b/lib/util/content.py
@@ -140,9 +140,26 @@ def iter_playbooks(force_ssg=False, content_dir=None):
     for file in find_playbooks(force_ssg, content_dir).iterdir():
         if file.suffix == '.yml':
             yield file
-    per_rule_dir = find_per_rule_playbooks(force_ssg, content_dir)
-    if per_rule_dir.exists():
-        yield from per_rule_dir.iterdir()
+
+
+def iter_per_rule_playbooks():
+    # from source (always build to make sure they are available)
+    if user_content := get_user_content(build=False):
+        build_content(
+            user_content,
+            {'SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOL': 'ON'},
+        )
+        playbooks_dir = find_per_rule_playbooks(content_dir=user_content)
+        if not playbooks_dir.exists() or not next(playbooks_dir.iterdir(), None):
+            raise RuntimeError(f"per-rule playbook dir doesn't exist or empty: {playbooks_dir}")
+        for playbook in playbooks_dir.iterdir():
+            yield playbook
+    # shipped via RPM (skip if ssg rule-playbooks RPM doesn't exist)
+    else:
+        playbooks_dir = find_per_rule_playbooks(force_ssg=True)
+        if playbooks_dir.exists():
+            for playbook in playbooks_dir.iterdir():
+                yield playbook
 
 
 def get_kickstart(profile, content_dir=None):

--- a/static-checks/ansible/lint/main.fmf
+++ b/static-checks/ansible/lint/main.fmf
@@ -9,7 +9,7 @@ description: |-
 test: $CONTEST_PYTHON -m lib.runtest ./test.py
 environment+:
     PYTHONPATH: ../../..
-duration: 30m
+duration: 2h
 require+:
   - openscap-scanner
   - ansible-core

--- a/static-checks/ansible/lint/test.py
+++ b/static-checks/ansible/lint/test.py
@@ -49,4 +49,8 @@ lint_playbook('playbook.yml', '(all) profile generated')
 for playbook in util.iter_playbooks():
     lint_playbook(playbook, playbook.name)
 
+# lint per-rule playbooks
+for playbook in util.iter_per_rule_playbooks():
+    lint_playbook(playbook, playbook.name)
+
 results.report_and_exit()

--- a/static-checks/ansible/syntax-check/main.fmf
+++ b/static-checks/ansible/syntax-check/main.fmf
@@ -5,7 +5,7 @@ description: |-
 test: $CONTEST_PYTHON -m lib.runtest ./test.py
 environment+:
     PYTHONPATH: ../../..
-duration: 15m
+duration: 1h
 require+:
   - openscap-scanner
   - ansible-core

--- a/static-checks/ansible/syntax-check/test.py
+++ b/static-checks/ansible/syntax-check/test.py
@@ -5,32 +5,35 @@ import subprocess
 from lib import ansible, util, results
 
 
+def check_playbook(playbook, name):
+    cmd = ['ansible-playbook', '--syntax-check', playbook]
+    ret = util.subprocess_run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+    )
+    if ret.returncode == 0:
+        results.report('pass', name)
+    else:
+        results.report('fail', name, ret.stdout)
+
+
 ansible.install_deps()
 
 ds = util.get_datastream()
 
-# Generate playbook from datastream and virtual (all) profile
+# Check playbook from datastream and virtual (all) profile
 cmd = [
     'oscap', 'xccdf', 'generate', 'fix', '--profile', '(all)',
     '--fix-type', 'ansible', '--output', 'playbook.yml', ds,
 ]
 ret = util.subprocess_run(cmd, check=True, stderr=subprocess.PIPE)
+check_playbook('playbook.yml', '(all) profile generated')
 
-# Check syntax of generated playbook
-cmd = ['ansible-playbook', '--syntax-check', 'playbook.yml']
-ret = util.subprocess_run(cmd, stderr=subprocess.PIPE)
-if ret.returncode == 0:
-    results.report('pass', '(all) profile generated')
-else:
-    results.report('fail', '(all) profile generated', ret.stderr)
-
-# Check syntax of shipped playbooks
+# Check shipped playbooks
 for playbook in util.iter_playbooks():
-    cmd = ['ansible-playbook', '--syntax-check', playbook]
-    ret = util.subprocess_run(cmd, stderr=subprocess.PIPE)
-    if ret.returncode == 0:
-        results.report('pass', playbook.name)
-    else:
-        results.report('fail', playbook.name, ret.stderr)
+    check_playbook(playbook, playbook.name)
+
+# Check per-rule playbooks
+for playbook in util.iter_per_rule_playbooks():
+    check_playbook(playbook, playbook.name)
 
 results.report_and_exit()


### PR DESCRIPTION
This impacts
```
/static-checks/ansible/lint
/static-checks/ansible/syntax-check
```
by making them always test per-rule playbooks:

- if CONTEST_CONTENT is given, the playbooks are explicitly built (or reused if built already)
- else we're testing RPM content and rely on per-rule-playbook RPM to be installed via 'recommend'
  - we could enforce its presence, but we probably want the tests usable even when it's not available, so RPM testing is still opportunistic