### PR TITLE
Waive DISA-alignment mismatches on audit_rules_* and file_permissions_etc_audit_auditd_stig

### DIFF
--- a/conf/waivers/productization
+++ b/conf/waivers/productization
@@ -126,4 +126,16 @@
 /hardening/host-os/ansible/stig/file_permissions_audit_configuration_stig
     rhel.is_centos() and rhel in [8, 9]
 
+# https://github.com/ComplianceAsCode/content/issues/15051
+/scanning/disa-alignment/(anaconda|ansible)/file_permissions_etc_audit_auditd_stig
+    rhel in [8, 9]
+
+# https://github.com/ComplianceAsCode/content/issues/15052
+/scanning/disa-alignment/[^/]+/audit_rules_sudoers_d
+# https://github.com/ComplianceAsCode/content/issues/15053
+/scanning/disa-alignment/[^/]+/audit_rules_login_events_faillock
+# https://github.com/ComplianceAsCode/content/issues/15054
+/scanning/disa-alignment/[^/]+/audit_rules_login_events_lastlog
+    rhel == 9
+
 # vim: syntax=python


### PR DESCRIPTION
Waive upstream issues:
https://github.com/ComplianceAsCode/content/issues/15051
https://github.com/ComplianceAsCode/content/issues/15052 
https://github.com/ComplianceAsCode/content/issues/15053 
https://github.com/ComplianceAsCode/content/issues/15054

I left a couple out of rules because I believe they were fixed in the meantime:

file_permissions_sshd_private_key — DISA-alignment mismatch on file_permissions_sshd_private_key — SSG pass, DISA fail (RHEL 8.10/9.2/9.4/9.6/9.8/9.9)

file_permissions_audit_configuration_stig — file_permissions_audit_configuration_stig fails SSG scan after SSG's own STIG remediation (RHEL 8.10, 9.2/9.4/9.6/9.8/9.9)