### PR TITLE
Remove outdated waivers after 0.1.82 stabilization

### DIFF
--- a/conf/waivers/permanent
+++ b/conf/waivers/permanent
@@ -63,9 +63,6 @@
 /static-checks/html-links/https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
     "URL returned error: 403" in note
 # likely has bot detection
-/static-checks/html-links/https://www.cyber.mil/stigs/downloads/.*
-    "Connection reset by peer" in note
-# also bot detection?
 /static-checks/html-links/https://www.cyber.gov.au/acsc/view-all-content/ism
     bool(re.search("HTTP/2 stream [0-9]+ was not closed cleanly: INTERNAL_ERROR", note))
 
@@ -153,15 +150,5 @@
 # rsyslogd remote host and certificate need to be configured manually
 /scanning/boot-errors/.+/rsyslogd.+(certificate.*is not set|key.*is not set|cannot resolve hostname).*
     True
-
-# File /boot/grub2/grub2.cfg is created with lenient permissions by
-# bootupd during the installation of a bootable container image.
-# Tests still fail on RHEL 10.0
-# https://github.com/coreos/bootupd/issues/952
-# https://issues.redhat.com/browse/OPENSCAP-5326
-# https://github.com/ComplianceAsCode/content/issues/14581
-/hardening/container/(anaconda-ostree|bootc-image-builder|old-new)/.+/file_permissions_grub2_cfg
-/hardening/container/(anaconda-ostree|bootc-image-builder|old-new)/.+/file_permissions_efi_grub2_cfg
-    rhel == 10.0 or rhel <= 9.7
 
 # vim: syntax=python

--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -88,9 +88,6 @@
 /hardening/container/anaconda-ostree/.+/accounts_password_set_min_life_existing
 /hardening/container/anaconda-ostree/.+/accounts_password_set_warn_age_existing
     True
-# https://github.com/ComplianceAsCode/content/issues/14254
-/hardening/container/(anaconda-ostree|bootc-image-builder|old-new)/.+/file_permissions_boot_grub2
-    rhel == 10
 
 # Image builder issue. Image builder needs to add BSI, ISM Official Secret
 # and ISM Official Top Secret to its allow list, tracked under
@@ -104,22 +101,12 @@
 /hardening/image-builder/uefi/ism_o_top_secret
     rhel == 10 and status == 'error'
 
-# https://github.com/ComplianceAsCode/content/issues/14559
-/scanning/boot-errors/(stig|ism_o|ism_o_secret|ism_o_top_secret)/.*sssd.service.*
-    rhel == 10
-/scanning/boot-errors/(stig|anssi_bp28_intermediary|anssi_bp28_enhanced|anssi_bp28_high)/.*sssd.service.*
-/scanning/boot-errors/(stig|anssi_bp28_intermediary|anssi_bp28_enhanced|anssi_bp28_high)/.*Failed to start System Security Services Daemon.*
-/scanning/boot-errors/(stig|anssi_bp28_intermediary|anssi_bp28_enhanced|anssi_bp28_high)/sssd.*No domain is enabled.*
-/scanning/boot-errors/(stig|anssi_bp28_high)/sssd: SSSD couldn't load the configuration database.*
-    rhel == 9
 # https://github.com/ComplianceAsCode/content/issues/14570
 /hardening/host-os/oscap/.+/rsyslog_files_permissions
     rhel.is_centos() and rhel in [9, 10]
 
-# https://github.com/ComplianceAsCode/content/issues/14992
-/hardening/host-os/ansible/.+/mount_option_.+
-/hardening/host-os/ansible/.+/systemd_tmp_mount_enabled
-/hardening/container/.+/mount_option_.+
+# https://github.com/ComplianceAsCode/content/issues/15002
+/hardening/host-os/ansible/.+/mount_option_tmp_noexec
     True
 
 # https://github.com/ComplianceAsCode/content/issues/15006


### PR DESCRIPTION
These waivers currently waive passed tests because the linked issues have been fixed, therefore they can be removed.