### PR TITLE
Remove accounts_password_all_shadowed_sha512 waiver as issue was fixed.

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -119,8 +119,5 @@
 # https://github.com/ComplianceAsCode/content/issues/14570
 /hardening/host-os/oscap/.+/rsyslog_files_permissions
     rhel.is_centos() and rhel in [9, 10]
-# https://github.com/ComplianceAsCode/content/issues/14832
-/per-rule/oscap/.+/accounts_password_all_shadowed_sha512/sha512_password.pass
-    rhel == 10
 
 # vim: syntax=python


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/pull/14977 has been merged and the issue https://github.com/ComplianceAsCode/content/issues/14832 has been closed.

The test scenario has been fixed to work on RHEL10 boxes where yescrypto would appear as default settings in the system causing the test scenario to not comply with the intended setup configuration.