### PR TITLE
Fix applicability of tests on CentOS Stream

### DIFF
--- a/hardening/container/anaconda-ostree/main.fmf
+++ b/hardening/container/anaconda-ostree/main.fmf
@@ -25,7 +25,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9 or distro ~< rhel-9.6
+  - when: distro < rhel-9 or distro ~< rhel-9.6 or distro < centos-stream-9
     enabled: false
     because: Image Mode not supported for older RHELs
 

--- a/hardening/container/bootc-image-builder/main.fmf
+++ b/hardening/container/bootc-image-builder/main.fmf
@@ -25,7 +25,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9 or distro ~< rhel-9.6
+  - when: distro < rhel-9 or distro ~< rhel-9.6 or distro < centos-stream-9
     enabled: false
     because: Image Mode not supported for older RHELs
 

--- a/hardening/container/old-new/main.fmf
+++ b/hardening/container/old-new/main.fmf
@@ -32,7 +32,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9 or distro ~< rhel-9.6 or distro ~< rhel-10.0
+  - when: distro < rhel-9 or distro ~< rhel-9.6 or distro < centos-stream-9 or distro ~< rhel-10.0
     enabled: false
     because: Image Mode not supported for older RHELs
 

--- a/scanning/boot-errors/main.fmf
+++ b/scanning/boot-errors/main.fmf
@@ -27,7 +27,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: we want to run virtualization on x86_64 only
-  - when: distro < rhel-9
+  - when: distro < rhel-9 or distro < centos-stream-9
     enabled: false
     because: systemd v239 (RHEL 8) doesn't support json output in 'systemctl list-units'
 

--- a/scanning/disa-alignment/anaconda.fmf
+++ b/scanning/disa-alignment/anaconda.fmf
@@ -4,6 +4,6 @@ environment+:
     PYTHONPATH: ../..
 duration: 30m
 adjust+:
-  - when: distro >= rhel-10
+  - when: distro >= rhel-10 or distro >= centos-stream-10
     enabled: false
     because: content doesn't have pre-made kickstarts for RHEL-10+

--- a/scanning/disa-alignment/main.fmf
+++ b/scanning/disa-alignment/main.fmf
@@ -20,6 +20,6 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: run virtualization on x86_64 only
-  - when: distro == rhel-10
+  - when: distro == rhel-10 or distro == centos-stream-10
     enabled: false
     because: TODO - no DISA STIG for RHEL-10 available yet

--- a/scanning/hummingbird/image/main.fmf
+++ b/scanning/hummingbird/image/main.fmf
@@ -13,7 +13,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: sufficient to check only on x86_64
-  - when: distro < rhel-10
+  - when: distro < rhel-10 or distro < centos-stream-10
     enabled: false
     because: sufficient to run only on RHEL 10
 

--- a/scanning/hummingbird/oscap-podman/main.fmf
+++ b/scanning/hummingbird/oscap-podman/main.fmf
@@ -13,7 +13,7 @@ adjust+:
   - when: arch != x86_64
     enabled: false
     because: sufficient to check only on x86_64
-  - when: distro < rhel-10
+  - when: distro < rhel-10 or distro < centos-stream-10
     enabled: false
     because: sufficient to run only on RHEL 10
 


### PR DESCRIPTION
Following tests should not run on CentOS Stream 8:
```
/hardening/container/*
/scanning/hummingbird/*
/scanning/boot-errors/*
```

Also disable `/scanning/disa-alignment/*` on CentOS Stream 10 (reason is the same as for RHEL 10).