### PR TITLE
disa-alignment: Upload ARF results to artifacts as well in case of failure

### DIFF
--- a/scanning/disa-alignment/anaconda.py
+++ b/scanning/disa-alignment/anaconda.py
@@ -47,4 +47,7 @@ with g.booted(), util.get_source_content() as content_dir:
     # Compare ARFs and report results from output
     shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
-results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])
+logs = ['ssg-report.html', 'disa-report.html']
+if results.global_counts['fail'] or results.global_counts['error']:
+    logs += ['ssg-arf.xml', 'disa-arf.xml']
+results.report_and_exit(logs=logs)

--- a/scanning/disa-alignment/ansible.py
+++ b/scanning/disa-alignment/ansible.py
@@ -61,4 +61,7 @@ with g.snapshotted():
         # Compare ARFs and report results from output
         shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
-results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])
+logs = ['ssg-report.html', 'disa-report.html']
+if results.global_counts['fail'] or results.global_counts['error']:
+    logs += ['ssg-arf.xml', 'disa-arf.xml']
+results.report_and_exit(logs=logs)

--- a/scanning/disa-alignment/oscap.py
+++ b/scanning/disa-alignment/oscap.py
@@ -51,4 +51,7 @@ with g.snapshotted():
         # Compare ARFs and report results from output
         shared.compare_arfs('ssg-arf.xml', 'disa-arf.xml')
 
-results.report_and_exit(logs=['ssg-report.html', 'disa-report.html'])
+logs = ['ssg-report.html', 'disa-report.html']
+if results.global_counts['fail'] or results.global_counts['error']:
+    logs += ['ssg-arf.xml', 'disa-arf.xml']
+results.report_and_exit(logs=logs)


### PR DESCRIPTION
I'm not sure this logic of uploading a log artifact only when the test fails makes sense. From what I see there are no cases like this across the project.

ARF files can take some space and I think they would only be good when there is actually a failure to investigate.

The HTML reports already have good OVAL results and provide the source of the failure, so it's rather complementing.

Please advise and/or feel free to reject.

---

disa-alignment: Upload ARF results to artifacts as well in case of test failure.

These files can be more easily processed locally by AI for example and can help reviewing more in depth the differences between the two sources of results.